### PR TITLE
HRM support for async jobs I: Base jobs processing system

### DIFF
--- a/hrm-service/migrations/20220701174400-contact-jobs.js
+++ b/hrm-service/migrations/20220701174400-contact-jobs.js
@@ -1,0 +1,66 @@
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+    CREATE SEQUENCE IF NOT EXISTS public."ContactJobs_id_seq"
+        INCREMENT 1
+        START 1
+        MINVALUE 1
+        MAXVALUE 9223372036854775807
+        CACHE 1
+  `);
+    console.log('Created sequence "ContactJobs_id_seq"');
+
+    await queryInterface.sequelize.query(`
+    ALTER SEQUENCE public."ContactJobs_id_seq"
+        OWNER TO hrm;
+  `);
+    console.log('Sequence "ContactJobs_id_seq" now owned by HRM');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS public."ContactJobs"
+      (
+        id bigint NOT NULL DEFAULT nextval('"ContactJobs_id_seq"'::regclass),
+        "contactId" integer NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "jobType" text COLLATE pg_catalog."default" NOT NULL,
+        requested timestamp with time zone NOT NULL,
+        completed timestamp with time zone,
+        "lastAttempt" timestamp with time zone,
+        "numberOfAttempts" integer NOT NULL DEFAULT 0,
+        "additionalPayload" jsonb,
+        "completionPayload" jsonb,
+        CONSTRAINT "ContactJobs_pkey" PRIMARY KEY (id),
+        CONSTRAINT "FK_ContactJobs_Contacts" FOREIGN KEY ("contactId", "accountSid")
+            REFERENCES public."Contacts" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE NO ACTION
+            ON DELETE NO ACTION
+      )
+    `);
+    console.log('Table "ContactJobs" created');
+
+    await queryInterface.sequelize.query(`      
+      ALTER TABLE IF EXISTS public."ContactJobs"
+          OWNER to hrm;
+    `);
+    console.log('Table "ContactJobs" now owned by HRM');
+
+    // await queryInterface.sequelize.query(`
+    //   CREATE INDEX IF NOT EXISTS "ContactJobs_contactId_accountSid_idx" ON public."ContactJobs"
+    //   USING btree ("contactId", "accountSid");
+    // `);
+    // console.log('Index ContactJobs_contactId_accountSid_idx created');
+  },
+
+  down: async queryInterface => {
+    // await queryInterface.sequelize.query(
+    //   `DROP INDEX IF EXISTS "ContactJobs_contactId_accountSid_idx";`,
+    // );
+    // console.log('Index ContactJobs_contactId_accountSid_idx dropped');
+
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS public."ContactJobs"`);
+    console.log('Table "ContactJobs" dropped');
+
+    await queryInterface.sequelize.query(`DROP SEQUENCE public."ContactJobs_id_seq"`);
+    console.log('Sequence "ContactJobs_id_seq" dropped');
+  },
+};

--- a/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-service/service-tests/case-search.test.ts
@@ -23,6 +23,7 @@ const each = require('jest-each').default;
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/case.permissions.test.ts
+++ b/hrm-service/service-tests/case.permissions.test.ts
@@ -19,6 +19,7 @@ const server = createService({
     cachePermissions: false, // Means we can evaluate different rules each request without restarting the service
   },
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/case.test.ts
+++ b/hrm-service/service-tests/case.test.ts
@@ -15,6 +15,7 @@ import * as mocks from './mocks';
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
+++ b/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
@@ -1,0 +1,150 @@
+import supertest from 'supertest';
+import timers from 'timers';
+
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+jest.spyOn(console, 'error').mockImplementation(() => {});
+
+const wait = async (ms: number) => {
+  const p = new Promise(resolve => setTimeout(resolve, ms));
+  return p;
+};
+
+let server;
+let createService;
+let contactJobProcessor;
+let contactJobComplete;
+let contactJobPublish;
+
+const startServer = () => {
+  const service = createService({
+    authTokenLookup: () => 'picernic basket',
+  });
+
+  service.listen();
+
+  server = service;
+};
+
+const stopServer = async () => {
+  if (server && server.close) await server.close();
+  server = null;
+  await wait(100);
+};
+
+beforeEach(() => {
+  jest.isolateModules(() => {
+    createService = require('../../src/app').createService;
+    contactJobProcessor = require('../../src/contact-job/contact-job-processor');
+    contactJobComplete = require('../../src/contact-job/contact-job-complete');
+    contactJobPublish = require('../../src/contact-job/contact-job-publish');
+  });
+});
+
+afterEach(async () => {
+  await stopServer();
+  // jest.resetModules();
+  jest.clearAllMocks();
+});
+
+describe('processContactJobs', () => {
+  test('intialized on server start', async () => {
+    const processorSpy = jest.spyOn(contactJobProcessor, 'processContactJobs');
+
+    const logSpy = jest.spyOn(console, 'log');
+
+    startServer();
+
+    expect(processorSpy).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      `Started processing jobs every ${contactJobProcessor.getProcessingInterval()} milliseconds.`,
+    );
+  });
+
+  test('calling processContactJobs twice does not spans another processor', async () => {
+    const setIntervalSpy = jest.spyOn(timers, 'setInterval');
+    const processorSpy = jest.spyOn(contactJobProcessor, 'processContactJobs');
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    startServer();
+
+    // await Promise.resolve();
+    // await wait(2000);
+
+    contactJobProcessor.processContactJobs();
+
+    expect(processorSpy).toHaveBeenCalledTimes(2);
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(`processContactJobs repeating task already running`);
+  });
+
+  test('swipes are as expected', async () => {
+    jest.spyOn(contactJobProcessor, 'getProcessingInterval').mockImplementation(() => 10);
+    const processorSpy = jest.spyOn(contactJobProcessor, 'processContactJobs');
+    const completeSpy = jest.spyOn(contactJobComplete, 'processCompleteContactJobs');
+    const publishSpy = jest.spyOn(contactJobPublish, 'publishPendingContactJobs');
+
+    startServer();
+
+    expect(processorSpy).toHaveBeenCalled();
+
+    await wait(contactJobProcessor.getProcessingInterval());
+
+    expect(completeSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    await wait(contactJobProcessor.getProcessingInterval());
+
+    expect(completeSpy).toHaveBeenCalledTimes(2);
+    expect(publishSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('error on swipe does not shuts down the server', async () => {
+    jest.spyOn(contactJobProcessor, 'getProcessingInterval').mockImplementation(() => 10);
+    const errorSpy = jest.spyOn(console, 'error');
+    const processorSpy = jest.spyOn(contactJobProcessor, 'processContactJobs');
+    const completeSpy = jest
+      .spyOn(contactJobComplete, 'processCompleteContactJobs')
+      .mockImplementationOnce(() => {
+        throw new Error('Aaaw, snap!');
+      });
+
+    startServer();
+
+    const request = supertest.agent(server);
+
+    expect(processorSpy).toHaveBeenCalled();
+
+    await wait(contactJobProcessor.getProcessingInterval());
+
+    expect(completeSpy).toHaveBeenCalledTimes(1);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'JOB PROCESSING SWEEP ABORTED DUE TO UNHANDLED ERROR',
+      Error('Aaaw, snap!'),
+    );
+
+    completeSpy.mockClear();
+
+    const response = await request.get('/');
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({ Message: 'HRM is up and running!' });
+
+    await wait(contactJobProcessor.getProcessingInterval());
+
+    // The another sweep is executed again in the future
+    expect(completeSpy).toHaveBeenCalled();
+  });
+
+  test('error starting the processor wont start server', async () => {
+    const processorSpy = jest
+      .spyOn(contactJobProcessor, 'processContactJobs')
+      .mockImplementationOnce(() => {
+        throw new Error('Aaaw, snap!');
+      });
+
+    expect(() => startServer()).toThrow();
+    expect(processorSpy).toHaveBeenCalled();
+  });
+});

--- a/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
+++ b/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
@@ -89,11 +89,17 @@ describe('processContactJobs', () => {
 
     expect(completeSpy).toHaveBeenCalledTimes(1);
     expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(completeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      publishSpy.mock.invocationCallOrder[0],
+    );
 
     await processorIntervalCallback();
 
     expect(completeSpy).toHaveBeenCalledTimes(2);
     expect(publishSpy).toHaveBeenCalledTimes(2);
+    expect(completeSpy.mock.invocationCallOrder[1]).toBeLessThan(
+      publishSpy.mock.invocationCallOrder[1],
+    );
   });
 
   test('error on sweep does not shuts down the server', async () => {

--- a/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-service/service-tests/contacts.test.ts
@@ -40,6 +40,7 @@ const { form, ...contact1WithRawJsonProp } = contact1 as CreateContactPayloadWit
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server, undefined);
 

--- a/hrm-service/service-tests/csam-reports.test.ts
+++ b/hrm-service/service-tests/csam-reports.test.ts
@@ -18,6 +18,7 @@ const CSAMReportController = require('../src/controllers/csam-report-controller'
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/permissions.test.ts
+++ b/hrm-service/service-tests/permissions.test.ts
@@ -8,6 +8,7 @@ const each = require('jest-each').default;
 
 const server = createService({
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/post-surveys.test.ts
+++ b/hrm-service/service-tests/post-surveys.test.ts
@@ -9,6 +9,7 @@ const models = require('../src/models');
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/service-tests/safe-router.test.ts
+++ b/hrm-service/service-tests/safe-router.test.ts
@@ -42,6 +42,7 @@ jest.mock('../src/routes', () => {
 const server = createService({
   permissions: openPermissions,
   authTokenLookup: () => 'picernic basket',
+  enableProcessContactJobs: false,
 }).listen();
 const request = supertest.agent(server);
 

--- a/hrm-service/src/app.ts
+++ b/hrm-service/src/app.ts
@@ -9,15 +9,18 @@ import { apiV0 } from './routes';
 import { Permissions, setupPermissions } from './permissions';
 import { jsonPermissions } from './permissions/json-permissions';
 import { getAuthorizationMiddleware, addAccountSid } from './middlewares';
+import { processContactJobs } from './contact-job/contact-job-processor';
 
 type ServiceCreationOptions = Partial<{
   permissions: Permissions;
   authTokenLookup: (accountSid: string) => string;
+  enableProcessContactJobs: boolean;
 }>;
 
 export function createService({
   permissions = jsonPermissions,
   authTokenLookup,
+  enableProcessContactJobs = true,
 }: ServiceCreationOptions = {}) {
   const app = express();
 
@@ -65,6 +68,10 @@ export function createService({
     res.json(error);
     next();
   });
+
+  if (enableProcessContactJobs) {
+    processContactJobs();
+  }
 
   console.log(`${new Date(Date.now()).toLocaleString()}: app.js has been created`);
 

--- a/hrm-service/src/contact-job/assertExhaustive.ts
+++ b/hrm-service/src/contact-job/assertExhaustive.ts
@@ -1,0 +1,5 @@
+// Function to test that there are no unhandled cases in a switch statement
+export const assertExhaustive = (param: never) => {
+  const exhaustiveCheck: never = param;
+  throw new Error(`Unhandled case: ${exhaustiveCheck}`);
+};

--- a/hrm-service/src/contact-job/client-sns.ts
+++ b/hrm-service/src/contact-job/client-sns.ts
@@ -1,0 +1,9 @@
+import { PublishToContactJobsTopicParams } from './contact-job-messages';
+
+export const publishToContactJobsTopic = async (params: PublishToContactJobsTopicParams) => {
+  try {
+    return params;
+  } catch (err) {
+    console.error('Error trying to send message to SNS topic', err);
+  }
+};

--- a/hrm-service/src/contact-job/client-sqs.ts
+++ b/hrm-service/src/contact-job/client-sqs.ts
@@ -1,0 +1,11 @@
+export const pollCompletedContactJobs = async (): Promise<{
+  Messages: { ReceiptHandle: string; Body: string }[];
+}> => {
+  return {
+    Messages: [],
+  };
+};
+
+export const deletedCompletedContactJobs = async (ReceiptHandle: any) => {
+  return ReceiptHandle;
+};

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -1,0 +1,44 @@
+import { completeContactJob, ContactJobType } from './contact-job-data-access';
+import { deletedCompletedContactJobs, pollCompletedContactJobs } from './client-sqs';
+import { CompletedContactJobBody, TestContactJobCompleted } from './contact-job-messages';
+
+async function processTestContactJobCompleted(completedJob: TestContactJobCompleted) {
+  return completedJob;
+}
+
+const processCompletedContactJob = async (completedJob: CompletedContactJobBody) => {
+  switch (completedJob.jobType) {
+    case ContactJobType.TEST_CONTACT_JOB: {
+      return processTestContactJobCompleted(completedJob);
+    }
+  }
+};
+
+export const processCompleteContactJobs = async () => {
+  const polledCompletedJobs = await pollCompletedContactJobs();
+
+  const { Messages: messages } = polledCompletedJobs;
+
+  if (Array.isArray(messages) && messages.length) {
+    const completedJobs = await Promise.allSettled(
+      messages.map(async m => {
+        const completedJob: CompletedContactJobBody = JSON.parse(m.Body);
+
+        await processCompletedContactJob(completedJob);
+
+        // Mark the job as completed
+        const markedComplete = await completeContactJob(
+          completedJob.jobId,
+          completedJob.completionPayload,
+        );
+
+        // Delete the message from the queue (this could be batched)
+        await deletedCompletedContactJobs(m.ReceiptHandle);
+
+        return markedComplete;
+      }),
+    );
+
+    return completedJobs;
+  }
+};

--- a/hrm-service/src/contact-job/contact-job-data-access.ts
+++ b/hrm-service/src/contact-job/contact-job-data-access.ts
@@ -1,0 +1,70 @@
+import { db, pgp } from '../connection-pool';
+import { Contact } from '../contact/contact-data-access';
+import { COMPLETE_JOB_SQL, PULL_DUE_JOBS_SQL } from './sql/contact-job-sql';
+
+export const enum ContactJobType {
+  TEST_CONTACT_JOB = 'test-contact-job',
+}
+
+type Job<TComplete = any, TAdditional = any> = {
+  id: number;
+  resource: Contact;
+  completed?: Date;
+  completionPayload?: TComplete;
+  additionalPayload: TAdditional;
+};
+
+export type TestContactJob = Job & { jobType: ContactJobType.TEST_CONTACT_JOB };
+
+export type ContactJob = TestContactJob;
+
+/**
+ * Returns all the jobs that are considered 'due'
+ * These are jobs that are not considered complete, and have also not been attempted since the time provided (to prevent jobs being retried too often)
+ * The logic could be further enhanced with logic to consider a job 'abandoned', i.e. after a certain number of attempts or if requested too long ago.
+ * This will pull the contact in its current state and add it to the job payload for sending
+ * @param lastAttemptedBefore
+ */
+export const pullDueContactJobs = async (lastAttemptedBefore: Date): Promise<ContactJob[]> => {
+  return db.task(conn => {
+    return conn.manyOrNone<ContactJob>(PULL_DUE_JOBS_SQL, {
+      lastAttemptedBefore: lastAttemptedBefore.toISOString(),
+    });
+  });
+};
+
+/**
+ * Mark a job complete and record the completionPayload for posterity
+ * @param id
+ * @param completionPayload
+ */
+export const completeContactJob = async (
+  id: number,
+  completionPayload: any,
+): Promise<ContactJob> => {
+  return db.task(tx => {
+    return tx.oneOrNone(COMPLETE_JOB_SQL, { id, completionPayload });
+  });
+};
+
+/**
+ * Add a new job to be completed to the ContactJobs queue
+ * @param job
+ */
+export const createContactJob = async (job: Omit<ContactJob, 'id'>): Promise<void> => {
+  const contact = job.resource;
+  await db.task(tx => {
+    const insertSql = pgp.helpers.insert(
+      {
+        requested: new Date().toISOString(),
+        jobType: job.jobType,
+        contactId: contact.id,
+        accountSid: contact.accountSid,
+        additionalPayload: job.additionalPayload,
+      },
+      null,
+      'ContactJobs',
+    );
+    return tx.none(insertSql);
+  });
+};

--- a/hrm-service/src/contact-job/contact-job-messages.ts
+++ b/hrm-service/src/contact-job/contact-job-messages.ts
@@ -1,0 +1,26 @@
+import { Contact } from '../contact/contact-data-access';
+import { ContactJob, ContactJobType } from './contact-job-data-access';
+
+type ContactJobMessageCommons = {
+  jobId: ContactJob['id'];
+  accountSid: Contact['accountSid'];
+  contactId: Contact['id'];
+  taskId: Contact['taskId'];
+  twilioWorkerId: Contact['twilioWorkerId'];
+};
+
+//====== Message payloads to publish for pending contact jobs ======//
+
+export type PublishTestContactJob = ContactJobMessageCommons & {
+  jobType: ContactJobType.TEST_CONTACT_JOB;
+};
+
+export type PublishToContactJobsTopicParams = PublishTestContactJob;
+
+//====== Message payloads expected for the completed contact jobs ======//
+
+export type TestContactJobCompleted = PublishTestContactJob & {
+  completionPayload: string;
+};
+
+export type CompletedContactJobBody = TestContactJobCompleted;

--- a/hrm-service/src/contact-job/contact-job-processor.ts
+++ b/hrm-service/src/contact-job/contact-job-processor.ts
@@ -7,12 +7,11 @@ let processingJobs = false;
 const JOB_PROCESSING_INTERVAL_MILLISECONDS = 5000;
 const JOB_RETRY_INTERVAL_MILLISECONDS = 60000;
 
-export const getProcessingInterval = () => JOB_PROCESSING_INTERVAL_MILLISECONDS;
-export const getRetryInterval = () => JOB_RETRY_INTERVAL_MILLISECONDS;
-
 export function processContactJobs() {
   if (!processingJobs) {
-    console.log(`Started processing jobs every ${getProcessingInterval()} milliseconds.`);
+    console.log(
+      `Started processing jobs every ${JOB_PROCESSING_INTERVAL_MILLISECONDS} milliseconds.`,
+    );
     processingJobs = true;
 
     return setInterval(async () => {
@@ -26,14 +25,14 @@ export function processContactJobs() {
         // console.log(completedJobs);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const pusblishResults = await publishPendingContactJobs(getRetryInterval());
+        const pusblishResults = await publishPendingContactJobs(JOB_RETRY_INTERVAL_MILLISECONDS);
 
         // Process published results
         // console.log(pusblishResults);
       } catch (err) {
         console.error('JOB PROCESSING SWEEP ABORTED DUE TO UNHANDLED ERROR', err);
       }
-    }, getProcessingInterval());
+    }, JOB_PROCESSING_INTERVAL_MILLISECONDS);
   } else {
     console.warn(`processContactJobs repeating task already running`);
   }

--- a/hrm-service/src/contact-job/contact-job-processor.ts
+++ b/hrm-service/src/contact-job/contact-job-processor.ts
@@ -1,0 +1,40 @@
+import { setInterval } from 'timers';
+import { processCompleteContactJobs } from './contact-job-complete';
+import { publishPendingContactJobs } from './contact-job-publish';
+
+let processingJobs = false;
+
+const JOB_PROCESSING_INTERVAL_MILLISECONDS = 5000;
+const JOB_RETRY_INTERVAL_MILLISECONDS = 60000;
+
+export const getProcessingInterval = () => JOB_PROCESSING_INTERVAL_MILLISECONDS;
+export const getRetryInterval = () => JOB_RETRY_INTERVAL_MILLISECONDS;
+
+export function processContactJobs() {
+  if (!processingJobs) {
+    console.log(`Started processing jobs every ${getProcessingInterval()} milliseconds.`);
+    processingJobs = true;
+
+    return setInterval(async () => {
+      // This is the primary job processing 'loop'
+      // First we process any completed jobs. These completed jobs would be pulled from a queue in prod but we just have a cheap in memory simulation using an array here
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const completedJobs = await processCompleteContactJobs();
+
+        // Process completed jobs
+        // console.log(completedJobs);
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const pusblishResults = await publishPendingContactJobs(getRetryInterval());
+
+        // Process published results
+        // console.log(pusblishResults);
+      } catch (err) {
+        console.error('JOB PROCESSING SWEEP ABORTED DUE TO UNHANDLED ERROR', err);
+      }
+    }, getProcessingInterval());
+  } else {
+    console.warn(`processContactJobs repeating task already running`);
+  }
+}

--- a/hrm-service/src/contact-job/contact-job-publish.ts
+++ b/hrm-service/src/contact-job/contact-job-publish.ts
@@ -1,0 +1,39 @@
+import { subMilliseconds } from 'date-fns';
+import { pullDueContactJobs, TestContactJob } from './contact-job-data-access';
+import { publishToContactJobsTopic } from './client-sns';
+import { ContactJobType } from './contact-job-data-access';
+
+export const publishTestContactJob = (contactJob: TestContactJob) => {
+  const { accountSid, id: contactId, taskId, twilioWorkerId } = contactJob.resource;
+
+  return publishToContactJobsTopic({
+    jobType: contactJob.jobType,
+    jobId: contactJob.id,
+    accountSid,
+    contactId,
+    taskId,
+    twilioWorkerId,
+  });
+};
+
+type PublishedContactJobResult = Awaited<ReturnType<typeof publishTestContactJob>>;
+
+export const publishPendingContactJobs = async (
+  contactJobRetryIntervalMiliseconds: number,
+): Promise<PromiseSettledResult<PublishedContactJobResult>[]> => {
+  // This pulls any jobs due to be run and marks them as attempted
+  const pendingJobs = await pullDueContactJobs(
+    subMilliseconds(new Date(), contactJobRetryIntervalMiliseconds),
+  );
+
+  const publishResults = await Promise.allSettled(
+    pendingJobs.map((pendingJob: TestContactJob) => {
+      switch (pendingJob.jobType) {
+        case ContactJobType.TEST_CONTACT_JOB:
+          return publishTestContactJob(pendingJob);
+      }
+    }),
+  );
+
+  return publishResults;
+};

--- a/hrm-service/src/contact-job/sql/contact-job-sql.ts
+++ b/hrm-service/src/contact-job/sql/contact-job-sql.ts
@@ -1,0 +1,19 @@
+import { selectContactsWithCsamReports } from '../../contact/sql/contact-get-sql';
+
+export const PULL_DUE_JOBS_SQL = `
+WITH due AS (
+  UPDATE "ContactJobs" SET "lastAttempt" = CURRENT_TIMESTAMP, "numberOfAttempts" = "numberOfAttempts" + 1
+  WHERE completed IS NULL AND ("lastAttempt" IS NULL OR "lastAttempt" <= $<lastAttemptedBefore>::TIMESTAMP WITH TIME ZONE) RETURNING *
+)
+SELECT due.*, to_jsonb(contacts.*) AS "resource" FROM due LEFT JOIN LATERAL (
+${selectContactsWithCsamReports(
+  'Contacts',
+)} WHERE c."accountSid" = due."accountSid" AND c."id" = due."contactId") AS contacts ON true`;
+
+export const COMPLETE_JOB_SQL = `
+UPDATE "ContactJobs" SET 
+    "completed" = CURRENT_TIMESTAMP, 
+    "completionPayload" = $<completionPayload:json>::JSONB
+WHERE "id" = $<id>
+RETURNING *
+`;

--- a/hrm-service/src/contact/sql/contact-get-sql.ts
+++ b/hrm-service/src/contact/sql/contact-get-sql.ts
@@ -1,24 +1,21 @@
 const ID_WHERE_CLAUSE = `WHERE c."accountSid" = $<accountSid> AND c."id" = $<contactId>`;
 const TASKID_WHERE_CLAUSE = `WHERE c."accountSid" = $<accountSid> AND c."taskId" = $<taskId>`;
 
-export const selectSingleContactByIdSql = (table: string) => `
+export const selectContactsWithCsamReports = (table: string) => `
         SELECT c.*, reports."csamReports" 
         FROM "${table}" c 
         LEFT JOIN LATERAL (
           SELECT COALESCE(jsonb_agg(to_jsonb(r)), '[]') AS  "csamReports" 
           FROM "CSAMReports" r 
           WHERE r."contactId" = c.id AND r."accountSid" = c."accountSid"
-        ) reports ON true
+        ) reports ON true`;
+
+export const selectSingleContactByIdSql = (table: string) => `
+      ${selectContactsWithCsamReports(table)}
       ${ID_WHERE_CLAUSE}`;
 
-export const selectSingleContactByTaskId = (table: string) => `
-        SELECT c.*, reports."csamReports" 
-        FROM "${table}" c 
-        LEFT JOIN LATERAL (
-          SELECT COALESCE(jsonb_agg(to_jsonb(r)), '[]') AS  "csamReports" 
-          FROM "CSAMReports" r 
-          WHERE r."contactId" = c.id AND r."accountSid" = c."accountSid"
-        ) reports ON true
+export const selectSingleContactByTaskId = (table: string) => ` 
+      ${selectContactsWithCsamReports(table)}
       ${TASKID_WHERE_CLAUSE}
       -- only take the latest, this ORDER / LIMIT clause would be redundant 
       ORDER BY c."createdAt" DESC LIMIT 1`;


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
This PR adds support to process async jobs. The loop is started when the server initializes and it's wrapped in a `setInterval` that will run every 5 seconds.
- Adds migration to create `ContactJobs` table.
- Adds fake SNS/SQS clients (will be used later on).
- Adds message types as we'll expect them (publish pending and complete job messages).
- Wraps publishing due jobs and polling completed ones in two separate files.
- Adds the main processor loop code. This is the only real working piece of code for now.

In this PR a fake job type is introduced, to make some typings easier. Will be removed in the following one.

Note: some cleanup is done in the follow up PR (https://github.com/techmatters/hrm/pull/239).

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1381)
- [x] New tests added

### Verification steps
- Start the local server.
- Confirm that the processor loop is running in the background, but it shouldn't do anything for now.