### PR TITLE
CHI-1017: Fix local test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,46 @@ In order to prevent sensitive credentials to be leaked, please follow this instr
 - Go into the repo root folder.
 - Run `git secrets --register-aws`.
 - Run `git config --local core.hooksPath .githooks/`.
+
+## Running tests
+
+The easiest way to run the tests locally is to run the test DB in docker.
+
+Ensure you have the following environment variables set on the terminal session you want to run your tests from:
+```
+POSTGRES_PORT=5433
+API_KEY='anything'
+RUNNING_TEST=true
+```
+
+Then, in the HRM root, run
+
+```shell
+docker compose -f ./docker-compose-test.yml up -d
+jest --verbose                                      # tests will run here 
+docker compose -f ./docker-compose-test.yml down    # if you forget this, the DB will not be cleared down & be in a dirty state for the next run, which could make tests unstable
+```
+
+### Debugging SQL in test runs
+
+If you want to debug the queries hitting the DB as part of the tests, you can use 2 terminal sessions.
+
+In a new terminal session run:
+
+```shell
+docker compose -f ./docker-compose-test.yml up # don't use the '-d' flag!
+```
+
+Then in the original (with the environment variables set) session run
+
+```shell
+jest --verbose 
+```
+
+You should see all the SQL queries run by the tests logged out in the docker terminal.
+
+After the run, Ctrl-C the docker compose session and run 
+```shell
+docker compose -f ./docker-compose-test.yml down
+```
+in any terminal window.

--- a/config/config.js
+++ b/config/config.js
@@ -6,6 +6,7 @@ module.exports = {
     password: process.env.RDS_PASSWORD || null,
     database: process.env.RDS_DBNAME || 'hrmdb',
     host: process.env.RDS_HOSTNAME || 'localhost',
+    port: process.env.POSTGRES_PORT || 5432,
     dialect: 'postgres',
   },
   staging: {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,8 @@
+services:
+  db:
+    build:
+      context: ./
+      dockerfile: ./docker-database/Dockerfile-test
+    command: ["postgres", "-c", "log_statement=all"]
+    ports:
+      - "5433:5432"

--- a/docker-database/Dockerfile-test
+++ b/docker-database/Dockerfile-test
@@ -1,0 +1,5 @@
+FROM library/postgres:11.14
+ENV POSTGRES_USER=hrm
+ENV POSTGRES_HOST_AUTH_METHOD=trust
+ENV POSTGRES_DB=hrmdb
+ADD tests/db-init/dump.sql /docker-entrypoint-initdb.d/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "start": "sequelize db:migrate && node ./bin/www",
-    "test": "RUNNING_TESTS=true jest --passWithNoTests --forceExit",
+    "test": "RUNNING_TESTS=true jest --passWithNoTests --forceExit --maxWorkers=1",
     "db:create-migration": "sequelize migration:generate --name ",
     "db:undo-last": "sequelize db:migrate:undo",
     "lint": "eslint --ext js .",

--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -26,6 +26,12 @@ const caseAuditsQuery = {
   },
 };
 
+afterAll(done => {
+  server.close(() => {
+    done();
+  });
+});
+
 beforeAll(async () => {
   await CaseAudit.destroy(caseAuditsQuery);
 });

--- a/tests/routes/csam-reports.test.js
+++ b/tests/routes/csam-reports.test.js
@@ -33,9 +33,13 @@ beforeAll(async () => {
   await CSAMReport.destroy(csamReports2DestroyQuery);
 });
 
-afterAll(async done => {
-  server.close(done);
-  await CSAMReport.destroy(csamReports2DestroyQuery);
+afterAll(done => {
+  server.close(() => {
+    CSAMReport.destroy(csamReports2DestroyQuery).then(() => {
+      console.log('csam reports test cleaned up.');
+      done();
+    });
+  });
 });
 
 describe('/csamReports route', () => {

--- a/tests/routes/post-surveys.test.js
+++ b/tests/routes/post-surveys.test.js
@@ -28,9 +28,14 @@ beforeAll(async () => {
   await PostSurvey.destroy(postSurveys2DestroyQuery);
 });
 
-afterAll(async done => {
-  server.close(done);
-  await PostSurvey.destroy(postSurveys2DestroyQuery);
+afterAll(done => {
+  server.close(() => {
+    console.log('post survey server closed.');
+    PostSurvey.destroy(postSurveys2DestroyQuery).then(() => {
+      console.log('post survey cleaned up.');
+      done();
+    });
+  });
 });
 
 // afterEach(async () => PostSurvey.destroy(postSurveys2DestroyQuery));

--- a/tests/routes/safe-router.test.js
+++ b/tests/routes/safe-router.test.js
@@ -37,6 +37,10 @@ const headers = {
 
 const baseRoute = `/v0/accounts/${accountSid}`;
 
+afterAll(done => {
+  server.close(done);
+});
+
 test('unauthorize endpoints with no middleware', async () => {
   const response = await request.get(`${baseRoute}/without-middleware`).set(headers);
   expect(response.status).toBe(401);


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description

* Ensures data in POST tests for contacts is added in a deterministic order, so the subsequent GET tests that verify the order recordset ordering always pass
* Fixed issue with Express server sessions not being fully cleaned up at the end of test runs
* Added docker config specifically for spinning up a DB for local test runs & instructions for how to use
* 
### Checklist
- [ X ] Corresponding issue has been opened
- [ N/A ] New tests added
- [ N/A ] Strings are localized

### Verification steps

Run tests locally using provided instructions, they should pass consistently now
