### PR TITLE
Dependabot config to disable automatic PRs - HRM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/hrm-service/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-name: "*"
+        dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+


### PR DESCRIPTION
Primary reviewer: @stephenhand 
Cc: @johnhbenetech 

## Description
The HRM equivalent of https://github.com/techmatters/flex-plugins/pull/762. Disables automated PRs from dependabot. We will track these using the dependabot reports instead.

