### PR TITLE
Added instagram as possible connected contact activity

### DIFF
--- a/controllers/activities.js
+++ b/controllers/activities.js
@@ -9,6 +9,7 @@ const ActivityTypes = {
     web: 'web',
     sms: 'sms',
     twitter: 'twitter',
+    instagram: 'instagram',
     default: 'default',
   },
   unknown: 'unknown',


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

This PR is related to https://github.com/techmatters/flex-plugins/pull/655

## Description
Adds `instagram` as a possible "connect contact activity" so they are properly displayed in Case Timeline when retrieved from the DB.

### Verification steps
- `npm start` to start local server
- Expose the server (using ngrok is like `ngrok http 3000`)
- Start Flex locally using the above linked branch
- Point `Twilio.Flex.Manager.getInstance().serviceConfiguration.attributes.hrm_base_url` to the public url given above
- Save an Instagram channel contact and link it to a new case
- Retrieve the case from the backend and the contact should be displayed properly in the Timeline