### PR TITLE
CHI-988: Added extra test coverage for case list and search endpoints.

### DIFF
--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -79,8 +79,6 @@ describe('/cases route', () => {
   };
 
   const validateSingleCaseResponse = (actual, expectedCaseModel, expectedContactModel) => {
-    const { firstName, lastName } = expectedContactModel.dataValues.rawJson.childInformation.name;
-
     expect(actual.status).toBe(200);
     expect(actual.body).toStrictEqual(
       expect.objectContaining({

--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -131,6 +131,7 @@ describe('/cases route', () => {
         await createdCase.destroy();
       });
 
+      // eslint-disable-next-line jest/expect-expect
       test('should return 200 when populated', async () => {
         const response = await request.get(route).set(headers);
         validateSingleCaseResponse(response, createdCase, createdContact);
@@ -429,6 +430,7 @@ describe('/cases route', () => {
         expect(ids).toContain(createdCase3.id);
       });
 
+      // eslint-disable-next-line jest/expect-expect
       test('should return 200 - search by contact number', async () => {
         const body = {
           helpline: 'helpline',

--- a/tests/routes/case.test.js
+++ b/tests/routes/case.test.js
@@ -59,7 +59,7 @@ describe('/cases route', () => {
   const fillNameAndPhone = contact => {
     const modifiedContact = {
       ...contact,
-      form: {
+      rawJson: {
         ...contact.form,
         childInformation: {
           ...contact.form.childInformation,
@@ -72,7 +72,6 @@ describe('/cases route', () => {
       number: '+1-202-555-0184',
     };
 
-    modifiedContact.rawJson = modifiedContact.form;
     delete modifiedContact.form;
 
     return modifiedContact;
@@ -128,6 +127,7 @@ describe('/cases route', () => {
       });
 
       afterEach(async () => {
+        await createdContact.destroy();
         await createdCase.destroy();
       });
 


### PR DESCRIPTION
Primary reviewer @murilovmachado 

## Description

* Case list endpoint tests now test scenarios where the endpoint returns data.
* Case search endpoint tests now validate some content within the records being returned in the response

### Checklist
- [ X ] Corresponding issue has been opened
- [ X ] New tests added

### Related Issues
Fixes CHI-988

### Verification steps

Tests are run automatically on PRs
