### PR TITLE
Added sort order to query returning data audits

### DIFF
--- a/hrm-service/service-tests/db-tests/audit_trigger.test.ts
+++ b/hrm-service/service-tests/db-tests/audit_trigger.test.ts
@@ -21,6 +21,7 @@ describe('Cases_audit_trigger', () => {
       OR 
       ("newRecord"->>'id' = '${createdCase.id}' AND "newRecord"->>'accountSid' = '${testAccountSid}')
     )
+    ORDER BY "timestamp_clock" ASC
   `;
 
   afterAll(async () => {
@@ -154,12 +155,15 @@ describe('CaseSections_audit_trigger', () => {
   const sectionName = 'section';
   const sectionId = '123';
 
-  const selectCreatedCaseSectionAudits = () =>
-    `SELECT * FROM "Audits" WHERE "tableName" = 'CaseSections' AND (
+  const selectCreatedCaseSectionAudits = () => `
+    SELECT * FROM "Audits" 
+    WHERE "tableName" = 'CaseSections' AND (
       ("oldRecord"->>'caseId' = '${createdCase.id}' AND "oldRecord"->>'sectionType' = '${sectionName}'  AND "oldRecord"->>'sectionId' = '${sectionId}')
       OR
       ("newRecord"->>'caseId' = '${createdCase.id}' AND "newRecord"->>'sectionType' = '${sectionName}'  AND "newRecord"->>'sectionId' = '${sectionId}')
-    )`;
+    )
+    ORDER BY "timestamp_clock" ASC
+    `;
 
   beforeAll(async () => {
     createdCase = await db.task(t =>
@@ -318,6 +322,7 @@ describe('Contacts_audit_trigger', () => {
       OR 
       ("newRecord"->>'id' = '${createdContact.id}' AND "newRecord"->>'accountSid' = '${testAccountSid}')
     )
+    ORDER BY "timestamp_clock" ASC
   `;
 
   afterAll(async () => {


### PR DESCRIPTION
## Description
After merging https://github.com/techmatters/hrm/pull/181, master branch CI is failing because of a service test. Locally it works fine for me, but I believe that based on the test output, the reason is a query used in tests not respecting the "order of insertion". I've been reading and seems like Postgres does not guarantees any order for queries with no `ORDER BY` clause, so this is an attempt to fix the master branch CI. 
