### PR TITLE
CHI-1315: Category filter on case search handles apostrophes

### DIFF
--- a/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-service/service-tests/case-search.test.ts
@@ -1020,6 +1020,42 @@ describe('/cases route', () => {
                 ),
             expectedTotalCount: 7,
           },
+          {
+            description: 'should allow any characters in categories and subcategories',
+            searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
+            body: {
+              filters: <CaseListFilters>{
+                categories: [
+                  { category: 'a', subcategory: "a'b\n,.!\t:{}" },
+                  { category: "'b\n\r,.!\t:{}", subcategory: 'ba' },
+                  { category: 'b', subcategory: 'bb' },
+                ],
+              },
+            },
+            sampleConfig: <InsertSampleCaseSettings>{
+              ...SEARCHABLE_CONTACT_PHONE_NUMBER_SAMPLE_CONFIG,
+              categoriesGenerator: idx => ({
+                a: {
+                  aa: true,
+                  "a'b\n,.!\t:{}": !(idx % 2),
+                },
+                "'b\n\r,.!	:{}": {
+                  ba: !(idx % 3),
+                  bb: false,
+                },
+              }),
+            },
+            expectedCasesAndContacts: sampleCasesAndContacts =>
+              sampleCasesAndContacts
+                .sort((ccc1, ccc2) => ccc2.case.id - ccc1.case.id)
+                .filter(
+                  ccc =>
+                    ccc.contact.rawJson.caseInformation.categories.a["a'b\n,.!\t:{}"] ||
+                    ccc.contact.rawJson.caseInformation.categories["'b\n\r,.!	:{}"].ba ||
+                    ccc.contact.rawJson.caseInformation.categories["'b\n\r,.!	:{}"].bb,
+                ),
+            expectedTotalCount: 7,
+          },
         ]).test(
           '$description',
           async ({

--- a/hrm-service/service-tests/case-validation.ts
+++ b/hrm-service/service-tests/case-validation.ts
@@ -1,5 +1,7 @@
 import { db, pgp } from '../src/connection-pool';
 import { WELL_KNOWN_CASE_SECTION_NAMES } from '../src/case/case';
+import { NewContactRecord } from '../src/contact/sql/contact-insert-sql';
+import { ContactRawJson } from '../src/contact/contact-json';
 
 declare global {
   namespace jest {
@@ -129,12 +131,17 @@ export const validateCaseListResponse = (actual, expectedCaseAndContactModels, c
         createdAt: expectedCaseModel.createdAt.toISOString(),
         updatedAt: expectedCaseModel.updatedAt.toISOString(),
       });
+
       expect(actual.body.cases[index].connectedContacts).toStrictEqual([
         expect.objectContaining({
-          ...expectedContactModel.dataValues,
+          ...expectedContactModel,
           csamReports: [],
-          createdAt: expect.toParseAsDate(expectedContactModel.dataValues.createdAt),
-          updatedAt: expect.toParseAsDate(expectedContactModel.dataValues.updatedAt),
+          timeOfContact: expect.toParseAsDate(expectedContactModel.timeOfContact),
+          createdAt: expect.toParseAsDate(expectedContactModel.createdAt),
+          updatedAt: expect.toParseAsDate(expectedContactModel.updatedAt),
+          rawJson: {
+            ...expectedContactModel.rawJson,
+          },
         }),
       ]);
     },
@@ -146,14 +153,14 @@ export const validateSingleCaseResponse = (actual, expectedCaseModel, expectedCo
 };
 
 export const fillNameAndPhone = (
-  contact,
+  contact: NewContactRecord & { form?: ContactRawJson },
   name = {
     firstName: 'Maria',
     lastName: 'Silva',
   },
   number = '+1-202-555-0184',
-) => {
-  const modifiedContact = {
+): NewContactRecord => {
+  const modifiedContact: NewContactRecord = {
     ...contact,
     rawJson: {
       ...contact.form,
@@ -165,7 +172,7 @@ export const fillNameAndPhone = (
     number,
   };
 
-  delete modifiedContact.form;
+  delete (<any>modifiedContact).form;
 
   return modifiedContact;
 };

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -136,7 +136,6 @@ const filterSql = ({
     ].filter(sql => sql),
   );
   if (categories && categories.length) {
-    //filterSqlClauses.push(categoriesCondition(categories));
     filterSqlClauses.push(bulkCategoriesCondition(categories));
   }
   if (!includeOrphans) {

--- a/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-service/src/case/sql/case-search-sql.ts
@@ -89,7 +89,7 @@ const CATEGORIES_FILTER_SQL = `EXISTS (
 SELECT 1 FROM 
 (
     SELECT categories.key AS category, subcategories.key AS subcategory 
-    FROM "Contacts" c,jsonb_each(c."rawJson"->'caseInformation'->'categories') categories, jsonb_each_text(categories.value) AS subcategories 
+    FROM "Contacts" c, jsonb_each(c."rawJson"->'caseInformation'->'categories') categories, jsonb_each_text(categories.value) AS subcategories 
     WHERE c."caseId" = cases.id AND c."accountSid" = cases."accountSid" AND subcategories.value = 'true'
 ) AS availableCategories
 INNER JOIN jsonb_to_recordset($<categories:json>) AS requiredCategories(category text, subcategory text) 

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -125,7 +125,7 @@ export const create = async (
   accountSid: string,
   newContact: NewContactRecord,
   csamReportIds: number[],
-): Promise<Contact | undefined> => {
+): Promise<Contact> => {
   return db.tx(async connection => {
     if (newContact.taskId) {
       const existingContact: Contact = await connection.oneOrNone<Contact>(

--- a/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-service/src/contact/contact-routes-v0.ts
@@ -2,7 +2,7 @@ import { SafeRouter, publicEndpoint, actionsMaps } from '../permissions';
 import createError from 'http-errors';
 import { patchContact, connectContactToCase, searchContacts, createContact } from './contact';
 import { asyncHandler } from '../utils';
-import { getById } from '../contact/contact-data-access';
+import { getById } from './contact-data-access';
 // eslint-disable-next-line prettier/prettier
 import type { Request, Response, NextFunction } from 'express';
 


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description

* Adds some service test coverage for category filtering on the case search endpoint
* Makes the SQL used for category filters accept any character in category / subcategory names & no longer vulnerable to SQL injection
* Refactors the SQL to filter on categories to be less verbose in cases where large numbers of categories are specified

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
Fixes CHI-1315

### Verification steps

* Deploy this build to staging
* Log in to the UK staging account
* Filter the Case List on one of the subcategoies with an apostrophe in its name (some can be found under the 'Location of Images' top level category)