### PR TITLE
Save channelSid and serviceSid of a contact

### DIFF
--- a/controllers/contact-controller.js
+++ b/controllers/contact-controller.js
@@ -303,6 +303,8 @@ const ContactController = Contact => {
       accountSid: accountSid || '',
       timeOfContact: body.timeOfContact || Date.now(),
       taskId: body.taskId || '',
+      channelSid: body.channelSid || '',
+      serviceSid: body.serviceSid || '',
     };
 
     const contact = await Contact.create(contactRecord);

--- a/migrations/20210630164641-add-channelsid-servicesid.js
+++ b/migrations/20210630164641-add-channelsid-servicesid.js
@@ -1,0 +1,19 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('Contacts', 'channelSid', Sequelize.STRING, { transaction: t }),
+        queryInterface.addColumn('Contacts', 'serviceSid', Sequelize.STRING, { transaction: t }),
+      ]);
+    });
+  },
+
+  down: queryInterface => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('Contacts', 'channelSid', { transaction: t }),
+        queryInterface.removeColumn('Contacts', 'serviceSid', { transaction: t }),
+      ]);
+    });
+  },
+};

--- a/models/contact.js
+++ b/models/contact.js
@@ -67,6 +67,8 @@ module.exports = (sequelize, DataTypes) => {
     accountSid: DataTypes.STRING,
     timeOfContact: DataTypes.DATE,
     taskId: DataTypes.STRING,
+    channelSid: DataTypes.STRING,
+    serviceSid: DataTypes.STRING,
   });
 
   Contact.associate = models => Contact.belongsTo(models.Case, { foreignKey: 'caseId' });

--- a/tests/db-init/dump.sql
+++ b/tests/db-init/dump.sql
@@ -121,7 +121,9 @@ CREATE TABLE public."Contacts" (
     "accountSid" character varying(255),
     "timeOfContact" timestamp with time zone,
     "taskId" character varying(255),
-    "createdBy" character varying(255)
+    "createdBy" character varying(255),
+    "channelSid" character varying(255),
+    "serviceSid" character varying(255)
 );
 
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-712

This PR saves `channelSid` and `serviceSid` when saving a contact.
It contains a migration file that creates those two new columns. The migration will be run automatically.