### PR TITLE
CHI-1331: resourcedb poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ typings/
 
 # TSC output
 **/dist/
+
+/resources-poc/resource-json/**

--- a/resources-poc/mongo/docker/docker-compose.yaml
+++ b/resources-poc/mongo/docker/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.9'
+
+services:
+  mongodb:
+    image: mongo:5.0
+    ports:
+      - 27017:27017
+    volumes:
+      - resource-poc_mongo_volume:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=resource-poc
+      - MONGO_INITDB_ROOT_PASSWORD=p0c
+volumes:
+  resource-poc_mongo_volume: { }

--- a/resources-poc/postgres/queries.sql
+++ b/resources-poc/postgres/queries.sql
@@ -1,0 +1,86 @@
+--Relational reference category update example - <300ms
+UPDATE resource_relational."ResourceReferenceAttributeValues" SET "value" = 'node-updated-1' || substring("value" from char_length('reference-node-1'))
+WHERE "accountSid" = 'ACCOUNT_5' AND left("value", char_length('reference-node-1')) = 'reference-node-1';
+
+--Relational inline category update example - can take 6-8 seconds to run against a 1000000 resource DB split evenly across 10 helplines
+--Reduced to ~500ms with an index on values
+UPDATE resource_relational."ResourceStringAttributes" SET "value" = 'node-updated-1' || substring("value" from char_length('inline-node-1'))
+WHERE "accountSid" = 'ACCOUNT_5' AND left("value", char_length('inline-node-1')) = 'inline-node-1';
+
+
+--Document reference category update example - can take 6-8 seconds to run against a 1000000 resource DB split evenly across 10 helplines
+UPDATE resource_document."Resources"
+SET "attributes" = res."attributes" || jsonb_build_object('inlineCategories', COALESCE(mc.inlineCategory,'[]')) AS newValue,
+							  res.*
+							  FROM resource_document."Resources" AS res
+INNER JOIN LATERAL (
+	SELECT jsonb_agg(
+		CASE WHEN (left(value, char_length('reference-node-1')) = 'reference-node-1') THEN 'node-updated-1' || substring(value from char_length('inline-node-1')+1) ELSE value END
+	) AS inlineCategory FROM
+	jsonb_array_elements_text(res."attributes"->'inlineCategories')
+	AS matchingCategories
+
+) AS mc ON true
+WHERE "accountSid" = 'ACCOUNT_5' AND EXISTS(
+	select
+    from jsonb_array_elements_text(res."attributes"->'inlineCategories')
+    WHERE left(value, char_length('inline-node-1')) = 'inline-node-1'
+);
+UPDATE resource_relational."ResourceReferenceAttributeValues" SET "value" = 'node-updated-1' || substring("value" from char_length('reference-node-1'))
+  WHERE "accountSid" = 'ACCOUNT_5' AND left("value", char_length('reference-node-1')) = 'reference-node-1';
+
+--Document inline category update example - can take 6-8 seconds to run against a 1000000 resource DB split evenly across 10 helplines
+UPDATE resource_document."Resources"
+SET "attributes" = res."attributes" || jsonb_build_object('referenceCategories', COALESCE(mc.inlineCategory,'[]')) AS newValue,
+							  res.*
+							  FROM resource_document."Resources" AS res
+INNER JOIN LATERAL (
+	SELECT jsonb_agg(
+		CASE WHEN (left(value, char_length('inline-node-1')) = 'inline-node-1') THEN 'node-updated-1' || substring(value from char_length('inline-node-1')+1) ELSE value END
+	) AS inlineCategory FROM
+	jsonb_array_elements_text(res."attributes"->'inlineCategories')
+	AS matchingCategories
+
+) AS mc ON true
+WHERE "accountSid" = 'ACCOUNT_5' AND EXISTS(
+	select
+    from jsonb_array_elements_text(res."attributes"->'inlineCategories')
+    WHERE left(value, char_length('inline-node-1')) = 'inline-node-1'
+);
+
+
+
+-- Relational full document as sets (UNION could be replaced by a batch of separate selects)
+-- Would need application side processing to produce a doc for an API and would need application side mapping if multiple resources were retrieved
+WITH res AS (
+    SELECT * as "attributes" FROM "Resources" WHERE r."name" = 'Test Resource 1000'
+)
+SELECT "resourceId", "accountSid", "key", "value"
+	FROM "ResourceStringAttributes"
+	WHERE res."id" = "resourceId" AND res."accountSid" = "accountSid"
+UNION ALL
+SELECT rra."resourceId", rra."accountSid", rrav."key", rrav."value"
+	FROM "ResourceReferenceAttributes" rra
+	LEFT JOIN "ResourceReferenceAttributeValues" rrav ON rra."referenceId" = rrav."id" AND rra."accountSid" = rrav."accountSid"
+	WHERE r."id" = rra."resourceId" AND r."accountSid" = rra."accountSid"
+
+
+-- Relational full document as JSON
+SELECT r.*, jsonb_object_agg(refs.key, refs.values) as "attributes" FROM "Resources" r
+LEFT JOIN LATERAL (
+	SELECT "resourceId", "accountSid", "key", jsonb_agg("ResourceStringAttributes"."value") AS values
+	FROM "ResourceStringAttributes"
+	WHERE r."id" = "resourceId" AND r."accountSid" = "accountSid"
+	GROUP BY "accountSid", "resourceId", "key"
+UNION ALL
+	SELECT rra."resourceId", rra."accountSid", rrav."key", jsonb_agg(rrav."value") AS values
+	FROM "ResourceReferenceAttributes" rra
+	LEFT JOIN "ResourceReferenceAttributeValues" rrav ON rra."referenceId" = rrav."id" AND rra."accountSid" = rrav."accountSid"
+	WHERE r."id" = rra."resourceId" AND r."accountSid" = rra."accountSid"
+	GROUP BY rra."accountSid", rra."resourceId", rrav."key"
+) refs ON true
+WHERE r."name" = 'Test Resource 1000'
+GROUP BY r."id", r."name", r."accountSid"
+
+-- Relational full document as JSON
+SELECT r.* WHERE r."name" = 'Test Resource 1000'

--- a/resources-poc/postgres/schemas/document.sql
+++ b/resources-poc/postgres/schemas/document.sql
@@ -1,0 +1,46 @@
+CREATE USER resource_document;
+
+-- SCHEMA: resource_document
+
+-- DROP SCHEMA IF EXISTS resource_document ;
+
+CREATE SCHEMA IF NOT EXISTS resource_document
+    AUTHORIZATION resource_document;
+
+-- Table: resource_document.Resources
+
+-- DROP TABLE IF EXISTS resource_document."Resources";
+
+CREATE TABLE IF NOT EXISTS resource_document."Resources"
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    name text COLLATE pg_catalog."default" NOT NULL,
+    attributes jsonb NOT NULL,
+    CONSTRAINT "Resources_pkey" PRIMARY KEY (id, "accountSid")
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_document."Resources"
+    OWNER to resource_document;
+
+-- Table: resource_document.ResourceReferenceAttributeValues
+
+-- DROP TABLE IF EXISTS resource_document."ResourceReferenceAttributeValues";
+
+CREATE TABLE IF NOT EXISTS resource_document."ResourceReferenceAttributeValues"
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    key text COLLATE pg_catalog."default" NOT NULL,
+    value text COLLATE pg_catalog."default" NOT NULL,
+    "valueLabel" text COLLATE pg_catalog."default",
+    language text COLLATE pg_catalog."default",
+    CONSTRAINT "ResourceReferenceAttributeValues_pkey" PRIMARY KEY (id, "accountSid")
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_document."ResourceReferenceAttributeValues"
+    OWNER to resource_document;

--- a/resources-poc/postgres/schemas/document.sql
+++ b/resources-poc/postgres/schemas/document.sql
@@ -44,3 +44,13 @@ TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS resource_document."ResourceReferenceAttributeValues"
     OWNER to resource_document;
+
+-- Index: ResourceReferenceAttributeValues_value_idx
+
+-- DROP INDEX IF EXISTS resource_relational."ResourceReferenceAttributeValues_value_idx";
+
+CREATE INDEX IF NOT EXISTS "ResourceReferenceAttributeValues_value_idx"
+    ON resource_relational."ResourceReferenceAttributeValues" USING btree
+    (value COLLATE pg_catalog."default" text_pattern_ops ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    INCLUDE("valueLabel", language)
+    TABLESPACE pg_default;

--- a/resources-poc/postgres/schemas/relational.sql
+++ b/resources-poc/postgres/schemas/relational.sql
@@ -1,0 +1,114 @@
+
+CREATE USER resource_relational;
+
+-- SCHEMA: resource_relational
+
+-- DROP SCHEMA IF EXISTS resource_relational ;
+
+CREATE SCHEMA IF NOT EXISTS resource_relational
+    AUTHORIZATION resource_relational;
+
+-- Table: resource_relational.ResourceReferenceAttributeValues
+
+-- DROP TABLE IF EXISTS resource_relational."ResourceReferenceAttributeValues";
+
+CREATE TABLE IF NOT EXISTS resource_relational."ResourceReferenceAttributeValues"
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    key text COLLATE pg_catalog."default" NOT NULL,
+    value text COLLATE pg_catalog."default" NOT NULL,
+    "valueLabel" text COLLATE pg_catalog."default",
+    language text COLLATE pg_catalog."default",
+    CONSTRAINT "ResourceReferenceAttributeValues_pkey" PRIMARY KEY (id, "accountSid")
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_relational."ResourceReferenceAttributeValues"
+    OWNER to resource_relational;
+
+-- Table: resource_relational.Resources
+
+-- DROP TABLE IF EXISTS resource_relational."Resources";
+
+CREATE TABLE IF NOT EXISTS resource_relational."Resources"
+(
+    id text COLLATE pg_catalog."default" NOT NULL,
+    name text COLLATE pg_catalog."default" NOT NULL,
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT "Resources_pkey" PRIMARY KEY (id, "accountSid")
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_relational."Resources"
+    OWNER to resource_relational;
+
+-- Table: resource_relational.ResourceStringAttributes
+
+-- DROP TABLE IF EXISTS resource_relational."ResourceStringAttributes";
+
+CREATE TABLE IF NOT EXISTS resource_relational."ResourceStringAttributes"
+(
+    "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+    key text COLLATE pg_catalog."default" NOT NULL,
+    value text COLLATE pg_catalog."default" NOT NULL,
+    "valueLabel" text COLLATE pg_catalog."default",
+    language text COLLATE pg_catalog."default",
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT "ResourceStringAttributes_pkey" PRIMARY KEY ("resourceId", key, value, "accountSid"),
+    CONSTRAINT "Resources_rsourceId_accountSid_fkey" FOREIGN KEY ("accountSid", "resourceId")
+        REFERENCES resource_relational."Resources" ("accountSid", id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_relational."ResourceStringAttributes"
+    OWNER to resource_relational;
+-- Index: fki_Resources_rsourceId_accountSid_fkey
+
+-- DROP INDEX IF EXISTS resource_relational."fki_Resources_rsourceId_accountSid_fkey";
+
+CREATE INDEX IF NOT EXISTS "fki_Resources_rsourceId_accountSid_fkey"
+    ON resource_relational."ResourceStringAttributes" USING btree
+    ("resourceId" COLLATE pg_catalog."default" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+-- Table: resource_relational.ResourceReferenceAttributes
+
+-- DROP TABLE IF EXISTS resource_relational."ResourceReferenceAttributes";
+
+CREATE TABLE IF NOT EXISTS resource_relational."ResourceReferenceAttributes"
+(
+    "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+    "referenceId" text COLLATE pg_catalog."default" NOT NULL,
+    "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT "ResourceReferenceAttributes_pkey" PRIMARY KEY ("resourceId", "referenceId", "accountSid"),
+    CONSTRAINT "ResourceReferenceAttributeValues_referenceId_accountSid_fkey" FOREIGN KEY ("accountSid", "referenceId")
+        REFERENCES resource_relational."ResourceReferenceAttributeValues" ("accountSid", id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID,
+    CONSTRAINT "Resources_rsourceId_accountSid_fkey" FOREIGN KEY ("accountSid", "resourceId")
+        REFERENCES resource_relational."Resources" ("accountSid", id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS resource_relational."ResourceReferenceAttributes"
+    OWNER to resource_relational;
+-- Index: fki_ResourceReferenceAttributeValues_referenceId_accountSid_fke
+
+-- DROP INDEX IF EXISTS resource_relational."fki_ResourceReferenceAttributeValues_referenceId_accountSid_fke";
+
+CREATE INDEX IF NOT EXISTS "fki_ResourceReferenceAttributeValues_referenceId_accountSid_fke"
+    ON resource_relational."ResourceReferenceAttributes" USING btree
+    ("referenceId" COLLATE pg_catalog."default" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/resources-poc/postgres/schemas/relational.sql
+++ b/resources-poc/postgres/schemas/relational.sql
@@ -112,3 +112,24 @@ CREATE INDEX IF NOT EXISTS "fki_ResourceReferenceAttributeValues_referenceId_acc
     ON resource_relational."ResourceReferenceAttributes" USING btree
     ("referenceId" COLLATE pg_catalog."default" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
     TABLESPACE pg_default;
+
+-- Index: ResourceStringAttributes_value_idx
+
+-- DROP INDEX IF EXISTS resource_relational."ResourceStringAttributes_value_idx";
+
+CREATE INDEX IF NOT EXISTS "ResourceStringAttributes_value_idx"
+    ON resource_relational."ResourceStringAttributes" USING btree
+    (value COLLATE pg_catalog."default" text_pattern_ops ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    INCLUDE("valueLabel", language)
+    TABLESPACE pg_default;
+
+
+-- Index: ResourceReferenceAttributeValues_value_idx
+
+-- DROP INDEX IF EXISTS resource_relational."ResourceReferenceAttributeValues_value_idx";
+
+CREATE INDEX IF NOT EXISTS "ResourceReferenceAttributeValues_value_idx"
+    ON resource_relational."ResourceReferenceAttributeValues" USING btree
+    (value COLLATE pg_catalog."default" text_pattern_ops ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    INCLUDE("valueLabel", language)
+    TABLESPACE pg_default;

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -2406,6 +2406,20 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.14",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
@@ -2997,6 +3011,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -3032,6 +3051,23 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.5",
         "picocolors": "^1.0.0"
+      }
+    },
+    "bson": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-writer": {
@@ -3205,6 +3241,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -3989,6 +4030,11 @@
         "os-tmpdir": "^1.0.1"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4046,6 +4092,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -4354,6 +4405,12 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4405,6 +4462,27 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.6"
+      }
+    },
+    "mongodb": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.0.tgz",
+      "integrity": "sha512-tJJEFJz7OQTQPZeVHZJIeSOjMRqc5eSyXTt86vSQENEErpkiG7279tM/GT5AVZ7TgXNh9HQxoa2ZkbrANz5GQw==",
+      "requires": {
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.0"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
     "ms": {
@@ -4763,8 +4841,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -4918,6 +4995,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4956,6 +5042,20 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4969,6 +5069,15 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
       }
     },
     "spex": {
@@ -5066,6 +5175,14 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
       }
     },
     "trim-right": {
@@ -5218,6 +5335,20 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,15 @@
     "build-then-import-conversation-postgres": "npm run build && node dist/import-conversation-postgres.js",
     "import-conversation-cloudsearch": "node dist/import-conversation-cloudsearch.js",
     "build-then-import-conversation-cloudsearch": "npm run build && node dist/import-conversation-cloudsearch.js",
-    "build-then-unzip-books": "npm run build && node dist/unzip-books.js"
+    "build-then-unzip-books": "npm run build && node dist/unzip-books.js",
+    "generate-resource-json": "node dist/generate-resource-json.js",
+    "build-then-generate-resource-json": "npm run build && node dist/generate-resource-json.js",
+    "import-resource-postgres-relational": "node dist/import-resource-postgres-relational.js",
+    "build-then-import-resource-postgres-relational": "npm run build && node dist/import-resource-postgres-relational.js",
+    "import-resource-postgres-document": "node dist/import-resource-postgres-document.js",
+    "build-then-import-resource-postgres-document": "npm run build && node dist/import-resource-postgres-document.js",
+    "import-resource-mongo": "node dist/import-resource-mongodb.js",
+    "build-then-import-resource-mongo": "npm run build && node dist/import-resource-mongodb.js"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",
@@ -45,6 +53,7 @@
     "axios": "^0.27.2",
     "date-fns": "^2.28.0",
     "delay": "^5.0.0",
+    "mongodb": "^4.9.0",
     "pg": "^8.7.3",
     "pg-promise": "^10.11.1",
     "uuid": "^8.3.2"

--- a/scripts/src/generate-resource-json.ts
+++ b/scripts/src/generate-resource-json.ts
@@ -1,0 +1,166 @@
+import { promises as fsPromises } from 'fs';
+import { randomUUID } from 'crypto';
+
+const CATEGORY_TREE_DEPTH = 5;
+const CATEGORY_TREE_CHILDREN_PER_NODE = 5;
+const MAX_CATEGORIES_PER_RESOURCE = 3;
+const MIN_CATEGORIES_PER_RESOURCE = 1;
+const RESOURCES_PER_FILE = 50000;
+const REFERENCES_PER_FILE = 20000;
+const ROOT_RESOURCE_DIRECTORY = '../resources-poc/resource-json';
+const ROOT_REFERENCE_DIRECTORY = '../resources-poc/reference-json';
+const ACCOUNT_SIDS = new Array(10).fill(0).map((_, idx) => `ACCOUNT_${idx}`);
+const CITIES = [
+  'Anderson Station',
+  'Ceres',
+  'Eros',
+  'Ganymede',
+  'Iapetus Station',
+  'Kelso Station',
+  'Medina Station',
+  'Oshima',
+  'Osiris Station',
+  'Phoebe',
+  'Prospero Station',
+  'Thoth Station',
+  'Tycho Station',
+];
+
+const randomBoolean = (truePercentage: number = 50): boolean =>
+  Math.random() < truePercentage / 100;
+
+const randomInteger = (min: number, max: number): number =>
+  Math.round(Math.random() * (max - min) + min);
+
+const randomItem = <T>(list: T[]) => list[randomInteger(0, list.length - 1)];
+
+const referenceMap: Record<string, Record<string, { key: string; id: string }>> = {};
+
+const generateRandomCategory = (nodePrefix: string): string =>
+  new Array(randomInteger(1, CATEGORY_TREE_DEPTH))
+    .fill(0)
+    .map(() => `${nodePrefix}-${randomInteger(0, CATEGORY_TREE_CHILDREN_PER_NODE)}`)
+    .join('/');
+
+const generateUniqueCategories = (nodePrefix: string): string[] => {
+  const categoryCount = randomInteger(MIN_CATEGORIES_PER_RESOURCE, MAX_CATEGORIES_PER_RESOURCE);
+  const categorySet: Set<string> = new Set();
+  while (categorySet.size < categoryCount) {
+    const category = generateRandomCategory(nodePrefix);
+    categorySet.add(category);
+  }
+  return [...categorySet];
+};
+
+const addOrLookupRef = async (
+  key: string,
+  value: string,
+  accountSid: string,
+): Promise<{ id: string; value: string }> => {
+  referenceMap[accountSid] = referenceMap[accountSid] ?? {};
+  referenceMap[accountSid][value] = referenceMap[accountSid][value] ?? { id: randomUUID(), key };
+  return { value, id: referenceMap[accountSid][value].id };
+};
+
+const writeReferences = async (): Promise<void> => {
+  const referenceList = Object.entries(referenceMap).flatMap(([accountSid, refs]) =>
+    Object.entries(refs).map(([value, { id, key }]) => ({
+      id,
+      value,
+      key,
+      accountSid,
+    })),
+  );
+  let counter = 0;
+  while (counter < referenceList.length) {
+    const end = Math.min(counter + REFERENCES_PER_FILE, referenceList.length);
+    const fileName = `${counter}-${end}.json`;
+    console.log('Writing reference file', fileName);
+    const referenceFile = await fsPromises.open(`${ROOT_REFERENCE_DIRECTORY}/${fileName}`, 'w+');
+    await referenceFile.writeFile(JSON.stringify(referenceList.slice(counter, end), null, 2));
+    counter += REFERENCES_PER_FILE;
+  }
+};
+
+async function main() {
+  const [, , ...args] = process.argv;
+
+  if (args.length !== 1) {
+    console.error(`[---------- ERROR ----------] Usage: scraper <number_of_files>`);
+    return;
+  }
+  console.log('Parsing arguments.');
+  const maxNumberOfResources = Number.parseInt(args[0]);
+  let resourcesWritten = 0;
+
+  async function writeResourceFile(targetResourceFile: string): Promise<void> {
+    console.log('Writing resource file', targetResourceFile);
+    let fileResources = 0;
+    const resourceFile = await fsPromises.open(targetResourceFile, 'w+');
+    try {
+      await resourceFile.writeFile('[');
+      while (fileResources < RESOURCES_PER_FILE && resourcesWritten < maxNumberOfResources) {
+        const accountSid = randomItem(ACCOUNT_SIDS);
+        const referenceCategories = await Promise.all(
+          generateUniqueCategories('reference-node').map(c =>
+            addOrLookupRef('referenceCategories', c, accountSid),
+          ),
+        );
+        try {
+          if (fileResources) {
+            await resourceFile.writeFile(',\r\n');
+          }
+          await resourceFile.writeFile(
+            JSON.stringify(
+              {
+                id: randomUUID(),
+                name: `Test Resource ${resourcesWritten}`,
+                accountSid,
+                attributes: {
+                  inlineCategories: generateUniqueCategories('inline-node'),
+                  referenceCategories,
+                  created: new Date().toISOString(),
+                  city: randomItem(CITIES),
+                  postalCode: randomInteger(10000, 99999).toString(),
+                  virtual: randomBoolean(),
+                },
+              },
+              null,
+              2,
+            ),
+          );
+          resourcesWritten++;
+          fileResources++;
+          console.log(
+            `Wrote ${resourcesWritten} / ${maxNumberOfResources} resources, ${fileResources} / ${RESOURCES_PER_FILE} in ${targetResourceFile}`,
+          );
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    } finally {
+      await resourceFile.writeFile(']');
+      await resourceFile.close();
+    }
+  }
+
+  try {
+    console.log('Starting writing resources.');
+    while (resourcesWritten < maxNumberOfResources) {
+      // eslint-disable-next-line @typescript-eslint/no-loop-func
+      const fileName = `${resourcesWritten}-${Math.min(
+        resourcesWritten + RESOURCES_PER_FILE,
+        maxNumberOfResources,
+      )}.json`;
+      await writeResourceFile(`${ROOT_RESOURCE_DIRECTORY}/${fileName}`);
+    }
+    console.log('Starting writing references.');
+    await writeReferences();
+  } catch (err) {
+    console.error(`Error running script:`, err);
+  }
+}
+
+main().catch(err => {
+  throw err;
+});

--- a/scripts/src/import-resource-mongodb.ts
+++ b/scripts/src/import-resource-mongodb.ts
@@ -1,0 +1,107 @@
+import { Reference, Resource } from './json-resource-types';
+import { importItems } from './resource-importer';
+import { MongoClient } from 'mongodb';
+
+const RESOURCES_DIRECTORY = '../resources-poc/resource-json';
+const REFERENCES_DIRECTORY = '../resources-poc/reference-json';
+const BATCH_SIZE = 5000;
+
+const DB_CONFIG = {
+  password: `p0c`,
+  username: 'resource-poc',
+  host: 'localhost',
+  port: 27017,
+};
+
+type ResourceDocument = Resource & { _id: string };
+type ReferenceDocument = Reference & { _id: string };
+
+const currentResourceBatch: ResourceDocument[] = [];
+const currentReferenceBatch: ReferenceDocument[] = [];
+
+let currentResourceBatchNo = 0,
+  currentReferenceBatchNo = 0;
+
+async function main() {
+  const mongo = new MongoClient(
+    `mongodb://${encodeURIComponent(DB_CONFIG.username)}:${encodeURIComponent(
+      DB_CONFIG.password,
+    )}@${DB_CONFIG.host}:${DB_CONFIG.port}/?maxPoolSize=20&w=majority`,
+  );
+
+  try {
+    const db = mongo.db('resource');
+
+    async function flushReferenceBatch() {
+      currentReferenceBatchNo++;
+      console.log(
+        `Inserting reference batch ${currentReferenceBatchNo} (docs ${currentReferenceBatchNo *
+          BATCH_SIZE} - ${(currentReferenceBatchNo + 1) * BATCH_SIZE})`,
+      );
+      await db.collection<ReferenceDocument>('references').insertMany(currentReferenceBatch);
+      currentReferenceBatch.length = 0;
+    }
+
+    async function insertReference(ref: Reference) {
+      currentReferenceBatch.push({ _id: `${ref.accountSid}/${ref.id}`, ...ref });
+      if (currentReferenceBatch.length > BATCH_SIZE) {
+        await flushReferenceBatch();
+      }
+    }
+
+    async function flushResourceBatch() {
+      currentResourceBatchNo++;
+      console.log(
+        `Inserting resource batch ${currentResourceBatchNo} (docs ${currentResourceBatchNo *
+          BATCH_SIZE} - ${(currentResourceBatchNo + 1) * BATCH_SIZE})`,
+      );
+      await db.collection<ResourceDocument>('resources').insertMany(currentResourceBatch);
+      currentResourceBatch.length = 0;
+    }
+
+    async function insertResource(resource: Resource) {
+      currentResourceBatch.push({ _id: `${resource.accountSid}/${resource.id}`, ...resource });
+      if (currentResourceBatch.length > BATCH_SIZE) {
+        await flushResourceBatch();
+      }
+    }
+    const [, , ...args] = process.argv;
+
+    console.log('Parsing arguments.');
+    if (args.length !== 1) {
+      console.error(
+        `Number of conversations not set, assuming entire contents of '${REFERENCES_DIRECTORY}' and '${RESOURCES_DIRECTORY}' is to be imported`,
+      );
+    }
+    const maxNumberOfResources = Number.parseInt(args.pop());
+
+    console.log('Dropping existing collections');
+    await db.dropCollection('resources');
+    await db.dropCollection('references');
+
+    console.log('Adding references');
+    await importItems(REFERENCES_DIRECTORY, insertReference);
+    await flushReferenceBatch();
+    console.log(`Wrote ${await db.collection('references').countDocuments()} reference documents`);
+    console.log('Adding resources');
+    await importItems(RESOURCES_DIRECTORY, insertResource, maxNumberOfResources);
+    await flushResourceBatch();
+    console.log(`Wrote ${await db.collection('resources').countDocuments()} resource documents`);
+    console.log('Creating resource indexes');
+    await db
+      .collection('resources')
+      .createIndexes([
+        { key: { 'attributes.inlineCategories': 1 } },
+        { key: { 'attributes.referenceCategories': 1 } },
+        { key: { accountSid: 1 } },
+      ]);
+    console.log('Creating reference indexes');
+    await db.collection('resources').createIndexes([{ key: { accountSid: 1, key: 1, value: 1 } }]);
+  } finally {
+    await mongo.close();
+  }
+}
+
+main().catch(err => {
+  throw err;
+});

--- a/scripts/src/import-resource-postgres-document.ts
+++ b/scripts/src/import-resource-postgres-document.ts
@@ -1,0 +1,56 @@
+import pgPromise from 'pg-promise';
+import { Reference, Resource } from './json-resource-types';
+import { importItems } from './resource-importer';
+
+const RESOURCES_DIRECTORY = '../resources-poc/resource-json';
+const REFERENCES_DIRECTORY = '../resources-poc/reference-json';
+const DB_CONFIG = {
+  password: null,
+  username: 'resource_document',
+  host: 'localhost',
+  port: 5432,
+  database: 'hrmdb',
+};
+
+const pgp = pgPromise({
+  schema: 'resource_document',
+});
+
+export const db = pgp(
+  `postgres://${encodeURIComponent(DB_CONFIG.username)}:${encodeURIComponent(DB_CONFIG.password)}@${
+    DB_CONFIG.host
+  }:${DB_CONFIG.port}/${encodeURIComponent(DB_CONFIG.database)}?&application_name=hrm-service`,
+);
+
+async function insertReference(ref: Reference) {
+  await db.tx(async connection => {
+    const referenceInsertSql = pgp.helpers.insert(ref, null, 'ResourceReferenceAttributeValues');
+    await connection.none(referenceInsertSql);
+  });
+}
+
+async function insertResource(resource: Resource) {
+  await db.tx(async connection => {
+    const resourceInsertSql = pgp.helpers.insert(resource, null, 'Resources');
+    await connection.none(resourceInsertSql);
+  });
+}
+
+async function main() {
+  const [, , ...args] = process.argv;
+
+  console.log('Parsing arguments.');
+  if (args.length !== 1) {
+    console.error(
+      `Number of conversations not set, assuming entire contents of '${REFERENCES_DIRECTORY}' and '${RESOURCES_DIRECTORY}' is to be imported`,
+    );
+  }
+  const maxNumberOfResources = Number.parseInt(args.pop());
+
+  await importItems(REFERENCES_DIRECTORY, insertReference);
+  await importItems(RESOURCES_DIRECTORY, insertResource, maxNumberOfResources);
+}
+
+main().catch(err => {
+  throw err;
+});

--- a/scripts/src/import-resource-postgres-relational.ts
+++ b/scripts/src/import-resource-postgres-relational.ts
@@ -1,0 +1,104 @@
+import pgPromise from 'pg-promise';
+import { Reference, Resource } from './json-resource-types';
+import { importItems } from './resource-importer';
+
+const RESOURCES_DIRECTORY = '../resources-poc/resource-json';
+const REFERENCES_DIRECTORY = '../resources-poc/reference-json';
+const DB_CONFIG = {
+  password: null,
+  username: 'resource_relational',
+  host: 'localhost',
+  port: 5432,
+  database: 'hrmdb',
+};
+
+const pgp = pgPromise({
+  schema: 'resource_relational',
+});
+
+export const db = pgp(
+  `postgres://${encodeURIComponent(DB_CONFIG.username)}:${encodeURIComponent(DB_CONFIG.password)}@${
+    DB_CONFIG.host
+  }:${DB_CONFIG.port}/${encodeURIComponent(DB_CONFIG.database)}?&application_name=hrm-service`,
+);
+
+async function insertReference(ref: Reference) {
+  await db.tx(async connection => {
+    const referenceInsertSql = pgp.helpers.insert(ref, null, 'ResourceReferenceAttributeValues');
+    await connection.none(referenceInsertSql);
+  });
+}
+
+async function insertResource(resource: Resource) {
+  await db.tx(async connection => {
+    const resourceInsertSql = pgp.helpers.insert(
+      {
+        id: resource.id,
+        name: resource.name,
+        accountSid: resource.accountSid,
+      },
+      null,
+      'Resources',
+    );
+    const inlineCategoryInserts = resource.attributes.inlineCategories.map(ic =>
+      pgp.helpers.insert(
+        {
+          resourceId: resource.id,
+          accountSid: resource.accountSid,
+          key: 'inlineCategories',
+          value: ic,
+        },
+        null,
+        'ResourceStringAttributes',
+      ),
+    );
+    const referenceCategoryInserts = resource.attributes.referenceCategories.map(rc =>
+      pgp.helpers.insert(
+        {
+          resourceId: resource.id,
+          accountSid: resource.accountSid,
+          referenceId: rc.id,
+        },
+        null,
+        'ResourceReferenceAttributes',
+      ),
+    );
+    const singleAttributeInserts = ['created', 'city', 'postalCode', 'virtual'].map(key =>
+      pgp.helpers.insert(
+        {
+          resourceId: resource.id,
+          accountSid: resource.accountSid,
+          key,
+          value: resource.attributes[key]?.toString(),
+        },
+        null,
+        'ResourceStringAttributes',
+      ),
+    );
+    await connection.batch([
+      connection.none(resourceInsertSql),
+      ...inlineCategoryInserts.map(sql => connection.none(sql)),
+      ...referenceCategoryInserts.map(sql => connection.none(sql)),
+      ...singleAttributeInserts.map(sql => connection.none(sql)),
+    ]);
+  });
+}
+
+async function main() {
+  const [, , ...args] = process.argv;
+
+  console.log('Parsing arguments.');
+  if (args.length !== 1) {
+    console.error(
+      `Number of conversations not set, assuming entire contents of '${REFERENCES_DIRECTORY}' and '${RESOURCES_DIRECTORY}' is to be imported`,
+    );
+  }
+  const maxNumberOfResources = Number.parseInt(args.pop());
+
+  await importItems(REFERENCES_DIRECTORY, insertReference);
+  await importItems(RESOURCES_DIRECTORY, insertResource, maxNumberOfResources);
+}
+
+main().catch(err => {
+  throw err;
+});

--- a/scripts/src/json-resource-types.ts
+++ b/scripts/src/json-resource-types.ts
@@ -1,0 +1,20 @@
+export type Resource = {
+  id: string;
+  name: string;
+  accountSid: string;
+  attributes: {
+    inlineCategories: string[];
+    referenceCategories: { id: string; value: string }[];
+    created: string;
+    city: string;
+    postalCode: string;
+    virtual: boolean;
+  };
+};
+
+export type Reference = {
+  id: string;
+  key: string;
+  value: string;
+  accountSid: string;
+};

--- a/scripts/src/resource-importer.ts
+++ b/scripts/src/resource-importer.ts
@@ -1,0 +1,29 @@
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+
+export async function importItems<T>(
+  directory: string,
+  writeAction: (item: T) => Promise<void>,
+  maxNumberOfItems?: number,
+) {
+  let processedConversations = 0;
+
+  console.log('Processing directory:', directory);
+  const directoryContents: string[] = await fsPromises.readdir(directory);
+
+  directoryLoop: for (const directoryItem of directoryContents) {
+    const itemPath = path.resolve(directory, directoryItem);
+    const info = await fsPromises.stat(itemPath);
+    if (info.isFile() && path.extname(itemPath) === '.json') {
+      console.log('Importing from file:', itemPath);
+      const fileItems: T[] = JSON.parse((await fsPromises.readFile(itemPath)).toString('utf8'));
+      for (const item of fileItems) {
+        await writeAction(item);
+
+        if (maxNumberOfItems && ++processedConversations >= maxNumberOfItems) {
+          break directoryLoop;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This  POC demonstrates 3 different options for the resource DB

1. A more traditional relational schema in Postgres, where attributes are stored in their own tables and looked up from a master resource record
2. A more document oriented schema in Postgres where most attributes are stored in a JSONB field, but has the notion of 'reference fields' marked with an ID, so they can be updated without update instructions needing to be generated for the entire database
3. A MongoDB database implementing a similar schema to the document oriented Postgres schema in option 2.

Scripts to generate & import JSON are in the `scripts` module, where the schema definitions & example queries are in the `resources-poc` module
