### PR TITLE
Fix docker file to compile type script on build rather than run

### DIFF
--- a/hrm-service/Dockerfile
+++ b/hrm-service/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:14-alpine as builder
 
-USER node
 WORKDIR /home/node
 
 COPY . /home/node
 
 RUN npm install
+RUN npm run build
 
 # RUN npm test
+USER node
 
 CMD ["npm", "start"]

--- a/hrm-service/package.json
+++ b/hrm-service/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "build": "npx tsc",
-    "start": "npm run build && sequelize db:migrate && cd ./dist && node ./bin/www",
+    "start": "sequelize db:migrate && cd ./dist && node ./bin/www",
+    "build-and-start": "npm run build && npm run start",
     "test": "jest --passWithNoTests --forceExit --maxWorkers=1",
     "test:unit": "jest unit-tests",
     "test:service": "jest --passWithNoTests --forceExit --maxWorkers=1 service-tests",


### PR DESCRIPTION
## Description

ECS health checks were failing, this is because container startup times were too long & causing timeouts

The cause of this was found to be the fact that the TypeScript compile step was being performed when running the container rather than when building it

This PR fixes this

### Checklist
- [ NO ] Corresponding issue has been opened
- [ N/A ] New tests added

### Verification steps

Deploy HRM to ECS
