### PR TITLE
CHI-1312: Search can handle empty string followUpDate in case records.

### DIFF
--- a/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-service/service-tests/case-search.test.ts
@@ -86,7 +86,7 @@ const insertSampleCases = async ({
       delete toCreate.updatedAt;
     }
     const followUpDate = followUpDateGenerator(i);
-    if (followUpDate) {
+    if (typeof followUpDate !== 'undefined') {
       toCreate.info = toCreate.info ?? {};
       toCreate.info.followUpDate = followUpDate;
     } else if (toCreate.info) {
@@ -726,31 +726,6 @@ describe('/cases route', () => {
           },
           {
             description:
-              'should only include cases with followUpDate after the followUpDate.from filter if specified',
-            searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
-            body: {
-              filters: {
-                followUpDate: {
-                  from: add(baselineDate, { days: 4, hours: 12 }).toISOString(),
-                },
-              },
-            },
-            sampleConfig: <InsertSampleCaseSettings>{
-              ...SEARCHABLE_CONTACT_PHONE_NUMBER_SAMPLE_CONFIG,
-              followUpDateGenerator: idx => addDays(baselineDate, idx).toISOString(),
-            },
-            expectedCasesAndContacts: sampleCasesAndContacts =>
-              sampleCasesAndContacts
-                .filter(
-                  ccc =>
-                    new Date(ccc.case.info.followUpDate) >
-                    add(baselineDate, { days: 4, hours: 12 }),
-                )
-                .sort((ccc1, ccc2) => ccc2.case.id - ccc1.case.id),
-            expectedTotalCount: 5,
-          },
-          {
-            description:
               'should only include cases with followUpDate between the followUpDate.from and the followUpDate.to filter if both are specified',
             searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
             body: {
@@ -779,6 +754,36 @@ describe('/cases route', () => {
           },
           {
             description:
+              'should exclude cases with followUpDate set as empty string if the followUpDate.from and the followUpDate.to filter if both are specified',
+            searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
+            body: {
+              filters: {
+                followUpDate: {
+                  from: add(baselineDate, { days: 2, hours: 12 }).toISOString(),
+                  to: add(baselineDate, { days: 6, hours: 12 }).toISOString(),
+                },
+              },
+            },
+            sampleConfig: <InsertSampleCaseSettings>{
+              ...SEARCHABLE_CONTACT_PHONE_NUMBER_SAMPLE_CONFIG,
+              followUpDateGenerator: idx =>
+                idx % 2 ? '' : addDays(baselineDate, idx).toISOString(),
+            },
+            expectedCasesAndContacts: sampleCasesAndContacts =>
+              sampleCasesAndContacts
+                .filter(
+                  ccc =>
+                    ccc.case.info.followUpDate &&
+                    new Date(ccc.case.info.followUpDate) >
+                      add(baselineDate, { days: 2, hours: 12 }) &&
+                    new Date(ccc.case.info.followUpDate) <
+                      add(baselineDate, { days: 6, hours: 12 }),
+                )
+                .sort((ccc1, ccc2) => ccc2.case.id - ccc1.case.id),
+            expectedTotalCount: 2,
+          },
+          {
+            description:
               'should only include cases without followUpDate set in followUpDate.exists: MUST_NOT_EXIST filter specified',
             searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
             body: {
@@ -792,6 +797,28 @@ describe('/cases route', () => {
               ...SEARCHABLE_CONTACT_PHONE_NUMBER_SAMPLE_CONFIG,
               followUpDateGenerator: idx =>
                 idx % 2 === 1 ? addDays(baselineDate, idx).toISOString() : undefined,
+            },
+            expectedCasesAndContacts: sampleCasesAndContacts =>
+              sampleCasesAndContacts
+                .filter(ccc => !ccc.case.info.followUpDate)
+                .sort((ccc1, ccc2) => ccc2.case.id - ccc1.case.id),
+            expectedTotalCount: 5,
+          },
+          {
+            description:
+              'should count an empty string value as not existing followUpDate.exists: MUST_NOT_EXIST filter specified',
+            searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
+            body: {
+              filters: {
+                followUpDate: {
+                  exists: DateExistsCondition.MUST_NOT_EXIST,
+                },
+              },
+            },
+            sampleConfig: <InsertSampleCaseSettings>{
+              ...SEARCHABLE_CONTACT_PHONE_NUMBER_SAMPLE_CONFIG,
+              followUpDateGenerator: idx =>
+                idx % 2 === 1 ? addDays(baselineDate, idx).toISOString() : '',
             },
             expectedCasesAndContacts: sampleCasesAndContacts =>
               sampleCasesAndContacts

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -59,7 +59,7 @@ FROM (
 const enum FilterableDateField {
   CREATED_AT = 'cases."createdAt"::TIMESTAMP WITH TIME ZONE',
   UPDATED_AT = 'cases."updatedAt"::TIMESTAMP WITH TIME ZONE',
-  FOLLOW_UP_DATE = `CAST(cases."info"->>'followUpDate' AS TIMESTAMP WITH TIME ZONE)`,
+  FOLLOW_UP_DATE = `CAST(NULLIF(cases."info"->>'followUpDate', '') AS TIMESTAMP WITH TIME ZONE)`,
 }
 
 const dateFilterCondition = (


### PR DESCRIPTION
Primary Reviewer @murilovmachado

## Description

* Add defensive SQL code to treat empty strings in followUpDate as nulls for case searches

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added


### Related Issues
Fixes CHI-1312

### Verification steps

Run a variety of 'Follow Up Date' based searches on an account with followUpDate set to an empty string in one or more case records
