### PR TITLE
CHI-1074: Remove cancan

### DIFF
--- a/hrm-service/src/permissions/setupCanForRules.ts
+++ b/hrm-service/src/permissions/setupCanForRules.ts
@@ -1,9 +1,5 @@
 import { isCounselorWhoCreated, isSupervisor, isCaseOpen } from './helpers';
 import { actionsMaps } from './actions';
-import { User } from './user';
-const models = require('../models');
-
-const { Case, PostSurvey } = models;
 
 /**
  * Given a conditionsState and a condition, returns true if the condition is true in the conditionsState


### PR DESCRIPTION
## Description

Just a quick PR to demonstrate that CanCan really isn't doing anything for us and could easily be removed, benefits being:

* Simplified permission code
* Reduced dependency sprawl
* We would no longer need to worry about having to have classes for our data types to keep cancan happy

Note this PR JUST removes cancan, the remedial work to remove the Case model etc isn't included

### Checklist
- [X] Corresponding issue has been opened
- 
### Related Issues
Fixes CHI-1074

### Verification steps

Automated service tests don't cover permissions (yet!) so some manual verification in postman would be advisable
