### PR TITLE
Edit monthly data pull query for clarity

### DIFF
--- a/hrm-service/sql/zm-data-pull.sql
+++ b/hrm-service/sql/zm-data-pull.sql
@@ -15,7 +15,7 @@ FROM
   left join lateral jsonb_each_text(categories.value) subcategories on true
 where
   "createdAt" >= '2021-11-01' -- Fill dateFrom
-  and "createdAt" <= '2021-11-30' -- Fill dateTo
+  and "createdAt" < '2021-12-01' -- Fill dateTo (exclusive)
   and "accountSid" = 'XXXXXXXXXX' -- Fill accountSid
   and subcategories.value = 'true'
 group by "createdAt", "twilioWorkerId", "timeOfContact", "rawJson" 


### PR DESCRIPTION
Primary reviewer: @murilovmachado 

## Description
The query as written could cause someone to mistakenly not pull the last day of the month. As `createdAt` is a timestamptz field, the clause `"createdAt" <= '2021-11-30'` will capture all data on or before `2021-11-30 00:00:00`. This essentially excludes all of 11/30. The edit to the query below changes this to encourage the user to specify the next day as an exclusive limit so that we capture the full month.

