### PR TITLE
Use JSONB flavour of JSON functions in search case query

### DIFF
--- a/sql/search-cases-query.sql
+++ b/sql/search-cases-query.sql
@@ -39,9 +39,7 @@ SELECT * FROM (
       )
       END
     AND
-      CASE WHEN :accountSid IS NULL THEN TRUE
-      ELSE cases."accountSid" = :accountSid
-      END
+      :accountSid IS NOT NULL cases."accountSid" = :accountSid
     AND
       CASE WHEN :counselor IS NULL THEN TRUE
       ELSE cases."twilioWorkerId" = :counselor

--- a/sql/search-cases-query.sql
+++ b/sql/search-cases-query.sql
@@ -15,18 +15,18 @@ SELECT * FROM (
     (count(*) OVER())::INTEGER AS "totalCount",
     cases.*,
     -- build "connectedContacts": an aggregate contacts as an array of json objects
-    COALESCE(json_agg(DISTINCT contacts.*) FILTER (WHERE contacts.id IS NOT NULL), '[]') AS "connectedContacts"
+    COALESCE(jsonb_agg(DISTINCT contacts.*) FILTER (WHERE contacts.id IS NOT NULL), '[]') AS "connectedContacts"
   FROM
     "Cases" cases,
     -- Transform "info" column as a table with columns "households" and "perpetrators"
     jsonb_to_record(info) AS info_as_table(households jsonb, perpetrators jsonb)
   -- Extract every household/perpetrator as a record and apply a join
-  LEFT JOIN LATERAL json_array_elements(households::JSON) h ON TRUE
-  LEFT JOIN LATERAL json_array_elements(perpetrators::JSON) p ON TRUE
+  LEFT JOIN LATERAL jsonb_array_elements(households::JSONB) h ON TRUE
+  LEFT JOIN LATERAL jsonb_array_elements(perpetrators::JSONB) p ON TRUE
   -- Join contacts on contacts.caseId column
   LEFT JOIN LATERAL (
     SELECT c.*,
-    COALESCE(json_agg(DISTINCT r.*) FILTER (WHERE r.id IS NOT NULL), '[]') AS "csamReports"
+    COALESCE(jsonb_agg(DISTINCT r.*) FILTER (WHERE r.id IS NOT NULL), '[]') AS "csamReports"
     FROM "Contacts" c LEFT JOIN "CSAMReports" r ON c."id" = r."contactId" WHERE c."caseId" = "cases".id
     GROUP BY c.id
     ) contacts ON true
@@ -141,7 +141,7 @@ SELECT * FROM (
     -- search on closedCases and orphaned cases (without connected contacts)
     CASE WHEN :closedCases::BOOLEAN = FALSE THEN (
       cases.status <> 'closed'
-      AND json_array_length(COALESCE(json_agg(DISTINCT contacts.*) FILTER (WHERE contacts.id IS NOT NULL), '[]')) > 0
+      AND jsonb_array_length(COALESCE(jsonb_agg(DISTINCT contacts.*) FILTER (WHERE contacts.id IS NOT NULL), '[]')) > 0
     )
     ELSE TRUE
     END

--- a/sql/search-cases-query.sql
+++ b/sql/search-cases-query.sql
@@ -39,7 +39,7 @@ SELECT * FROM (
       )
       END
     AND
-      :accountSid IS NOT NULL cases."accountSid" = :accountSid
+      :accountSid IS NOT NULL AND cases."accountSid" = :accountSid
     AND
       CASE WHEN :counselor IS NULL THEN TRUE
       ELSE cases."twilioWorkerId" = :counselor


### PR DESCRIPTION
Primary Reviewer @murilovmachado 

## Description
Use JSONB flavour of JSON functions in search case query, because these have equality operators - resolving issues that occur when cases have multiple households or perpetrators.

@murilovmachado - as added safety do you think we should make this query fail / return nothing if no account is supplied. I can't thing why the HRM service would have any business querying cases across multiple helplines, allowing it in the query just seems like a way we could introduce bugs that could compromise data security for helplines in the future

### Checklist
- [ X ] Corresponding issue has been opened
- [ N/A ] New tests added
- [ N/A ] Strings are localized

### Related Issues
Fixes https://bugs.benetech.org/browse/CHI-1017

### Verification steps

Run a search in the flex plugin vs the dev database once these changes are deployed
