### PR TITLE
accountSid part of PK + Review & Enhance HRM DB indexes

### DIFF
--- a/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
+++ b/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
@@ -1,0 +1,96 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    // Modify Cases PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Cases" DROP CONSTRAINT "Cases_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "Cases"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Cases" ADD PRIMARY KEY ("id", "accountSid");',
+    );
+    console.log('Added new PK to "Cases"');
+
+    // Modify Contacts PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Contacts" DROP CONSTRAINT "Contacts_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "Contacts"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Contacts" ADD PRIMARY KEY ("id", "accountSid");',
+    );
+    console.log('Added new PK to "Contacts"');
+
+    // Modify PostSurveys PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT "PostSurveys_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "PostSurveys"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."PostSurveys" ADD PRIMARY KEY ("id", "accountSid");',
+    );
+    console.log('Added new PK to "PostSurveys"');
+
+    // Modify CSAMReports PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT "CSAMReports_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "CSAMReports"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."CSAMReports" ADD PRIMARY KEY ("id", "accountSid");',
+    );
+    console.log('Added new PK to "CSAMReports"');
+
+    // Contacts references Cases (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Contacts" ADD CONSTRAINT "Contacts_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid") 
+        REFERENCES public."Cases" ("id", "accountSid") MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT;
+    `);
+    console.log('Added new FK to "Contacts" referencing "Cases"');
+
+    // CSAMReports references Contacts (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CSAMReports" ADD CONSTRAINT "CSAMReports_contactId_accountSid_fkey" FOREIGN KEY ("contactId", "accountSid") 
+        REFERENCES public."Contacts" ("id", "accountSid") MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT;
+    `);
+    console.log('Added new FK to "CSAMReports" referencing "Contacts"');
+
+    // Add accountSid column to CaseSections
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CaseSections" ADD COLUMN IF NOT EXISTS "accountSid" character varying(255) COLLATE pg_catalog."default";
+    `);
+
+    // Backfill CaseSections accountSid using parent Case record
+    await queryInterface.sequelize.query(`
+      UPDATE "CaseSections" cs SET "accountSid" = "c"."accountSid" FROM "Cases" "c" WHERE cs."caseId" = "c"."id";
+    `);
+
+    // Mark CaseSections accountSid as NOT NULL
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "CaseSections" ALTER COLUMN "accountSid" SET NOT NULL;
+    `);
+    console.log(
+      'Added "accountSid" column to "CaseSections" table, backfilled with parent "Case" info',
+    );
+
+    // CaseSections references Cases (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CaseSections" ADD CONSTRAINT "CaseSections_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid") 
+        REFERENCES public."Cases" (id, "accountSid") MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+    `);
+    console.log('Added new FK to "CaseSections" referencing "Cases"');
+  },
+
+  down: async queryInterface => {},
+};

--- a/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
+++ b/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
@@ -48,7 +48,7 @@ module.exports = {
 
     // Contacts references Cases (FK)
     await queryInterface.sequelize.query(`
-      ALTER TABLE public."Contacts" ADD CONSTRAINT "Contacts_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid") 
+      ALTER TABLE public."Contacts" ADD CONSTRAINT "Contacts_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid")
         REFERENCES public."Cases" ("id", "accountSid") MATCH SIMPLE
         ON UPDATE CASCADE
         ON DELETE RESTRICT;
@@ -57,7 +57,7 @@ module.exports = {
 
     // CSAMReports references Contacts (FK)
     await queryInterface.sequelize.query(`
-      ALTER TABLE public."CSAMReports" ADD CONSTRAINT "CSAMReports_contactId_accountSid_fkey" FOREIGN KEY ("contactId", "accountSid") 
+      ALTER TABLE public."CSAMReports" ADD CONSTRAINT "CSAMReports_contactId_accountSid_fkey" FOREIGN KEY ("contactId", "accountSid")
         REFERENCES public."Contacts" ("id", "accountSid") MATCH SIMPLE
         ON UPDATE CASCADE
         ON DELETE RESTRICT;
@@ -84,7 +84,7 @@ module.exports = {
 
     // CaseSections references Cases (FK)
     await queryInterface.sequelize.query(`
-      ALTER TABLE public."CaseSections" ADD CONSTRAINT "CaseSections_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid") 
+      ALTER TABLE public."CaseSections" ADD CONSTRAINT "CaseSections_caseId_accountSid_fkey" FOREIGN KEY ("caseId", "accountSid")
         REFERENCES public."Cases" (id, "accountSid") MATCH SIMPLE
         ON UPDATE CASCADE
         ON DELETE CASCADE;
@@ -92,5 +92,78 @@ module.exports = {
     console.log('Added new FK to "CaseSections" referencing "Cases"');
   },
 
-  down: async queryInterface => {},
+  down: async queryInterface => {
+    // Revert Cases PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Cases" DROP CONSTRAINT "Cases_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "Cases"');
+
+    await queryInterface.sequelize.query('ALTER TABLE public."Cases" ADD PRIMARY KEY ("id");');
+    console.log('Reverted PK to "Cases"');
+
+    // Revert Contacts PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."Contacts" DROP CONSTRAINT "Contacts_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "Contacts"');
+
+    await queryInterface.sequelize.query('ALTER TABLE public."Contacts" ADD PRIMARY KEY ("id");');
+    console.log('Reverted PK to "Contacts"');
+
+    // Revert PostSurveys PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT "PostSurveys_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "PostSurveys"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."PostSurveys" ADD PRIMARY KEY ("id");',
+    );
+    console.log('Reverted PK to "PostSurveys"');
+
+    // Revert CSAMReports PK
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT "CSAMReports_pkey" CASCADE;',
+    );
+    console.log('Dropped PK from "CSAMReports"');
+
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."CSAMReports" ADD PRIMARY KEY ("id");',
+    );
+    console.log('Reverted PK to "CSAMReports"');
+
+    // Contacts references Cases (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Contacts" ADD CONSTRAINT "Contacts_caseId_fkey" FOREIGN KEY ("caseId")
+        REFERENCES public."Cases" ("id") MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT;
+    `);
+    console.log('Reverted FK to "Contacts" referencing "Cases"');
+
+    // CSAMReports references Contacts (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CSAMReports" ADD CONSTRAINT "CSAMReports_contactId_fkey" FOREIGN KEY ("contactId")
+        REFERENCES public."Contacts" ("id") MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT;
+    `);
+    console.log('Reverted FK to "CSAMReports" referencing "Contacts"');
+
+    // Remove accountSid column from CaseSections
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CaseSections" DROP COLUMN IF EXISTS "accountSid" CASCADE;
+    `);
+    console.log('Removed "accountSid" column from "CaseSections" table');
+
+    // CaseSections references Cases (FK)
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."CaseSections" ADD CONSTRAINT "CaseSections_caseId_fkey" FOREIGN KEY ("caseId")
+        REFERENCES public."Cases" (id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+    `);
+    console.log('Added new FK to "CaseSections" referencing "Cases"');
+  },
 };

--- a/hrm-service/migrations/20220429173823-create-indexes.js
+++ b/hrm-service/migrations/20220429173823-create-indexes.js
@@ -1,0 +1,62 @@
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "fki_CaseSections_caseId_Case_id_fk";
+    `);
+    console.log('Index fki_CaseSections_caseId_Case_id_fk dropped');
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "CaseSections_caseId_accountSid_idx" ON public."CaseSections" 
+      USING btree ("caseId", "accountSid");
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "CSAMReports_contactId_accountSid_idx" ON public."CSAMReports" 
+      USING btree ("contactId", "accountSid");
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "Contacts_caseId_accountSid_idx" ON public."Contacts" 
+      USING btree ("caseId", "accountSid");
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "Contacts_accountSid_idx" ON public."Contacts" 
+      USING btree ("accountSid");
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "Cases_accountSid_idx" ON public."Cases" 
+      USING btree ("accountSid");
+    `);
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "fki_CaseSections_caseId_Case_id_fk";
+    `);
+    console.log('Index fki_CaseSections_caseId_Case_id_fk dropped');
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "CaseSections_caseId_accountSid_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "CSAMReports_contactId_accountSid_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "Contacts_caseId_accountSid_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "Contacts_accountSid_idx";
+    `);
+
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "Cases_accountSid_idx";
+    `);
+  },
+};

--- a/hrm-service/migrations/20220429173823-create-indexes.js
+++ b/hrm-service/migrations/20220429173823-create-indexes.js
@@ -11,52 +11,63 @@ module.exports = {
       CREATE INDEX IF NOT EXISTS "CaseSections_caseId_accountSid_idx" ON public."CaseSections" 
       USING btree ("caseId", "accountSid");
     `);
+    console.log('Index CaseSections_caseId_accountSid_idx created');
 
     await queryInterface.sequelize.query(`
       CREATE INDEX IF NOT EXISTS "CSAMReports_contactId_accountSid_idx" ON public."CSAMReports" 
       USING btree ("contactId", "accountSid");
     `);
+    console.log('Index CSAMReports_contactId_accountSid_idx created');
 
     await queryInterface.sequelize.query(`
       CREATE INDEX IF NOT EXISTS "Contacts_caseId_accountSid_idx" ON public."Contacts" 
       USING btree ("caseId", "accountSid");
     `);
+    console.log('Index Contacts_caseId_accountSid_idx created');
 
     await queryInterface.sequelize.query(`
       CREATE INDEX IF NOT EXISTS "Contacts_accountSid_idx" ON public."Contacts" 
       USING btree ("accountSid");
     `);
+    console.log('Index Contacts_accountSid_idx created');
 
     await queryInterface.sequelize.query(`
       CREATE INDEX IF NOT EXISTS "Cases_accountSid_idx" ON public."Cases" 
       USING btree ("accountSid");
     `);
+    console.log('Index Cases_accountSid_idx created');
   },
 
   down: async queryInterface => {
     await queryInterface.sequelize.query(`
-      DROP INDEX IF EXISTS "fki_CaseSections_caseId_Case_id_fk";
-    `);
-    console.log('Index fki_CaseSections_caseId_Case_id_fk dropped');
-
-    await queryInterface.sequelize.query(`
       DROP INDEX IF EXISTS "CaseSections_caseId_accountSid_idx";
     `);
+    console.log('Index CaseSections_caseId_accountSid_idx dropped');
 
     await queryInterface.sequelize.query(`
       DROP INDEX IF EXISTS "CSAMReports_contactId_accountSid_idx";
     `);
+    console.log('Index CSAMReports_contactId_accountSid_idx dropped');
 
     await queryInterface.sequelize.query(`
       DROP INDEX IF EXISTS "Contacts_caseId_accountSid_idx";
     `);
+    console.log('Index Contacts_caseId_accountSid_idx dropped');
 
     await queryInterface.sequelize.query(`
       DROP INDEX IF EXISTS "Contacts_accountSid_idx";
     `);
+    console.log('Index Contacts_accountSid_idx dropped');
 
     await queryInterface.sequelize.query(`
       DROP INDEX IF EXISTS "Cases_accountSid_idx";
     `);
+    console.log('Index Cases_accountSid_idx dropped');
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "fki_CaseSections_caseId_Case_id_fk" ON public."CaseSections" USING btree
+        ("caseId" ASC NULLS LAST)
+      `);
+    console.log('Index fki_CaseSections_caseId_Case_id_fk created');
   },
 };

--- a/hrm-service/service-tests/case-audits.test.js
+++ b/hrm-service/service-tests/case-audits.test.js
@@ -27,10 +27,13 @@ const caseAuditsQuery = {
 
 beforeAll(async () => {
   await CaseAudit.destroy(caseAuditsQuery);
+  await Case.destroy(caseAuditsQuery);
 });
 
-afterAll(done => {
-  server.close(done);
+afterAll(async () => {
+  await CaseAudit.destroy(caseAuditsQuery);
+  await Case.destroy(caseAuditsQuery);
+  server.close();
 });
 
 afterEach(async () => CaseAudit.destroy(caseAuditsQuery));

--- a/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-service/service-tests/case-search.test.ts
@@ -163,11 +163,13 @@ describe('/cases route', () => {
       });
 
       afterEach(async () => {
+        await Contact.destroy({
+          where: { id: createdCasesAndContacts.map(ccc => ccc.contact.id) },
+        });
         await Promise.all([
           db.none(`DELETE FROM "Cases" WHERE id IN ($<ids:csv>)`, {
             ids: createdCasesAndContacts.map(ccc => ccc.case.id),
           }),
-          Contact.destroy({ where: { id: createdCasesAndContacts.map(ccc => ccc.contact.id) } }),
         ]);
       });
 
@@ -373,7 +375,6 @@ describe('/cases route', () => {
           expect(response.body.count).toBe(3);
         });
 
-        // eslint-disable-next-line jest/expect-expect
         test('should return 200 - search by contact number', async () => {
           const body = {
             helpline: 'helpline',

--- a/hrm-service/service-tests/case-validation.ts
+++ b/hrm-service/service-tests/case-validation.ts
@@ -74,7 +74,7 @@ export const without = (original, ...property) => {
   return output;
 };
 
-export const convertCaseInfoToExpectedInfo = (input: any) => {
+export const convertCaseInfoToExpectedInfo = (input: any, accountSid: string = null) => {
   if (!input || !input.info) return { ...input };
   const expectedCase = {
     ...input,
@@ -87,6 +87,7 @@ export const convertCaseInfoToExpectedInfo = (input: any) => {
         expectedInfo[sectionName] = expectedInfo[sectionName].map(section => ({
           id: expect.anything(),
           ...section,
+          accountSid: section.accountSid || expectedCase.accountSid || accountSid,
           createdAt: expect.toParseAsDate(section.createdAt),
         }));
         if (sectionName === 'counsellorNotes') {

--- a/hrm-service/service-tests/case.test.ts
+++ b/hrm-service/service-tests/case.test.ts
@@ -515,7 +515,7 @@ describe('/cases route', () => {
             ...convertCaseInfoToExpectedInfo(originalCase),
             createdAt: expect.toParseAsDate(originalCase.createdAt),
             updatedAt: expect.toParseAsDate(),
-            ...convertCaseInfoToExpectedInfo(update),
+            ...convertCaseInfoToExpectedInfo(update, accountSid),
             updatedBy: customWorkerSid || workerSid,
           };
 

--- a/hrm-service/service-tests/contacts.test.js
+++ b/hrm-service/service-tests/contacts.test.js
@@ -39,17 +39,16 @@ const query = {
 };
 
 beforeAll(async () => {
+  await CSAMReport.destroy(query);
   await Contact.destroy(query);
+  await Case.destroy(query);
 });
 
-afterAll(done => {
-  server.close(() => {
-    Case.destroy(query).then(() => {
-      CSAMReport.destroy(query).then(() => {
-        Contact.destroy(query).then(() => done());
-      });
-    });
-  });
+afterAll(async () => {
+  await CSAMReport.destroy(query);
+  await Contact.destroy(query);
+  await Case.destroy(query);
+  server.close();
   console.log('Deleted data in contacts.test');
 });
 
@@ -156,7 +155,8 @@ describe('/contacts route', () => {
       // Test the association
       expect(response.body.csamReports).toHaveLength(2);
 
-      // Remove this contact to not interfere with following tests
+      // Remove records to not interfere with following tests
+      await CSAMReport.destroy({ where: { contactId: response.body.id } });
       await Contact.destroy({ where: { id: response.body.id } });
     });
   });

--- a/hrm-service/sql/test-utils/fill-db-function
+++ b/hrm-service/sql/test-utils/fill-db-function
@@ -1,0 +1,55 @@
+-- WARNING: Only intended to be used for local tests & development, not against real DBs
+
+-- This function creates recors for Cases, CaseSections, Contacts and CSAMReports
+
+CREATE OR REPLACE FUNCTION fillDB() RETURNS void AS
+$BODY$
+DECLARE
+   r record;
+   account_sid text;
+   helpline_name text;
+   worker_sid text;
+   case_id integer;
+   contact_id integer;
+BEGIN
+    FOR r IN (SELECT generate_series(1, 100) as num)
+    LOOP
+        account_sid = 'account-' || (r.num % 5)::text;
+        helpline_name = account_sid || 'helpline-' || (r.num % 2)::text;
+        worker_sid = account_sid || 'worker-' || (r.num % 10)::text;
+
+        -- WITH case_record AS (
+        --   INSERT INTO "Cases" ("info", "accountSid", "helpline", "status", "twilioWorkerId", "createdBy", "createdAt", "updatedAt", "updatedBy")
+        --   VALUES ('{}'::jsonb, account_sid, helpline_name, 'open', worker_sid, worker_sid, current_timestamp, current_timestamp, NULL)
+        --   RETURNING *
+        -- ),
+        -- contact_record AS (
+        --   INSERT INTO "Contacts" ("rawJson", "accountSid", "helpline", "createdBy", "createdAt", "updatedAt", "updatedBy", "caseId") 
+        --   VALUES ('{}'::jsonb, account_sid, helpline_name, worker_sid, current_timestamp, current_timestamp, NULL, (SELECT case_record.id FROM case_record))
+        --   RETURNING *
+        -- )
+
+          INSERT INTO "Cases" ("info", "accountSid", "helpline", "status", "twilioWorkerId", "createdBy", "createdAt", "updatedAt", "updatedBy")
+          VALUES ('{}'::jsonb, account_sid, helpline_name, 'open', worker_sid, worker_sid, current_timestamp, current_timestamp, NULL)
+          RETURNING id INTO case_id;
+
+          INSERT INTO "Contacts" ("rawJson", "accountSid", "helpline", "createdBy", "createdAt", "updatedAt", "updatedBy", "caseId") 
+          VALUES ('{}'::jsonb, account_sid, helpline_name, worker_sid, current_timestamp, current_timestamp, NULL, case_id)
+          RETURNING id INTO contact_id;
+
+        INSERT INTO "CaseSections" ("caseId", "sectionType", "createdAt", "createdBy", "updatedAt", "updatedBy", "sectionTypeSpecificData", "accountSid")
+        VALUES (case_id, 'sectionName', current_timestamp, worker_sid, current_timestamp, current_timestamp, '{}'::jsonb, account_sid);
+
+        INSERT INTO "CaseSections" ("caseId", "sectionType", "createdAt", "createdBy", "updatedAt", "updatedBy", "sectionTypeSpecificData", "accountSid")
+        VALUES (case_id, 'sectionName', current_timestamp, worker_sid, current_timestamp, current_timestamp, '{}'::jsonb, account_sid);
+
+        INSERT INTO "CSAMReports" ("accountSid", "twilioWorkerId", "csamReportId", "contactId", "createdAt", "updatedAt")
+        VALUES (account_sid, worker_sid, 'csam-report-' || r.num::text, contact_id, current_timestamp, current_timestamp);
+
+        INSERT INTO "CSAMReports" ("accountSid", "twilioWorkerId", "csamReportId", "contactId", "createdAt", "updatedAt")
+        VALUES (account_sid, worker_sid, 'csam-report-' || r.num::text, contact_id, current_timestamp, current_timestamp);
+    END LOOP;
+    RETURN;
+END;
+$BODY$
+LANGUAGE plpgsql;

--- a/hrm-service/sql/test-utils/selectSingleCaseByIdSql
+++ b/hrm-service/sql/test-utils/selectSingleCaseByIdSql
@@ -1,0 +1,26 @@
+-- WARNING: Only intended to be used for local tests & development, not against real DBs
+
+-- This query is the one in src/case/sql/case-get-sql.ts with accountSid and case id provided
+
+SELECT
+  cases.*,
+  caseSections."caseSections",
+  contacts."connectedContacts"
+  FROM "Cases" AS cases
+
+  LEFT JOIN LATERAL ( 
+  SELECT COALESCE(jsonb_agg(to_jsonb(c) || to_jsonb(reports)), '[]') AS  "connectedContacts" 
+  FROM "Contacts" c 
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(jsonb_agg(to_jsonb(r)), '[]') AS  "csamReports" 
+    FROM "CSAMReports" r 
+    WHERE r."contactId" = c.id AND r."accountSid" = c."accountSid"
+  ) reports ON true
+  WHERE c."caseId" = cases.id AND c."accountSid" = cases."accountSid"
+) contacts ON true
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(jsonb_agg(to_jsonb(cs) ORDER BY cs."createdAt"), '[]') AS  "caseSections"
+    FROM "CaseSections" cs
+    WHERE cs."caseId" = cases.id
+  ) caseSections ON true
+WHERE "cases"."accountSid" = 'ACCOUNT_SID' AND "cases"."id" = 1143

--- a/hrm-service/src/case/case-data-access.ts
+++ b/hrm-service/src/case/case-data-access.ts
@@ -77,6 +77,7 @@ export type CaseSectionRecord = {
   sectionType: string;
   sectionId: string;
   sectionTypeSpecificData: Record<string, any>;
+  accountSid: string;
   createdAt: string;
   createdBy: string;
   updatedAt?: string;
@@ -149,7 +150,7 @@ export const create = async (
       const statement = `${pgp.helpers.insert(caseRecord, null, 'Cases')} RETURNING *`;
       let inserted: CaseRecord = await transaction.one(statement);
       if ((caseSections ?? []).length) {
-        const allSections = caseSections.map(s => ({ ...s, caseId: inserted.id }));
+        const allSections = caseSections.map(s => ({ ...s, caseId: inserted.id, accountSid }));
         const sectionStatement = `${caseSectionUpsertSql(allSections)};${selectSingleCaseByIdSql(
           'Cases',
         )}`;
@@ -217,7 +218,7 @@ export const update = async (
     if (caseRecordUpdates.info) {
       const allSections: CaseSectionRecord[] = caseRecordUpdates.caseSections ?? [];
       if (allSections.length) {
-        caseUpdateSqlStatements.push(caseSectionUpsertSql(allSections));
+        caseUpdateSqlStatements.push(caseSectionUpsertSql(allSections.map(s => ({ ...s, accountSid }))));
       }
       // Map case sections into a list of ids grouped by category, which allows a more concise DELETE SQL statement to be generated
       const caseSectionIdsByType = allSections.reduce((idsBySectionType, caseSection) => {

--- a/hrm-service/src/case/case.ts
+++ b/hrm-service/src/case/case.ts
@@ -243,6 +243,7 @@ const caseToCaseRecord = (
           updatedBy: section.updatedBy,
           updatedAt: section.updatedAt,
           sectionTypeSpecificData: getSectionSpecificData(section),
+          accountSid: section.accountSid,
         };
         return caseSectionRecordToUpsert;
       }),

--- a/hrm-service/src/case/sql/case-get-sql.ts
+++ b/hrm-service/src/case/sql/case-get-sql.ts
@@ -12,13 +12,13 @@ export const selectSingleCaseByIdSql = (tableName: string) => `SELECT
         LEFT JOIN LATERAL (
           SELECT COALESCE(jsonb_agg(to_jsonb(r)), '[]') AS  "csamReports" 
           FROM "CSAMReports" r 
-          WHERE r."contactId" = c.id
+          WHERE r."contactId" = c.id AND r."accountSid" = c."accountSid"
         ) reports ON true
-        WHERE c."caseId" = cases.id
+        WHERE c."caseId" = cases.id AND c."accountSid" = cases."accountSid"
       ) contacts ON true
         LEFT JOIN LATERAL (
           SELECT COALESCE(jsonb_agg(to_jsonb(cs) ORDER BY cs."createdAt"), '[]') AS  "caseSections"
           FROM "CaseSections" cs
-          WHERE cs."caseId" = cases.id
+          WHERE cs."caseId" = cases.id AND cs."accountSid" = cases."accountSid"
         ) caseSections ON true
       ${ID_WHERE_CLAUSE}`;

--- a/hrm-service/src/case/sql/case-sections-sql.ts
+++ b/hrm-service/src/case/sql/case-sections-sql.ts
@@ -2,6 +2,9 @@ import { pgp } from '../../connection-pool';
 // eslint-disable-next-line prettier/prettier
 import { CaseSectionRecord } from '../case-data-access';
 
+/**
+ * Is this FILTER (WHERE cs."caseId" IS NOT NULL) needed? Won't cs."caseId" always be not null as "caseId" is part of the PK?
+ */
 export const SELECT_CASE_SECTIONS = `SELECT 
          COALESCE(jsonb_agg(DISTINCT cs.*) FILTER (WHERE cs."caseId" IS NOT NULL), '[]') AS "caseSections"
                      FROM "CaseSections" cs

--- a/hrm-service/src/case/sql/case-sections-sql.ts
+++ b/hrm-service/src/case/sql/case-sections-sql.ts
@@ -5,7 +5,7 @@ import { CaseSectionRecord } from '../case-data-access';
 export const SELECT_CASE_SECTIONS = `SELECT 
          COALESCE(jsonb_agg(DISTINCT cs.*) FILTER (WHERE cs."caseId" IS NOT NULL), '[]') AS "caseSections"
                      FROM "CaseSections" cs
-                     WHERE cs."caseId" = cases.id`;
+                     WHERE cs."caseId" = cases.id AND cs."accountSid" = cases."accountSid"`;
 
 export const caseSectionUpsertSql = (sections: CaseSectionRecord[]): string =>
   `${pgp.helpers.insert(
@@ -19,6 +19,7 @@ export const caseSectionUpsertSql = (sections: CaseSectionRecord[]): string =>
       'updatedBy',
       'updatedAt',
       'sectionTypeSpecificData',
+      'accountSid',
     ],
     'CaseSections',
   )} 
@@ -35,8 +36,8 @@ export const deleteMissingCaseSectionsSql = (idsByType: Record<string, string[]>
         )
         .join(' OR '),
     );
-    return `DELETE FROM "CaseSections" WHERE "caseId" = $<caseId> AND NOT (${sectionTypeWhereExpression})`;
+    return `DELETE FROM "CaseSections" WHERE "caseId" = $<caseId> AND "accountSid" = $<accountSid> AND NOT (${sectionTypeWhereExpression})`;
   } else {
-    return `DELETE FROM "CaseSections" WHERE "caseId" = $<caseId>`;
+    return `DELETE FROM "CaseSections" WHERE "caseId" = $<caseId> AND "accountSid" = $<accountSid>`;
   }
 };


### PR DESCRIPTION
## Description
This PR:
- Updates test dump to the state previous to this PR.
- Adds migration to have `accountSid` as part of relevant of PK:
  - Adds `accountSid` column as part of the PK of `Cases`, `Contacts`, `CSAMReports` and `PostSurveys` tables.
  - Adds `accountSid` column to `CaseSections` table, and back-fills it with the value present in the parent case of each record.
  - Adds `accountSid` to be taken into consideration for the relevant queries on `Cases` and `CaseSections` queries. This change is skipped for the rest of the tables because the "controllers" are already taking into consideration and filling the `accountSid` with the corresponding value (or empty string as default. Q: Should we review and change this "empty string default" given that now we have `accountSid` as part of the PK of our tables?).
  - Updates the following FKs: `Contacts` reference to `Cases`, `CaseSections` reference `Cases`, `CSAMReports` reference to `Contacts`.
  - Adjusts CI to the above changes.
- Adds migration that creates new indexes:
  - As [Postgres does not automatically creates indexes on FKs](https://www.postgresql.org/docs/current/ddl-constraints.html#:~:text=A%20foreign%20key%20must,on%20the%20referencing%20columns.), this PR includes indexes matching all of our FK relationships (e.g. index on `caseId`-`accountSid` on `CaseSections` table, to improve queries like "retrieving all the case sections for a given case").
  - Indexes for `Cases` and `Contacts` tables on `accountSid` column.
- Adds two "utility queries" that I found useful while working on this, 
  - `fillDB()` function, used to create records for most of our tables (useful to test cost of queries). Can be created via CLI or PGAdmin and then called like `SELECT fillDB()`.
  -  `selectSingleCaseByIdSql` query, that's just one of the queries we use in our app. Useful when used with `EXPLAIN ANALIZE` to see the difference on the cost of queries before and after the creation of the indexes.

Some results I got before the creation of indexes

![Screenshot from 2022-04-29 17-14-19](https://user-images.githubusercontent.com/15805319/166072183-8dd7d929-d71b-4fd9-ae68-ea13e8f53d92.png)

and after they are created

![Screenshot from 2022-04-29 17-14-48](https://user-images.githubusercontent.com/15805319/166072285-896cf1cc-2db9-44ab-bb85-b1b45fa37a21.png)

For what I could observe, planning and execution costs vary but the ones with indexes are consistently lower than the same queries without the indexes (so they are worth I think :smile:).

### Checklist
- [ ] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1084)
- [ ] New tests added

### Verification steps
- [Optional but recommended] Start the test containerized test DB.
- `➜ POSTGRES_PORT=5433 API_KEY=anything USE_OPEN_PERMISSIONS=true npm start` so the migrations are executed against the DB (omit the env vars if not using container).
- Check that everything still works.
- Maybe test the costs of some queries with and without the indexes (you can `➜ POSTGRES_PORT=5433 API_KEY=anything USE_OPEN_PERMISSIONS=true npm run db:undo-last` to remove the indexes, as they are isolated in the latest migration).