### PR TITLE
Rename query param order to sortDirection

### DIFF
--- a/hrm-service/src/controllers/case-controller.js
+++ b/hrm-service/src/controllers/case-controller.js
@@ -132,11 +132,11 @@ const CaseController = (Case, sequelize) => {
   };
 
   const listCases = async (query, accountSid) => {
-    const { limit, offset, sortBy, order } = getPaginationElements(query);
+    const { limit, offset, sortBy, sortDirection } = getPaginationElements(query);
     const { helpline } = query;
 
     const queryObject = {
-      order: [[sortBy, `${order} NULLS LAST`]],
+      order: [[sortBy, `${sortDirection} NULLS LAST`]],
       limit,
       offset,
       include: {

--- a/hrm-service/src/controllers/helpers.js
+++ b/hrm-service/src/controllers/helpers.js
@@ -35,9 +35,9 @@ const getPaginationElements = query => {
   const limit = Math.min(queryLimit, 1000);
   const offset = (query.offset && parseInt(query.offset, 10)) || 0;
   const sortBy = query.sortBy || 'id';
-  const order = query.order || 'DESC';
+  const sortDirection = query.sortDirection || 'DESC';
 
-  return { limit, offset, sortBy, order };
+  return { limit, offset, sortBy, sortDirection };
 };
 
 const isEmptySearchParams = body => {

--- a/hrm-service/unit-tests/controllers/case-controller.test.js
+++ b/hrm-service/unit-tests/controllers/case-controller.test.js
@@ -188,7 +188,7 @@ describe('Test listCases query params', () => {
     });
   });
 
-  describe('sortBy and order', () => {
+  describe('sortBy and sortDirection', () => {
     test('default values', async () => {
       const findAndCountAllSpy = jest
         .spyOn(MockCase, 'findAndCountAll')
@@ -213,7 +213,7 @@ describe('Test listCases query params', () => {
       expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
     });
 
-    test('custom sortBy and order', async () => {
+    test('custom sortBy and sortDirection', async () => {
       const findAndCountAllSpy = jest
         .spyOn(MockCase, 'findAndCountAll')
         .mockImplementation(() => ({ rows: [], count: 0 }));
@@ -222,7 +222,7 @@ describe('Test listCases query params', () => {
         limit: 10,
         offset: 0,
         sortBy: 'Child Name',
-        order: 'ASC',
+        sortDirection: 'ASC',
       };
 
       await CaseController.listCases(queryParams, accountSid);
@@ -241,10 +241,6 @@ describe('Test listCases query params', () => {
       };
 
       expect(findAndCountAllSpy).toHaveBeenCalledWith(expectedQueryObject);
-    });
-
-    test('nullable/empty data at the end', async () => {
-      expect(1).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Description
This PR renames the query param `order` to `sortDirection`.