### PR TITLE
Hide jobs creation and processing behind FF

### DIFF
--- a/hrm-service/setTestEnvVars.js
+++ b/hrm-service/setTestEnvVars.js
@@ -21,3 +21,6 @@ process.env.PERMISSIONS_notConfigured = '';
 process.env.PERMISSIONS_notExistsInRulesMap = 'notExistsInRulesMap';
 
 process.env.INCLUDE_ERROR_IN_RESPONSE = true;
+
+process.env.ENABLE_CREATE_CONTACT_JOBS = true;
+process.env.ENABLE_PROCESS_CONTACT_JOBS = true;

--- a/hrm-service/src/app.ts
+++ b/hrm-service/src/app.ts
@@ -10,6 +10,7 @@ import { Permissions, setupPermissions } from './permissions';
 import { jsonPermissions } from './permissions/json-permissions';
 import { getAuthorizationMiddleware, addAccountSid } from './middlewares';
 import { processContactJobs } from './contact-job/contact-job-processor';
+import { enableProcessContactJobsFlag } from './featureFlags';
 
 type ServiceCreationOptions = Partial<{
   permissions: Permissions;
@@ -20,7 +21,7 @@ type ServiceCreationOptions = Partial<{
 export function createService({
   permissions = jsonPermissions,
   authTokenLookup,
-  enableProcessContactJobs = true,
+  enableProcessContactJobs = enableProcessContactJobsFlag,
 }: ServiceCreationOptions = {}) {
   const app = express();
 

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -1,4 +1,5 @@
 import { db } from '../connection-pool';
+import { enableCreateContactJobsFlag } from '../featureFlags';
 import {
   APPEND_MEDIA_URL_SQL,
   UPDATE_CASEID_BY_ID,
@@ -159,7 +160,7 @@ export const create = async (
       { csamReportIds },
     );
 
-    if (isChatChannel(created.channel)) {
+    if (enableCreateContactJobsFlag && isChatChannel(created.channel)) {
       await createContactJob(connection)({
         jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
         resource: created,

--- a/hrm-service/src/featureFlags.ts
+++ b/hrm-service/src/featureFlags.ts
@@ -1,0 +1,2 @@
+export const enableCreateContactJobsFlag = /^true$/i.test(process.env.ENABLE_CREATE_CONTACT_JOBS);
+export const enableProcessContactJobsFlag = /^true$/i.test(process.env.ENABLE_PROCESS_CONTACT_JOBS);


### PR DESCRIPTION
## Description
Hides the processing and creation of jobs in feature flags. For now the FF are brought from env vars (we use them locally anyways), but this could be a file being injected before compile step in deploy actions. 

### Verification steps
- Check tests are fine.
- Start server and check no jobs are created or processed.
- Hardcode the FF as true, recompile, start server and check jobs are created and processed.