### PR TITLE
HRM support for async jobs II: Handle possible failures in completed jobs

### DIFF
--- a/hrm-service/migrations/20220701174400-contact-jobs.js
+++ b/hrm-service/migrations/20220701174400-contact-jobs.js
@@ -27,6 +27,7 @@ module.exports = {
         completed timestamp with time zone,
         "lastAttempt" timestamp with time zone,
         "numberOfAttempts" integer NOT NULL DEFAULT 0,
+        "failedAttemptsPayloads" jsonb,
         "additionalPayload" jsonb,
         "completionPayload" jsonb,
         CONSTRAINT "ContactJobs_pkey" PRIMARY KEY (id),

--- a/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
+++ b/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
@@ -263,7 +263,7 @@ describe('complete retrieve-transcript job type', () => {
       };
 
       // const pollCompletedContactJobsSpy =
-      jest.spyOn(SQSClient, 'pollCompletedContactJobs').mockImplementation(() =>
+      jest.spyOn(SQSClient, 'pollCompletedContactJobsFromQueue').mockImplementation(() =>
         Promise.resolve({
           Messages: [
             {
@@ -330,7 +330,10 @@ describe('complete retrieve-transcript job type', () => {
       expect(
         isAfter(updatedRetrieveContactTranscriptJob.completed!, startedTimestamp),
       ).toBeTruthy();
-      expect(updatedRetrieveContactTranscriptJob.completionPayload).toBe('some-url-here');
+      expect(updatedRetrieveContactTranscriptJob.completionPayload).toMatchObject({
+        message: 'Job processed successfully',
+        value: 'some-url-here',
+      });
 
       // Check the updated contact in the DB
       const updatedContact = await db.task(async t =>
@@ -381,7 +384,7 @@ describe('complete retrieve-transcript job type', () => {
       };
 
       // const pollCompletedContactJobsSpy =
-      jest.spyOn(SQSClient, 'pollCompletedContactJobs').mockImplementation(() =>
+      jest.spyOn(SQSClient, 'pollCompletedContactJobsFromQueue').mockImplementation(() =>
         Promise.resolve({
           Messages: [
             {
@@ -442,9 +445,9 @@ describe('complete retrieve-transcript job type', () => {
         expect(
           isAfter(updatedRetrieveContactTranscriptJob.completed!, startedTimestamp),
         ).toBeTruthy();
-        expect(updatedRetrieveContactTranscriptJob.completionPayload).toBe(
-          'Attempts limit reached',
-        );
+        expect(updatedRetrieveContactTranscriptJob.completionPayload).toMatchObject({
+          message: 'Attempts limit reached',
+        });
       } else {
         // But previous job is completed hence not retrieved as due
         // expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(0);

--- a/hrm-service/src/contact-job/client-sqs.ts
+++ b/hrm-service/src/contact-job/client-sqs.ts
@@ -1,4 +1,4 @@
-export const pollCompletedContactJobs = async (): Promise<{
+export const pollCompletedContactJobsFromQueue = async (): Promise<{
   Messages: { ReceiptHandle: string; Body: string }[];
 }> => {
   return {
@@ -6,6 +6,6 @@ export const pollCompletedContactJobs = async (): Promise<{
   };
 };
 
-export const deletedCompletedContactJobs = async (ReceiptHandle: any) => {
+export const deleteCompletedContactJobsFromQueue = async (ReceiptHandle: any) => {
   return ReceiptHandle;
 };

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -55,10 +55,11 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
           await processCompletedContactJob(completedJob);
 
           // Mark the job as completed
-          const markedComplete = await completeContactJob(
-            completedJob.jobId,
-            completedJob.attemptPayload,
-          );
+          const completionPayload = {
+            message: 'Job processed successfully',
+            value: completedJob.attemptPayload,
+          };
+          const markedComplete = await completeContactJob(completedJob.jobId, completionPayload);
 
           // Delete the message from the queue (this could be batched)
           await deleteCompletedContactJobsFromQueue(m.ReceiptHandle);
@@ -69,10 +70,8 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
           const updated = await appendFailedAttemptPayload(jobId, attemptNumber, attemptPayload);
 
           if (attemptNumber === jobMaxAttempts) {
-            const markedComplete = await completeContactJob(
-              completedJob.jobId,
-              'Attempts limit reached',
-            );
+            const completionPayload = { message: 'Attempts limit reached' };
+            const markedComplete = await completeContactJob(completedJob.jobId, completionPayload);
 
             await deleteCompletedContactJobsFromQueue(m.ReceiptHandle);
 

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -1,4 +1,8 @@
-import { completeContactJob, ContactJobType } from './contact-job-data-access';
+import {
+  ContactJobType,
+  completeContactJob,
+  appendFailedAttemptPayload,
+} from './contact-job-data-access';
 import { deletedCompletedContactJobs, pollCompletedContactJobs } from './client-sqs';
 import {
   CompletedContactJobBody,
@@ -13,7 +17,7 @@ export const processCompletedRetrieveContactTranscript = async (
 ) => {
   return appendMediaUrls(completedJob.accountSid, completedJob.contactId, [
     {
-      url: completedJob.completionPayload,
+      url: completedJob.attemptPayload,
       type: ContactMediaType.TRANSCRIPT,
     },
   ]);
@@ -30,7 +34,7 @@ const processCompletedContactJob = async (completedJob: CompletedContactJobBody)
   }
 };
 
-export const pollAndprocessCompletedContactJobs = async () => {
+export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number) => {
   const polledCompletedJobs = await pollCompletedContactJobs();
 
   const { Messages: messages } = polledCompletedJobs;
@@ -44,18 +48,34 @@ export const pollAndprocessCompletedContactJobs = async () => {
       try {
         const completedJob: CompletedContactJobBody = JSON.parse(m.Body);
 
-        await processCompletedContactJob(completedJob);
+        if (completedJob.attemptResult === 'success') {
+          await processCompletedContactJob(completedJob);
 
-        // Mark the job as completed
-        const markedComplete = await completeContactJob(
-          completedJob.jobId,
-          completedJob.completionPayload,
-        );
+          // Mark the job as completed
+          const markedComplete = await completeContactJob(
+            completedJob.jobId,
+            completedJob.attemptPayload,
+          );
 
-        // Delete the message from the queue (this could be batched)
-        await deletedCompletedContactJobs(m.ReceiptHandle);
+          // Delete the message from the queue (this could be batched)
+          await deletedCompletedContactJobs(m.ReceiptHandle);
 
-        return markedComplete;
+          return markedComplete;
+        } else {
+          const { jobId, attemptNumber, attemptPayload } = completedJob;
+          const updated = await appendFailedAttemptPayload(jobId, attemptNumber, attemptPayload);
+
+          if (updated.numberOfAttempts === jobMaxAttempts) {
+            const markedComplete = await completeContactJob(
+              completedJob.jobId,
+              'Attempts limit reached',
+            );
+
+            return markedComplete;
+          }
+
+          return updated;
+        }
       } catch (err) {
         console.error('Failed to process CompletedContactJobBody:', m, err);
         return Promise.reject(err);

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -3,7 +3,7 @@ import {
   completeContactJob,
   appendFailedAttemptPayload,
 } from './contact-job-data-access';
-import { deletedCompletedContactJobs, pollCompletedContactJobs } from './client-sqs';
+import { deleteCompletedContactJobsFromQueue, pollCompletedContactJobsFromQueue } from './client-sqs';
 import {
   CompletedContactJobBody,
   CompletedRetrieveContactTranscript,
@@ -35,7 +35,7 @@ const processCompletedContactJob = async (completedJob: CompletedContactJobBody)
 };
 
 export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number) => {
-  const polledCompletedJobs = await pollCompletedContactJobs();
+  const polledCompletedJobs = await pollCompletedContactJobsFromQueue();
 
   const { Messages: messages } = polledCompletedJobs;
 
@@ -58,7 +58,7 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
           );
 
           // Delete the message from the queue (this could be batched)
-          await deletedCompletedContactJobs(m.ReceiptHandle);
+          await deleteCompletedContactJobsFromQueue(m.ReceiptHandle);
 
           return markedComplete;
         } else {

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -69,7 +69,7 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
           const { jobId, attemptNumber, attemptPayload } = completedJob;
           const updated = await appendFailedAttemptPayload(jobId, attemptNumber, attemptPayload);
 
-          if (attemptNumber === jobMaxAttempts) {
+          if (attemptNumber >= jobMaxAttempts) {
             const completionPayload = { message: 'Attempts limit reached' };
             const markedComplete = await completeContactJob(completedJob.jobId, completionPayload);
 

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -3,7 +3,10 @@ import {
   completeContactJob,
   appendFailedAttemptPayload,
 } from './contact-job-data-access';
-import { deleteCompletedContactJobsFromQueue, pollCompletedContactJobsFromQueue } from './client-sqs';
+import {
+  deleteCompletedContactJobsFromQueue,
+  pollCompletedContactJobsFromQueue,
+} from './client-sqs';
 import {
   CompletedContactJobBody,
   CompletedRetrieveContactTranscript,
@@ -70,6 +73,8 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
               completedJob.jobId,
               'Attempts limit reached',
             );
+
+            await deleteCompletedContactJobsFromQueue(m.ReceiptHandle);
 
             return markedComplete;
           }

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -65,7 +65,7 @@ export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number)
           const { jobId, attemptNumber, attemptPayload } = completedJob;
           const updated = await appendFailedAttemptPayload(jobId, attemptNumber, attemptPayload);
 
-          if (updated.numberOfAttempts === jobMaxAttempts) {
+          if (attemptNumber === jobMaxAttempts) {
             const markedComplete = await completeContactJob(
               completedJob.jobId,
               'Attempts limit reached',

--- a/hrm-service/src/contact-job/contact-job-data-access.ts
+++ b/hrm-service/src/contact-job/contact-job-data-access.ts
@@ -105,6 +105,6 @@ export const appendFailedAttemptPayload = async (
     tx.oneOrNone<ContactJob>(APPEND_FAILED_ATTEMPT_PAYLOAD, {
       id,
       attemptNumber,
-      attemptPayload: JSON.stringify(attemptPayload),
+      attemptPayload: attemptPayload,
     }),
   );

--- a/hrm-service/src/contact-job/contact-job-messages.ts
+++ b/hrm-service/src/contact-job/contact-job-messages.ts
@@ -23,12 +23,17 @@ export type PublishToContactJobsTopicParams = PublishRetrieveContactTranscript;
 
 //====== Message payloads expected for the completed contact jobs ======//
 
-type CompletedContactJobMessageCommons<T> = {
-  attemptResult: 'success' | 'failure';
-  attemptPayload: T;
-};
+type CompletedContactJobMessageCommons<TSuccess, TFailure> =
+  | {
+      attemptResult: 'success';
+      attemptPayload: TSuccess;
+    }
+  | {
+      attemptResult: 'failure';
+      attemptPayload: TFailure;
+    };
 
 export type CompletedRetrieveContactTranscript = PublishRetrieveContactTranscript &
-  CompletedContactJobMessageCommons<string>;
+  CompletedContactJobMessageCommons<string, any>;
 
 export type CompletedContactJobBody = CompletedRetrieveContactTranscript;

--- a/hrm-service/src/contact-job/contact-job-messages.ts
+++ b/hrm-service/src/contact-job/contact-job-messages.ts
@@ -7,6 +7,7 @@ type ContactJobMessageCommons = {
   contactId: Contact['id'];
   taskId: Contact['taskId'];
   twilioWorkerId: Contact['twilioWorkerId'];
+  attemptNumber: number;
 };
 
 //====== Message payloads to publish for pending contact jobs ======//
@@ -22,8 +23,12 @@ export type PublishToContactJobsTopicParams = PublishRetrieveContactTranscript;
 
 //====== Message payloads expected for the completed contact jobs ======//
 
-export type CompletedRetrieveContactTranscript = PublishRetrieveContactTranscript & {
-  completionPayload: string;
+type CompletedContactJobMessageCommons<T> = {
+  attemptResult: 'success' | 'failure';
+  attemptPayload: T;
 };
+
+export type CompletedRetrieveContactTranscript = PublishRetrieveContactTranscript &
+  CompletedContactJobMessageCommons<string>;
 
 export type CompletedContactJobBody = CompletedRetrieveContactTranscript;

--- a/hrm-service/src/contact-job/contact-job-processor.ts
+++ b/hrm-service/src/contact-job/contact-job-processor.ts
@@ -8,7 +8,7 @@ let processingJobs = false;
 
 const JOB_PROCESSING_INTERVAL_MILLISECONDS = 5000; // 5 seconds
 const JOB_RETRY_INTERVAL_MILLISECONDS = 120000; // 2 minutes
-const JOB_MAX_ATTEMPTS = 20;
+export const JOB_MAX_ATTEMPTS = 20;
 
 export function processContactJobs() {
   if (!processingJobs) {

--- a/hrm-service/src/contact-job/contact-job-processor.ts
+++ b/hrm-service/src/contact-job/contact-job-processor.ts
@@ -8,6 +8,7 @@ let processingJobs = false;
 
 const JOB_PROCESSING_INTERVAL_MILLISECONDS = 5000; // 5 seconds
 const JOB_RETRY_INTERVAL_MILLISECONDS = 120000; // 2 minutes
+const JOB_MAX_ATTEMPTS = 20;
 
 export function processContactJobs() {
   if (!processingJobs) {
@@ -19,7 +20,7 @@ export function processContactJobs() {
     return setInterval(async () => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const completedJobs = await pollAndprocessCompletedContactJobs();
+        const completedJobs = await pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
         const dueContactJobs = await pullDueContactJobs(
           subMilliseconds(new Date(), JOB_RETRY_INTERVAL_MILLISECONDS),

--- a/hrm-service/src/contact-job/contact-job-publish.ts
+++ b/hrm-service/src/contact-job/contact-job-publish.ts
@@ -28,6 +28,7 @@ export const publishRetrieveContactTranscript = (contactJob: RetrieveContactTran
     taskId,
     twilioWorkerId,
     filePath,
+    attemptNumber: contactJob.numberOfAttempts,
   });
 };
 

--- a/hrm-service/src/contact-job/sql/contact-job-sql.ts
+++ b/hrm-service/src/contact-job/sql/contact-job-sql.ts
@@ -1,19 +1,34 @@
 import { selectContactsWithCsamReports } from '../../contact/sql/contact-get-sql';
 
 export const PULL_DUE_JOBS_SQL = `
-WITH due AS (
-  UPDATE "ContactJobs" SET "lastAttempt" = CURRENT_TIMESTAMP, "numberOfAttempts" = "numberOfAttempts" + 1
-  WHERE completed IS NULL AND ("lastAttempt" IS NULL OR "lastAttempt" <= $<lastAttemptedBefore>::TIMESTAMP WITH TIME ZONE) RETURNING *
-)
-SELECT due.*, to_jsonb(contacts.*) AS "resource" FROM due LEFT JOIN LATERAL (
-${selectContactsWithCsamReports(
-  'Contacts',
-)} WHERE c."accountSid" = due."accountSid" AND c."id" = due."contactId") AS contacts ON true`;
+  WITH due AS (
+    UPDATE "ContactJobs" SET "lastAttempt" = CURRENT_TIMESTAMP, "numberOfAttempts" = "numberOfAttempts" + 1
+    WHERE completed IS NULL AND ("lastAttempt" IS NULL OR "lastAttempt" <= $<lastAttemptedBefore>::TIMESTAMP WITH TIME ZONE) RETURNING *
+  )
+  SELECT due.*, to_jsonb(contacts.*) AS "resource" FROM due LEFT JOIN LATERAL (
+  ${selectContactsWithCsamReports(
+    'Contacts',
+  )} WHERE c."accountSid" = due."accountSid" AND c."id" = due."contactId") AS contacts ON true
+`;
 
 export const COMPLETE_JOB_SQL = `
-UPDATE "ContactJobs" SET 
-    "completed" = CURRENT_TIMESTAMP, 
-    "completionPayload" = $<completionPayload:json>::JSONB
-WHERE "id" = $<id>
-RETURNING *
+  UPDATE "ContactJobs" SET
+      "completed" = CURRENT_TIMESTAMP,
+      "completionPayload" = $<completionPayload:json>::JSONB
+  WHERE "id" = $<id>
+  RETURNING *
+`;
+
+export const APPEND_FAILED_ATTEMPT_PAYLOAD = `
+  UPDATE "ContactJobs"
+  SET
+    "failedAttemptsPayloads" =
+      COALESCE("failedAttemptsPayloads", '{}'::JSONB) || jsonb_set(
+        "failedAttemptsPayloads", -- target
+        format('{%s}', $<attemptNumber>)::text[], -- path
+        COALESCE("failedAttemptsPayloads"#>format('{%s}', $<attemptNumber>)::text[], '[]'::JSONB) || $<attemptPayload:json>::JSONB, -- value
+        true -- create if not exists
+      )
+  WHERE id = $<id>
+  RETURNING *
 `;

--- a/hrm-service/src/contact/contact.ts
+++ b/hrm-service/src/contact/contact.ts
@@ -132,7 +132,7 @@ export const createContact = async (
     await createContactJob({
       jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
       resource: created,
-      additionalPayload: undefined,
+      additionalPayload: null,
     });
   }
 

--- a/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
+++ b/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
@@ -4,6 +4,8 @@ import * as SQSClient from '../../src/contact-job/client-sqs';
 import * as contactJobDataAccess from '../../src/contact-job/contact-job-data-access';
 import * as contactJobComplete from '../../src/contact-job/contact-job-complete';
 import { ContactJobType } from '../../src/contact-job/contact-job-data-access';
+import { CompletedContactJobBody } from '../../src/contact-job/contact-job-messages';
+import { JOB_MAX_ATTEMPTS } from '../../src/contact-job/contact-job-processor';
 
 jest.mock('../../src/contact-job/client-sqs');
 
@@ -19,7 +21,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         Messages: [],
       }));
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs();
+    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(sqsSpy).toHaveBeenCalled();
     expect(Array.isArray(result)).toBeTruthy();
@@ -28,13 +30,25 @@ describe('pollAndprocessCompletedContactJobs', () => {
 
   test('Invalid job format throws but does not shuts down other jobs', async () => {
     const invalidPayload = {
-      Body: JSON.stringify({ jobType: 'invalid' }),
+      Body: JSON.stringify({ jobType: 'invalid', attemptResult: 'success' }),
       ReceiptHandle: 'invalid',
     };
+    const valid1: CompletedContactJobBody = {
+      jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+      jobId: 1,
+      accountSid: 'accountSid',
+      attemptNumber: 1,
+      contactId: 123,
+      taskId: 'taskId',
+      twilioWorkerId: 'twilioWorkerId',
+      serviceSid: 'serviceSid',
+      channelSid: 'channelSid',
+      filePath: 'filePath',
+      attemptPayload: 'some-url-here',
+      attemptResult: 'success',
+    };
     const validPayload = {
-      Body: JSON.stringify({
-        jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
-      }),
+      Body: JSON.stringify(valid1),
       ReceiptHandle: 'valid',
     };
 
@@ -50,7 +64,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
       .spyOn(contactJobDataAccess, 'completeContactJob')
       .mockImplementation(async () => 'done' as any);
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs();
+    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(processCompletedRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledTimes(1);
@@ -65,17 +79,29 @@ describe('pollAndprocessCompletedContactJobs', () => {
   });
 
   test('If a job fails, it does not shuts down other jobs', async () => {
+    const valid1: CompletedContactJobBody = {
+      jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+      jobId: 1,
+      accountSid: 'accountSid',
+      attemptNumber: 1,
+      contactId: 123,
+      taskId: 'taskId',
+      twilioWorkerId: 'twilioWorkerId',
+      serviceSid: 'serviceSid',
+      channelSid: 'channelSid',
+      filePath: 'filePath',
+      attemptPayload: 'some-url-here',
+      attemptResult: 'success',
+    };
+
     const validPayload1 = {
-      Body: JSON.stringify({
-        jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
-      }),
+      Body: JSON.stringify(valid1),
       ReceiptHandle: 'valid',
     };
 
+    const valid2 = { ...valid1, jobId: 2, contactId: 321 };
     const validPayload2 = {
-      Body: JSON.stringify({
-        jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
-      }),
+      Body: JSON.stringify(valid2),
       ReceiptHandle: 'valid',
     };
 
@@ -95,7 +121,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
       .spyOn(contactJobDataAccess, 'completeContactJob')
       .mockImplementation(async () => 'done' as any);
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs();
+    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(processCompletedRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(2);
     expect(errorSpy).toHaveBeenCalledTimes(1);
@@ -109,19 +135,24 @@ describe('pollAndprocessCompletedContactJobs', () => {
     expect(result[1].status).toBe('fulfilled');
   });
 
-  const completedJobsList = [
+  const completedJobsList: {
+    job: CompletedContactJobBody;
+    processCompletedFunction: keyof typeof contactJobComplete;
+  }[] = [
     {
       job: {
         jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+        attemptResult: 'success',
         jobId: 1,
         accountSid: 'accountSid',
-        contactId: 'contactId',
+        contactId: 123,
         taskId: 'taskId',
         twilioWorkerId: 'twilioWorkerId',
         serviceSid: 'serviceSid',
         channelSid: 'channelSid',
         filePath: 'filePath',
-        completionPayload: 'completionPayload',
+        attemptNumber: 1,
+        attemptPayload: 'completionPayload',
       },
       processCompletedFunction: 'processCompletedRetrieveContactTranscript',
     },
@@ -136,7 +167,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
   });
 
   each(completedJobsList).test(
-    '$job.jobType job is processed accordingly',
+    '$job.jobType successful job is processed accordingly',
     async ({ job, processCompletedFunction }) => {
       const validPayload = {
         Body: JSON.stringify(job),
@@ -156,11 +187,99 @@ describe('pollAndprocessCompletedContactJobs', () => {
         .spyOn(contactJobDataAccess, 'completeContactJob')
         .mockImplementation(async () => validPayload as any);
 
-      const result = await contactJobComplete.pollAndprocessCompletedContactJobs();
+      const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
       expect(processCompletedFunctionSpy).toHaveBeenCalledWith(job);
-      expect(completeContactJobSpy).toHaveBeenCalledWith(job.jobId, job.completionPayload);
+      expect(completeContactJobSpy).toHaveBeenCalledWith(job.jobId, job.attemptPayload);
       expect(deletedCompletedContactJobsSpy).toHaveBeenCalledWith(validPayload.ReceiptHandle);
+
+      expect(result[0].status).toBe('fulfilled');
+    },
+  );
+
+  const failedJobsList: {
+    job: CompletedContactJobBody;
+    processCompletedFunction: keyof typeof contactJobComplete;
+    expectMarkedAsComplete: boolean;
+  }[] = [
+    {
+      job: {
+        jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+        attemptResult: 'failure',
+        jobId: 1,
+        accountSid: 'accountSid',
+        contactId: 123,
+        taskId: 'taskId',
+        twilioWorkerId: 'twilioWorkerId',
+        serviceSid: 'serviceSid',
+        channelSid: 'channelSid',
+        filePath: 'filePath',
+        attemptNumber: 1,
+        attemptPayload: 'failed attemptPayload',
+      },
+      processCompletedFunction: 'processCompletedRetrieveContactTranscript',
+      expectMarkedAsComplete: false,
+    },
+  ];
+
+  test('Check that we are testing all the possible job types (useful for the next test)', () => {
+    expect(failedJobsList.length).toBe(Object.values(ContactJobType).length);
+
+    Object.values(ContactJobType).forEach(jobType => {
+      expect(failedJobsList.some(({ job }) => job.jobType === jobType)).toBeTruthy();
+    });
+  });
+
+  each(
+    // Per each test case, add an identical one but that should be marked as complete
+    failedJobsList.flatMap(testCase => [
+      testCase,
+      {
+        ...testCase,
+        job: { ...testCase.job, attemptNumber: JOB_MAX_ATTEMPTS },
+        expectMarkedAsComplete: true,
+      },
+    ]),
+  ).test(
+    '$job.jobType failed job is processed accordingly with attempt number $job.attemptNumber',
+    async ({ job, processCompletedFunction, expectMarkedAsComplete }) => {
+      const validPayload = {
+        Body: JSON.stringify(job),
+        ReceiptHandle: 'valid',
+      };
+
+      jest.spyOn(SQSClient, 'pollCompletedContactJobs').mockImplementation(async () => ({
+        Messages: [validPayload],
+      }));
+      const deletedCompletedContactJobsSpy = jest
+        .spyOn(SQSClient, 'deletedCompletedContactJobs')
+        .mockImplementation(async () => {});
+      const processCompletedFunctionSpy = jest
+        .spyOn(contactJobComplete, processCompletedFunction)
+        .mockImplementation(async () => {});
+      const completeContactJobSpy = jest
+        .spyOn(contactJobDataAccess, 'completeContactJob')
+        .mockImplementation(async () => job);
+      const appendFailedAttemptPayloadSpy = jest
+        .spyOn(contactJobDataAccess, 'appendFailedAttemptPayload')
+        .mockImplementation(() => job);
+
+      const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+
+      expect(processCompletedFunctionSpy).not.toHaveBeenCalled();
+      expect(deletedCompletedContactJobsSpy).not.toHaveBeenCalled();
+
+      if (expectMarkedAsComplete) {
+        expect(completeContactJobSpy).toHaveBeenCalledWith(job.jobId, 'Attempts limit reached');
+      } else {
+        expect(completeContactJobSpy).not.toHaveBeenCalled();
+      }
+
+      expect(appendFailedAttemptPayloadSpy).toHaveBeenCalledWith(
+        job.jobId,
+        job.attemptNumber,
+        job.attemptPayload,
+      );
 
       expect(result[0].status).toBe('fulfilled');
     },

--- a/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
+++ b/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
@@ -241,7 +241,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
       },
     ]),
   ).test(
-    '$job.jobType failed job is processed accordingly with attempt number $job.attemptNumber',
+    '$job.jobType failed job is processed accordingly with expectMarkedAsComplete "$job.expectMarkedAsComplete"',
     async ({ job, processCompletedFunction, expectMarkedAsComplete }) => {
       const validPayload = {
         Body: JSON.stringify(job),


### PR DESCRIPTION
Primary reviewer: @stephenhand 

## Description
This PR is a follow up of https://github.com/techmatters/hrm/pull/239.
Here I'm including:
- Handling jobs that are "completed" but with a failure. In this case we also keep track of the payloads on failure.
- Adding max retries so the jobs won't be infinitely attempted. TODO: Exponential backoff.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

### Verification steps
- Trust the tests? :P or

- Start a local server, expose via ngrok, point to it from Flex and save a chat contact.
- Confirm that a new pending job was created, and that it is published on the next iteration of the processor.
- Stop the server and "mock" the polling function to return the same contact job as before, with the same shape as it was published, plus an `attemptNumber === 1`, `attemptResult === 'failed'` and `attemptPayload === <error description>`.
- Run the server again and check that the "faked completed job" is processed accordingly, adding the above payload to the key `1` of the `failedAttemptsPayloads` column.
- Repeat the above two steps with `attemptNumber === 20` and confirm that on top of the above, the job is marked as complete with a failure message.