### PR TITLE
Chi 1267 qa release workflow

### DIFF
--- a/.github/workflows/hrm-ecs-ci-multiregion.yml
+++ b/.github/workflows/hrm-ecs-ci-multiregion.yml
@@ -66,7 +66,7 @@ on:
         type: string
 
 env:
-  AWS_DEFAULT_REGION: ${{ github.event.inputs.region }}
+  AWS_DEFAULT_REGION: ${{ inputs.region }}
   GITHUB_SHA: ${{ github.sha }}
 
 jobs:
@@ -153,3 +153,4 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
       if:
+        github.event.inputs.

--- a/.github/workflows/hrm-ecs-ci-multiregion.yml
+++ b/.github/workflows/hrm-ecs-ci-multiregion.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ github.event.inputs.region }}
+        aws-region: ${{ inputs.region }}
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -93,9 +93,9 @@ jobs:
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ${{ github.event.inputs.environment }}-hrm
+        ECR_REPOSITORY: ${{ inputs.environment }}-hrm
         IMAGE_TAG_1: latest
-        IMAGE_TAG_2: ${{ github.event.inputs.environment }}-hrm-${{ github.sha }}
+        IMAGE_TAG_2: ${{ inputs.environment }}-hrm-${{ github.sha }}
       run: |
         # Build a docker container and
         # push it to ECR so that it can
@@ -106,22 +106,22 @@ jobs:
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG_2"
 
     - name: Download current ECS task definition
-      run: aws ecs describe-task-definition --task-definition ${{ github.event.inputs.environment }}-hrm-task --query taskDefinition > task-definition.json
+      run: aws ecs describe-task-definition --task-definition ${{ inputs.environment }}-hrm-task --query taskDefinition > task-definition.json
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: task-definition.json
-        container-name: ${{ github.event.inputs.environment }}-hrm-container
+        container-name: ${{ inputs.environment }}-hrm-container
         image: ${{ steps.build-image.outputs.image }}
 
     - name: Deploy Amazon ECS task definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: ${{ github.event.inputs.environment }}-ecs-service
-        cluster: ${{ github.event.inputs.environment }}-ecs-cluster
+        service: ${{ inputs.environment }}-ecs-service
+        cluster: ${{ inputs.environment }}-ecs-cluster
         wait-for-service-stability: true
 
 
@@ -153,4 +153,4 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
       if:
-        github.event.inputs.
+        ${{ inputs.send-slack-message != 'false' }}

--- a/.github/workflows/hrm-ecs-ci-multiregion.yml
+++ b/.github/workflows/hrm-ecs-ci-multiregion.yml
@@ -149,7 +149,7 @@ jobs:
       uses: slackapi/slack-github-action@v1.14.0
       with:
         channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-        slack-message: "`[HRM]` Action ${{ github.workflow }} completed with SHA ${{ github.sha }} to region `${{ github.event.inputs.region }}`, environment `${{ github.event.inputs.environment }}` :rocket:."
+        slack-message: "`[HRM]` Action ${{ github.workflow }} completed with SHA ${{ github.sha }} to region `${{ inputs.region }}`, environment `${{ inputs.environment }}` :rocket:."
       env:
         SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
       if:

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ github.head_ref }}
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ github.ref }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@master
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@CHI-1267-qa_release_workflow
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -77,7 +77,7 @@ jobs:
           tag-prefix: ${{ inputs.tag-prefix }}
           tag-suffix: 'qa'
           title: ${{ inputs.title }}
-          repository: ${{ github.event.repository.name }}
+          repository: ${{ github.repository }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
         id: create_pre_release
 

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@CHI-1267-qa_release_workflow
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@master
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create pre release
         # TODO: remove branch tag
-        uses: techmatters/flex-plugins/.github/actions/generate-pre-release@gian_CHI-1262-p2
+        uses: techmatters/flex-plugins/.github/actions/generate-pre-release@master
         with:
           tag-prefix: ${{ inputs.tag-prefix }}
           tag-suffix: 'qa'

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -20,7 +20,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     with:
       send-slack-message: 'false'
-      region: 'us-east-1'
+      region: us-east-1
       environment: 'development'
   run-e2e-tests:
     needs: build-and-deploy

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@CHI-1267-qa_release_workflow
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@master
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -18,8 +18,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      E2E_DEV_ACCOUNT_SID: ${{ secrets.E2E_DEV_ACCOUNT_SID }}
-      E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
     with:
       send-slack-message: 'false'
       region: 'us-east-1'

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ GITHUB_REF }}
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ github.head_ref }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -82,30 +82,12 @@ jobs:
         id: create_pre_release
 
       ## TODO: Abstract all of this in a custom action reused across repos?
-      # Setup credentials to access AWS for parameters
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Slack aselo-deploys channel
+        uses: techmatters/flex-plugins/.github/actions/notify-deploys@master
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      # Set env vars to send slack message
-      - name: Set GITHUB_ACTIONS_SLACK_BOT_TOKEN
-        uses: "marvinpinto/action-inject-ssm-secrets@latest"
-        with:
-          ssm_parameter: "GITHUB_ACTIONS_SLACK_BOT_TOKEN"
-          env_variable_name: "GITHUB_ACTIONS_SLACK_BOT_TOKEN"
-      - name: Set ASELO_DEPLOYS_CHANNEL_ID
-        uses: "marvinpinto/action-inject-ssm-secrets@latest"
-        with:
-          ssm_parameter: "ASELO_DEPLOYS_CHANNEL_ID"
-          env_variable_name: "ASELO_DEPLOYS_CHANNEL_ID"
-      # Send Slack notifying success
-      - name: Slack Aselo channel
-        id: slack
-        uses: slackapi/slack-github-action@v1.14.0
-        with:
-          channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-          slack-message: "`[Serverless]` Action ${{ github.workflow }} completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_pre_release.outputs.automatic_releases_tag }} :rocket:."
+          slack-message: "`[HRM]` Action ${{ github.workflow }} completed with SHA ${{ github.sha }}. Release tag is ${{ steps.create_pre_release.outputs.generated-pre-release-tag }} :rocket:."
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -22,6 +22,8 @@ jobs:
       E2E_DEV_AUTH_TOKEN: ${{ secrets.E2E_DEV_AUTH_TOKEN }}
     with:
       send-slack-message: 'false'
+      region: 'us-east-1'
+      environment: 'development'
   run-e2e-tests:
     needs: build-and-deploy
 

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -1,6 +1,6 @@
 # Workflow to create a new pre-release with qa suffix
 
-name: Pre-release QA
+name: "Create a QA candidate release"
 
 # Controls when the action will run.
 on:
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ GITHUB_REF }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -1,7 +1,5 @@
 # Workflow to create a new pre-release with qa suffix
-
 name: "Create a QA candidate release"
-
 # Controls when the action will run.
 on:
   workflow_dispatch:
@@ -15,7 +13,7 @@ on:
 
 jobs:
   build-and-deploy:
-    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@${{ github.ref }}
+    uses: techmatters/hrm/.github/workflows/hrm-ecs-ci-multiregion.yml@CHI-1267-qa_release_workflow
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -20,7 +20,7 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     with:
       send-slack-message: 'false'
-      region: us-east-1
+      region: 'us-east-1'
       environment: 'development'
   run-e2e-tests:
     needs: build-and-deploy

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -69,41 +69,16 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '14.x'
-          # Get latest tag for this version
-      - name: Get latest tag
-        uses: oprypin/find-latest-tag@v1
-        with:
-          repository: techmatters/serverless # This repo
-          # releases-only: false  # This repository doesn't use GitHub's "release" feature.
-          prefix: "${{ inputs.tag-prefix }}-qa"
-        id: latest_matching_tag
-        continue-on-error: true
 
-      # Generate next tag
-      - name: Generate next tag
-        # TODO: remove branch tag (gian_CHI-1262-p2)
-        uses: techmatters/flex-plugins/.github/actions/generate-next-tag@gian_CHI-1262-p2
+      - name: Create pre release
+        # TODO: remove branch tag
+        uses: techmatters/flex-plugins/.github/actions/generate-pre-release@gian_CHI-1262-p2
         with:
-          prefix: "${{ inputs.tag-prefix }}-qa"
-          latest-matching-tag: ${{ steps.latest_matching_tag.outputs.tag }}
-        id: generate_next_tag
-
-      - run: echo ${{ steps.generate_next_tag.outputs.generated-tag }}
-
-      # Create a pre-release
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: ${{ steps.generate_next_tag.outputs.generated-tag }}
-          prerelease: true
+          tag-prefix: ${{ inputs.tag-prefix }}
+          tag-suffix: 'qa'
           title: ${{ inputs.title }}
-          # files: |
-          #   LICENSE.txt
-          #   *.jar
+          repository: ${{ github.event.repository.name }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
         id: create_pre_release
 
       ## TODO: Abstract all of this in a custom action reused across repos?


### PR DESCRIPTION
Primary Reviewer: @GPaoloni 

## Description

* Adds a workflow for tagging a build with a pre-release version tag, e.g. v1.5.1-qa.1, assuming that the E2E tests pass with this version of HRM deployed
* Adds a workflow_call event trigger to the deploy workflow, so it can be called from the release workflow as part of it's E2E test check

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added


### Related Issues
CHI-1267

### Verification steps

* Run the workflow for a fresh version.
* Verify a new Github release & tag has been created with a `-qa.1` suffix
* Run the workflow again for the same version.
* Verify a new Github release & tag has been created with a `-qa.2` suffix
* Update HRM with a change that will break the E2E tests, push it to a branch
* Warn the team that you are about to break HRM
* Run the workflow
* Ensure that the E2E tests fail as expected, this fails the workflow run and no additional release & tag are created
* REDEPLOY HRM MASTER TO DEV - otherwise the broken HRM version will still be on dev

