### PR TITLE
[Bug fix] Search date range not filtering accurately for Cases

### DIFF
--- a/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-service/service-tests/case-search.test.ts
@@ -334,7 +334,7 @@ describe('/cases route', () => {
         const subRoute = `${route}/search`;
         const searchTestRunStart = new Date().toISOString();
 
-        beforeEach(async () => {
+        beforeAll(async () => {
           createdCase1 = await caseApi.createCase(withHouseholds(case1), accountSid, workerSid);
           createdCase2 = await caseApi.createCase(case1, accountSid, workerSid);
           createdCase3 = await caseApi.createCase(withPerpetrators(case1), accountSid, workerSid);
@@ -347,7 +347,7 @@ describe('/cases route', () => {
           createdCase2 = await caseApi.getCase(createdCase2.id, accountSid);
         });
 
-        afterEach(async () => {
+        afterAll(async () => {
           await createdContact.destroy();
           await caseDb.deleteById(createdCase1.id, accountSid);
           await caseDb.deleteById(createdCase2.id, accountSid);
@@ -386,7 +386,7 @@ describe('/cases route', () => {
             body: {
               helpline: 'helpline',
               dateFrom: searchTestRunStart,
-              dateTo: add(new Date(), { hours: 1 }), // flaky test as new Date() is bound at object creation time, which occurs before test execution. Adding 1 hour should be enough offset
+              dateTo: add(new Date(), { hours: 1 }).toISOString(), // flaky test as new Date() is bound at object creation time, which occurs before test execution. Adding 1 hour should be enough offset
             },
           },
         ]).test('$description', async ({ body }) => {

--- a/hrm-service/src/case/case-data-access.ts
+++ b/hrm-service/src/case/case-data-access.ts
@@ -9,6 +9,7 @@ import { caseSectionUpsertSql, deleteMissingCaseSectionsSql } from './sql/case-s
 import { DELETE_BY_ID } from './sql/case-delete-sql';
 import { selectSingleCaseByIdSql } from './sql/case-get-sql';
 import { Contact } from '../contact/contact-data-access';
+import { SearchParameters } from '../search';
 
 export type CaseRecordCommon = {
   info: any;
@@ -64,12 +65,7 @@ export type CaseListConfiguration = {
   limit?: number
 };
 
-export type CaseSearchCriteria = {
-  phoneNumber?: string,
-  contactNumber?: string,
-  firstName?: string,
-  lastName?: string,
-};
+type CaseSearchCriteria = Pick<SearchParameters, 'firstName' | 'lastName' | 'phoneNumber' | 'contactNumber' | 'dateFrom' | 'dateTo'>;
 
 export const enum DateExistsCondition {
   MUST_EXIST = 'MUST_EXIST',
@@ -163,7 +159,7 @@ export const getById = async (
 
 export const search = async (
   listConfiguration: CaseListConfiguration,
-  accountSid,
+  accountSid: string,
   searchCriteria: CaseSearchCriteria = {},
   filters: CaseListFilters = {},
 ): Promise<{ cases: readonly CaseRecord[]; count: number }> => {
@@ -179,6 +175,8 @@ export const search = async (
       lastName: searchCriteria.lastName ? `%${searchCriteria.lastName}%` : null,
       phoneNumber: searchCriteria.phoneNumber ? `%${searchCriteria.phoneNumber.replace(/[\D]/gi, '')}%` : null,
       contactNumber: searchCriteria.contactNumber || null,
+      dateFrom: searchCriteria.dateFrom || null,
+      dateTo: searchCriteria.dateTo || null,
       limit: limit,
       offset: offset,
     };

--- a/hrm-service/src/case/case.ts
+++ b/hrm-service/src/case/case.ts
@@ -9,12 +9,12 @@ import {
   CaseListConfiguration,
   CaseListFilters,
   CaseRecordCommon,
-  CaseSearchCriteria,
   CaseSectionRecord,
   NewCaseRecord,
 } from './case-data-access';
 import { randomUUID } from 'crypto';
 import { Contact } from '../contact/contact-data-access';
+import { SearchParameters } from '../search';
 
 type CaseInfoSection = {
   id: string;
@@ -317,18 +317,14 @@ export const getCase = async (id: number, accountSid: string): Promise<Case | un
   return;
 };
 
-export type SearchParameters = CaseSearchCriteria & {
+export type CaseSearchParameters = SearchParameters & {
   filters?: CaseListFilters;
-} & {
-  helpline?: string;
-  counselor?: string;
-  closedCases?: boolean;
 };
 
 export const searchCases = async (
-  accountSid,
+  accountSid: string,
   listConfiguration: CaseListConfiguration = {},
-  search: SearchParameters = {},
+  search: CaseSearchParameters = {},
 ): Promise<{ cases: readonly Case[]; count: number }> => {
   const { filters, helpline, counselor, closedCases, ...searchCriteria } = search;
   const caseFilters = filters ?? {};

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -219,7 +219,7 @@ const SEARCH_WHERE_CLAUSE = `(
       $<dateFrom> IS NULL OR cases."createdAt" >= $<dateFrom>
     )
     AND (
-      $<dateTo> IS NULL OR cases."createdAt" >= $<dateTo>
+      $<dateTo> IS NULL OR cases."createdAt" <= $<dateTo>
     )`;
 
 const selectCasesUnorderedSql = (whereClause: string, havingClause: string = '') =>

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -214,6 +214,12 @@ const SEARCH_WHERE_CLAUSE = `(
       EXISTS (
         SELECT 1 FROM "Contacts" c WHERE c."caseId" = cases.id AND c."accountSid" = cases."accountSid" AND c.number = $<contactNumber>
       )
+    )
+    AND (
+      $<dateFrom> IS NULL OR cases."createdAt" >= $<dateFrom>
+    )
+    AND (
+      $<dateTo> IS NULL OR cases."createdAt" >= $<dateTo>
     )`;
 
 const selectCasesUnorderedSql = (whereClause: string, havingClause: string = '') =>

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -5,6 +5,7 @@ import { endOfDay, parseISO, startOfDay } from 'date-fns';
 import { selectSingleContactByIdSql, selectSingleContactByTaskId } from './sql/contact-get-sql';
 import { insertContactSql, NewContactRecord } from './sql/contact-insert-sql';
 import { PersonInformation } from './contact-json';
+import { SearchParameters } from '../search';
 
 type ExistingContactRecord = {
   id: number;
@@ -14,18 +15,6 @@ type ExistingContactRecord = {
 
 export type Contact = ExistingContactRecord & {
   csamReports: any[];
-};
-
-export type SearchParameters = {
-  helpline?: string;
-  firstName?: string;
-  lastName?: string;
-  counselor?: string;
-  phoneNumber?: string;
-  dateFrom?: string;
-  dateTo?: string;
-  contactNumber?: string;
-  onlyDataContacts: boolean;
 };
 
 /**

--- a/hrm-service/src/contact/contact.ts
+++ b/hrm-service/src/contact/contact.ts
@@ -1,14 +1,8 @@
-import {
-  connectToCase,
-  Contact,
-  create,
-  patch,
-  search,
-  SearchParameters,
-} from './contact-data-access';
+import { connectToCase, Contact, create, patch, search } from './contact-data-access';
 import { ContactRawJson } from './contact-json';
 import { retrieveCategories, getPaginationElements } from '../controllers/helpers';
 import { NewContactRecord } from './sql/contact-insert-sql';
+import { SearchParameters } from '../search';
 
 export type PatchPayload = {
   rawJson: Partial<

--- a/hrm-service/src/search.ts
+++ b/hrm-service/src/search.ts
@@ -1,0 +1,15 @@
+/**
+ * Type that describes the payload sent when performing a search operation (contacts & cases)
+ */
+export type SearchParameters = {
+  helpline?: string;
+  firstName?: string;
+  lastName?: string;
+  counselor?: string;
+  phoneNumber?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  contactNumber?: string;
+  onlyDataContacts?: boolean;
+  closedCases?: boolean;
+};

--- a/hrm-service/unit-tests/case/case-data-access.test.ts
+++ b/hrm-service/unit-tests/case/case-data-access.test.ts
@@ -206,11 +206,59 @@ describe('search', () => {
         expectedDbParameters: { limit: 100, offset: 25 },
         expectedInSql: ['"id" DESC', '"childName" DESC NULLS LAST'],
       },
+      {
+        description: 'should pass null query values when CaseSearchCriteria is empty',
+        listConfig: {
+          limit: 100,
+          offset: 25,
+          sortBy: OrderByColumns.CHILD_NAME,
+        },
+        searchCriteria: {},
+        expectedDbParameters: {
+          limit: 100,
+          offset: 25,
+          firstName: null,
+          lastName: null,
+          phoneNumber: null,
+          contactNumber: null,
+          dateFrom: null,
+          dateTo: null,
+        },
+        expectedInSql: ['"id" DESC', '"childName" DESC NULLS LAST'],
+      },
+      {
+        description: 'should pass appropriate query values when CaseSearchCriteria is provided',
+        listConfig: {
+          limit: 100,
+          offset: 25,
+          sortBy: OrderByColumns.CHILD_NAME,
+        },
+        searchCriteria: {
+          firstName: 'firstName',
+          lastName: 'lastName',
+          phoneNumber: '123',
+          contactNumber: 'contactNumber',
+          dateFrom: '2022-06-20',
+          dateTo: '2022-06-21',
+        },
+        expectedDbParameters: {
+          limit: 100,
+          offset: 25,
+          firstName: '%firstName%',
+          lastName: '%lastName%',
+          phoneNumber: '%123%',
+          contactNumber: 'contactNumber',
+          dateFrom: '2022-06-20',
+          dateTo: '2022-06-21',
+        },
+        expectedInSql: ['"id" DESC', '"childName" DESC NULLS LAST'],
+      },
     ]).test(
       '$description',
       async ({
         listConfig = {},
         filters = {},
+        searchCriteria = {},
         expectedDbParameters,
         expectedInSql = [],
         notExpectedInSql = [],
@@ -220,7 +268,7 @@ describe('search', () => {
           { ...createMockCaseRecord({ id: 1 }), totalCount: 1337 },
         ];
         const anySpy = jest.spyOn(conn, 'any').mockResolvedValue(dbResult);
-        const result = await caseDb.search(listConfig, accountSid, {}, filters);
+        const result = await caseDb.search(listConfig, accountSid, searchCriteria, filters);
         expect(anySpy).toHaveBeenCalledWith(
           expect.stringContaining('Cases'),
           expect.objectContaining({ ...expectedDbParameters, accountSid }),


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
This PR fixes the bug described in the ticket linked below, where "the Search date range filter is not pulling the correct cases in the search result based on the filter applied". The issue was that the date filters were not being used in the SQL statement for case search.

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1203)
- [x] New tests added

### Verification steps
The service tests added in this PR should suffice to see that the filters are working as expected, but you can also test like:
- Start local server.
- Expose it via ngrok, and point to it from Flex.
- Create 3 new cases (or use existing ones).
- Test search functionality works as expected with the date ranges provided on each call (results will depend on what's on the DB).