### PR TITLE
CHI-1118: Date filters

### DIFF
--- a/hrm-service/package-lock.json
+++ b/hrm-service/package-lock.json
@@ -3546,9 +3546,10 @@
       }
     },
     "date-fns": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.10.0.tgz",
-      "integrity": "sha512-EhfEKevYGWhWlZbNeplfhIU/+N+x0iCIx7VzKlXma2EdQyznVlZhCptXUY+BegNpPW2kjdx15Rvq503YcXXrcA=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "dev": true
     },
     "dayjs": {
       "version": "1.10.4",

--- a/hrm-service/package-lock.json
+++ b/hrm-service/package-lock.json
@@ -3548,8 +3548,7 @@
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
       "version": "1.10.4",

--- a/hrm-service/package.json
+++ b/hrm-service/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "cancan": "^3.1.0",
     "cors": "^2.8.5",
-    "date-fns": "^2.10.0",
     "debug": "^4.1.1",
     "deep-diff": "^1.0.2",
     "dotenv": "^8.2.0",
@@ -58,6 +57,7 @@
     "babel-core": "^6.26.3",
     "chalk": "^4.0.0",
     "cross-env": "^7.0.3",
+    "date-fns": "^2.28.0",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^16.1.4",

--- a/hrm-service/package.json
+++ b/hrm-service/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "cancan": "^3.1.0",
     "cors": "^2.8.5",
+    "date-fns": "^2.28.0",
     "debug": "^4.1.1",
     "deep-diff": "^1.0.2",
     "dotenv": "^8.2.0",
@@ -57,7 +58,6 @@
     "babel-core": "^6.26.3",
     "chalk": "^4.0.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^2.28.0",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^16.1.4",

--- a/hrm-service/service-tests/case-validation.ts
+++ b/hrm-service/service-tests/case-validation.ts
@@ -105,6 +105,15 @@ export const convertCaseInfoToExpectedInfo = (input: any) => {
 
 export const validateCaseListResponse = (actual, expectedCaseAndContactModels, count) => {
   expect(actual.status).toBe(200);
+  if (count === 0) {
+    expect(actual.body).toStrictEqual(
+      expect.objectContaining({
+        cases: [],
+        count,
+      }),
+    );
+    return;
+  }
   expect(actual.body).toStrictEqual(
     expect.objectContaining({
       cases: expect.arrayContaining([expect.anything()]),

--- a/hrm-service/src/case/case-data-access.ts
+++ b/hrm-service/src/case/case-data-access.ts
@@ -96,9 +96,15 @@ export type CaseSearchCriteria = {
   lastName?: string,
 };
 
+export const enum DateExistsCondition {
+  MUST_EXIST = 'MUST_EXIST',
+  MUST_NOT_EXIST = 'MUST_NOT_EXIST',
+}
+
 export type DateFilter = {
   from?: string,
   to?: string,
+  exists?: DateExistsCondition
 };
 
 export type CaseListFilters = {
@@ -106,6 +112,8 @@ export type CaseListFilters = {
   statuses?: string[],
   excludedStatuses?: string[],
   createdAt?: DateFilter,
+  updatedAt?: DateFilter,
+  followUpDate?: DateFilter,
   helplines?: string[],
   includeOrphans?: boolean
 };

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -52,9 +52,9 @@ FROM (
 ) AS contacts WHERE contacts."caseId" = cases.id`;
 
 const enum FilterableDateField {
-  CREATED_AT = 'cases."createdAt"',
-  UPDATED_AT = 'cases."updatedAt"',
-  FOLLOW_UP_DATE = `cases."info"->>'followUpDate'`,
+  CREATED_AT = 'cases."createdAt"::TIMESTAMP WITH TIME ZONE',
+  UPDATED_AT = 'cases."updatedAt"::TIMESTAMP WITH TIME ZONE',
+  FOLLOW_UP_DATE = `CAST(cases."info"->>'followUpDate' AS TIMESTAMP WITH TIME ZONE)`,
 }
 
 const dateFilterCondition = (
@@ -69,10 +69,11 @@ const dateFilterCondition = (
   }
   if (filter.to || filter.from) {
     return pgp.as.format(
-      `(($<from> IS NULL OR ${field}::TIMESTAMP WITH TIME ZONE >= $<from>::TIMESTAMP WITH TIME ZONE) 
-            AND ($<to> IS NULL OR ${field}::TIMESTAMP WITH TIME ZONE <= $<to>::TIMESTAMP WITH TIME ZONE)
+      `(($<from> IS NULL OR ${field} >= $<from>::TIMESTAMP WITH TIME ZONE) 
+            AND ($<to> IS NULL OR ${field} <= $<to>::TIMESTAMP WITH TIME ZONE)
             ${existsCondition ? ` AND ${existsCondition}` : ''})`,
       filter,
+      { def: null },
     );
   }
   return existsCondition;


### PR DESCRIPTION
TODO: Tests

Primary Reviewer: @murilovmachado 

## Description

* Adds 'updatedAt' and 'followUpDate' filters to the case search endpoint
* Changes date filter logic to be based on TIMESTAMP WITH TIME ZONE types rather than DATE types, to account for date based searches being 'local days' from the client perspective, not UTC days.

### Checklist
- [ X ] Corresponding issue has been opened
- [ NO ] New tests added


### Related Issues
CHI-1118

### Verification steps

* Service Test coverage coming soon
