### PR TITLE
Fixed migration script for records with null accountSid

### DIFF
--- a/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
+++ b/hrm-service/migrations/20220427154028-alter-tables-accountSid-PK.js
@@ -2,9 +2,12 @@
 
 module.exports = {
   up: async queryInterface => {
+    // Remove cases without account ID
+    await queryInterface.sequelize.query('DELETE FROM public."Cases" WHERE "accountSid" IS NULL');
+    console.log('Removed cases with NULL accountSid');
     // Modify Cases PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."Cases" DROP CONSTRAINT "Cases_pkey" CASCADE;',
+      'ALTER TABLE public."Cases" DROP CONSTRAINT IF EXISTS "Cases_pkey" CASCADE;',
     );
     console.log('Dropped PK from "Cases"');
 
@@ -13,9 +16,14 @@ module.exports = {
     );
     console.log('Added new PK to "Cases"');
 
+    // Remove cases without account ID
+    await queryInterface.sequelize.query(
+      'DELETE FROM public."Contacts" WHERE "accountSid" IS NULL',
+    );
+    console.log('Removed contacts with NULL accountSid');
     // Modify Contacts PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."Contacts" DROP CONSTRAINT "Contacts_pkey" CASCADE;',
+      'ALTER TABLE public."Contacts" DROP CONSTRAINT IF EXISTS "Contacts_pkey" CASCADE;',
     );
     console.log('Dropped PK from "Contacts"');
 
@@ -26,7 +34,11 @@ module.exports = {
 
     // Modify PostSurveys PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT "PostSurveys_pkey" CASCADE;',
+      'DELETE FROM public."PostSurveys" WHERE "accountSid" IS NULL',
+    );
+    console.log('Removed PostSurveys with NULL accountSid');
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT IF EXISTS "PostSurveys_pkey" CASCADE;',
     );
     console.log('Dropped PK from "PostSurveys"');
 
@@ -36,8 +48,14 @@ module.exports = {
     console.log('Added new PK to "PostSurveys"');
 
     // Modify CSAMReports PK
+
+    // Modify PostSurveys PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT "CSAMReports_pkey" CASCADE;',
+      'DELETE FROM public."CSAMReports" WHERE "accountSid" IS NULL',
+    );
+    console.log('Removed CSAMReports with NULL accountSid');
+    await queryInterface.sequelize.query(
+      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT IF EXISTS "CSAMReports_pkey" CASCADE;',
     );
     console.log('Dropped PK from "CSAMReports"');
 
@@ -95,7 +113,7 @@ module.exports = {
   down: async queryInterface => {
     // Revert Cases PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."Cases" DROP CONSTRAINT "Cases_pkey" CASCADE;',
+      'ALTER TABLE public."Cases" DROP CONSTRAINT IF EXISTS "Cases_pkey" CASCADE;',
     );
     console.log('Dropped PK from "Cases"');
 
@@ -104,7 +122,7 @@ module.exports = {
 
     // Revert Contacts PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."Contacts" DROP CONSTRAINT "Contacts_pkey" CASCADE;',
+      'ALTER TABLE public."Contacts" DROP CONSTRAINT IF EXISTS "Contacts_pkey" CASCADE;',
     );
     console.log('Dropped PK from "Contacts"');
 
@@ -113,7 +131,7 @@ module.exports = {
 
     // Revert PostSurveys PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT "PostSurveys_pkey" CASCADE;',
+      'ALTER TABLE public."PostSurveys" DROP CONSTRAINT IF EXISTS "PostSurveys_pkey" CASCADE;',
     );
     console.log('Dropped PK from "PostSurveys"');
 
@@ -124,7 +142,7 @@ module.exports = {
 
     // Revert CSAMReports PK
     await queryInterface.sequelize.query(
-      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT "CSAMReports_pkey" CASCADE;',
+      'ALTER TABLE public."CSAMReports" DROP CONSTRAINT IF EXISTS "CSAMReports_pkey" CASCADE;',
     );
     console.log('Dropped PK from "CSAMReports"');
 


### PR DESCRIPTION
Primary Reviewer: @GPaoloni 

## Description

Some DBs have legacy records with NULL account SIDs (hrm-development is one), so the script needs tweaking to remove these before changing the PKs

It also adds some 'IF EXISTS' clauses to DROP CONSTRAINT statements to make partially failed migrations easier to rerun

IMPORTANT NOTE - if any of these records need to be kept, they need 

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [ ] 
### Related Issues
Fixes CHI-1084

### Verification steps

Run the migration against test databases