### PR TITLE
[WIP] Implement permissions for access to externally stored transcripts

### DIFF
--- a/hrm-service/permission-rules/br.json
+++ b/hrm-service/permission-rules/br.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/ca.json
+++ b/hrm-service/permission-rules/ca.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/cl.json
+++ b/hrm-service/permission-rules/cl.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["everyone"]],
 "editFollowUpDate":  [["everyone"]],
 "editContact":  [["everyone"]],
-"viewPostSurvey":  [["isSupervisor"]]
+"viewPostSurvey":  [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/co.json
+++ b/hrm-service/permission-rules/co.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
-"viewPostSurvey": [["isSupervisor"]]
+"viewPostSurvey": [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/demo.json
+++ b/hrm-service/permission-rules/demo.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["everyone"]]
 }

--- a/hrm-service/permission-rules/dev.json
+++ b/hrm-service/permission-rules/dev.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["everyone"]]
 }

--- a/hrm-service/permission-rules/e2e.json
+++ b/hrm-service/permission-rules/e2e.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/et.json
+++ b/hrm-service/permission-rules/et.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/hu.json
+++ b/hrm-service/permission-rules/hu.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/in.json
+++ b/hrm-service/permission-rules/in.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/jm.json
+++ b/hrm-service/permission-rules/jm.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/mw.json
+++ b/hrm-service/permission-rules/mw.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/open.json
+++ b/hrm-service/permission-rules/open.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["everyone"]],
   "editFollowUpDate": [["everyone"]],
   "editContact": [["everyone"]],
-  "viewPostSurvey": [["everyone"]]
+  "viewPostSurvey": [["everyone"]],
+  "viewExternalTranscript": [["everyone"]]
 }

--- a/hrm-service/permission-rules/ph.json
+++ b/hrm-service/permission-rules/ph.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/pl.json
+++ b/hrm-service/permission-rules/pl.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/ro.json
+++ b/hrm-service/permission-rules/ro.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"], ["isOwner"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/th.json
+++ b/hrm-service/permission-rules/th.json
@@ -18,5 +18,6 @@
 "editChildIsAtRisk":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editFollowUpDate":  [["isSupervisor"],["isCreator", "isCaseOpen"]],
 "editContact":  [["isSupervisor"],["isOwner"]],
-"viewPostSurvey":  [["isSupervisor"]]
+"viewPostSurvey":  [["isSupervisor"]],
+"viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/uk.json
+++ b/hrm-service/permission-rules/uk.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/za.json
+++ b/hrm-service/permission-rules/za.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/permission-rules/zm.json
+++ b/hrm-service/permission-rules/zm.json
@@ -18,5 +18,6 @@
   "editChildIsAtRisk": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editFollowUpDate": [["isSupervisor"], ["isCreator", "isCaseOpen"]],
   "editContact": [["isSupervisor"]],
-  "viewPostSurvey": [["isSupervisor"]]
+  "viewPostSurvey": [["isSupervisor"]],
+  "viewExternalTranscript": [["isSupervisor"]]
 }

--- a/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-service/service-tests/contacts.test.ts
@@ -1,7 +1,7 @@
 import supertest from 'supertest';
 import * as Sequelize from 'sequelize';
 // eslint-disable-next-line prettier/prettier
-import type { ContactRawJson } from '../src/contact/contact-json';
+import { ContactMediaType, ContactRawJson } from '../src/contact/contact-json';
 import { createService } from '../src/app';
 const models = require('../src/models');
 import {
@@ -16,19 +16,18 @@ import {
   withTaskId,
   case1,
   case2,
-  workerSid, nonData2, nonData1,
+  workerSid,
+  nonData2,
+  nonData1,
 } from './mocks';
-import each  from 'jest-each';
+import each from 'jest-each';
 import { db } from '../src/connection-pool';
 import { subHours, subDays } from 'date-fns';
 
 import './case-validation';
 import * as caseApi from '../src/case/case';
 import * as caseDb from '../src/case/case-data-access';
-import {
-  CreateContactPayloadWithFormProperty,
-  PatchPayload,
-} from '../src/contact/contact';
+import { CreateContactPayloadWithFormProperty, PatchPayload } from '../src/contact/contact';
 import * as contactApi from '../src/contact/contact';
 import * as contactDb from '../src/contact/contact-data-access';
 import { openPermissions } from '../src/permissions/json-permissions';
@@ -38,9 +37,7 @@ import { chatChannels } from '../src/contact/channelTypes';
 import * as contactInsertSql from '../src/contact/sql/contact-insert-sql';
 import { selectSingleContactByTaskId } from '../src/contact/sql/contact-get-sql';
 
-
 const { form, ...contact1WithRawJsonProp } = contact1 as CreateContactPayloadWithFormProperty;
-
 
 const server = createService({
   permissions: openPermissions,
@@ -94,11 +91,8 @@ const cleanupContactsJobs = () =>
   );
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
-const getContactByTaskId = (taskId: string, accountSid: string) => 
-  db.oneOrNone(
-    selectSingleContactByTaskId('Contacts'),
-    { accountSid, taskId },
-  );
+const getContactByTaskId = (taskId: string, accountSid: string) =>
+  db.oneOrNone(selectSingleContactByTaskId('Contacts'), { accountSid, taskId });
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
 const deleteContactById = (id: number, accountSid: string) =>
@@ -119,14 +113,13 @@ const deleteContactJobById = (id: number, accountSid: string) =>
   );
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
-const selectJobsByContactId = (contactId: number, accountSid: string) => 
+const selectJobsByContactId = (contactId: number, accountSid: string) =>
   db.task(t =>
     t.manyOrNone(`
       SELECT * FROM "ContactJobs"
       WHERE "contactId" = ${contactId} AND "accountSid" = '${accountSid}';
     `),
   );
-
 
 const query = {
   where: {
@@ -296,7 +289,6 @@ describe('/contacts route', () => {
         .set(headers)
         .send({ ...contact1, csamReports: [notExistingCsamReport] });
 
-
       // Test the association
       expect(response.status).toBe(200);
 
@@ -312,7 +304,6 @@ describe('/contacts route', () => {
     });
 
     test('Connects to CSAM reports (valid csam reports ids)', async () => {
-
       // Create CSAM Report
       const csamReportId1 = 'csam-report-id-1';
       const csamReportId2 = 'csam-report-id-2';
@@ -362,8 +353,23 @@ describe('/contacts route', () => {
     each(
       chatChannels.map(channel => ({
         channel,
-        contact: { ...withTaskId, channel, taskId: `${withTaskId.taskId}-${channel}` },
-      }))).test(
+        contact: {
+          ...withTaskId,
+          form: {
+            ...withTaskId.form,
+            conversationMedia: [
+              {
+                store: 'S3',
+                type: ContactMediaType.TRANSCRIPT,
+                url: undefined,
+              },
+            ],
+          },
+          channel,
+          taskId: `${withTaskId.taskId}-${channel}`,
+        },
+      })),
+    ).test(
       `contacts with channel type $channel should create ${contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT} job`,
       async ({ contact }) => {
         const res = await request
@@ -372,30 +378,36 @@ describe('/contacts route', () => {
           .send(contact);
 
         expect(res.status).toBe(200);
-        
+
         const createdContact = await contactDb.getById(accountSid, res.body.id);
         const jobs = await selectJobsByContactId(createdContact.id, createdContact.accountSid);
 
-        const retrieveContactTranscriptJobs = jobs.filter(j => j.jobType === contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT);
+        const retrieveContactTranscriptJobs = jobs.filter(
+          j => j.jobType === contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+        );
         expect(retrieveContactTranscriptJobs).toHaveLength(1);
 
         // Test that idempotence applies to jobs too
         const res2 = await request
-        .post(route)
-        .set(headers)
-        .send(contact);
+          .post(route)
+          .set(headers)
+          .send(contact);
 
         expect(res2.status).toBe(200);
         const jobs2 = await selectJobsByContactId(res.body.id, res.body.accountSid);
 
-        const retrieveContactTranscriptJobs2 = jobs2.filter(j => j.jobType === contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT);
+        const retrieveContactTranscriptJobs2 = jobs2.filter(
+          j => j.jobType === contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
+        );
         expect(retrieveContactTranscriptJobs2).toHaveLength(1);
 
         const attemptedContact = await getContactByTaskId(contact.taskId, accountSid);
 
         expect(attemptedContact).not.toBeNull();
 
-        await Promise.all(retrieveContactTranscriptJobs.map(j => deleteContactJobById(j.id, j.accountSid)));
+        await Promise.all(
+          retrieveContactTranscriptJobs.map(j => deleteContactJobById(j.id, j.accountSid)),
+        );
         await deleteContactById(res.body.id, res.body.accountSid);
       },
     );
@@ -403,13 +415,30 @@ describe('/contacts route', () => {
     each(
       chatChannels.map(channel => ({
         channel,
-        contact: { ...withTaskId, channel, taskId: `${withTaskId.taskId}-${channel}` },
-      }))).test(
+        contact: {
+          ...withTaskId,
+          form: {
+            ...withTaskId.form,
+            conversationMedia: [
+              {
+                store: 'S3',
+                type: ContactMediaType.TRANSCRIPT,
+                url: undefined,
+              },
+            ],
+          },
+          channel,
+          taskId: `${withTaskId.taskId}-${channel}`,
+        },
+      })),
+    ).test(
       `if contact with channel type $channel is not created, neither is ${contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT} job`,
       async ({ contact }) => {
-        const insertContactSqlSpy = jest.spyOn(contactInsertSql, 'insertContactSql').mockImplementationOnce(() => {
-          throw new Error('Ups');
-        });
+        const insertContactSqlSpy = jest
+          .spyOn(contactInsertSql, 'insertContactSql')
+          .mockImplementationOnce(() => {
+            throw new Error('Ups');
+          });
 
         const createContactJobSpy = jest.spyOn(contactJobDataAccess, 'createContactJob');
 
@@ -419,7 +448,7 @@ describe('/contacts route', () => {
           .send(contact);
 
         expect(res.status).toBe(500);
-        
+
         expect(createContactJobSpy).not.toHaveBeenCalled();
 
         const attemptedContact = await getContactByTaskId(contact.taskId, accountSid);
@@ -434,13 +463,30 @@ describe('/contacts route', () => {
     each(
       chatChannels.map(channel => ({
         channel,
-        contact: { ...withTaskId, channel, taskId: `${withTaskId.taskId}-${channel}` },
-      }))).test(
+        contact: {
+          ...withTaskId,
+          form: {
+            ...withTaskId.form,
+            conversationMedia: [
+              {
+                store: 'S3',
+                type: ContactMediaType.TRANSCRIPT,
+                url: undefined,
+              },
+            ],
+          },
+          channel,
+          taskId: `${withTaskId.taskId}-${channel}`,
+        },
+      })),
+    ).test(
       `if ${contactJobDataAccess.ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT} job creation fails with channel type $channel, the contact is not created either`,
       async ({ contact }) => {
-        const createContactJobSpy = jest.spyOn(contactJobDataAccess, 'createContactJob').mockImplementationOnce(() => {
-          throw new Error('Ups');
-        });
+        const createContactJobSpy = jest
+          .spyOn(contactJobDataAccess, 'createContactJob')
+          .mockImplementationOnce(() => {
+            throw new Error('Ups');
+          });
 
         const res = await request
           .post(route)
@@ -448,7 +494,7 @@ describe('/contacts route', () => {
           .send(contact);
 
         expect(res.status).toBe(500);
-        
+
         const attemptedContact = await getContactByTaskId(contact.taskId, accountSid);
 
         expect(attemptedContact).toBeNull();
@@ -570,7 +616,9 @@ describe('/contacts route', () => {
           },
         });
 
-        await Promise.all(createdContacts.filter(c => c.id).map(c => deleteContactById(c.id, c.accountSid)));
+        await Promise.all(
+          createdContacts.filter(c => c.id).map(c => deleteContactById(c.id, c.accountSid)),
+        );
       });
 
       each([
@@ -657,7 +705,8 @@ describe('/contacts route', () => {
           },
         },
         {
-          changeDescription: 'multiple input search without name search excluding non data contacts',
+          changeDescription:
+            'multiple input search without name search excluding non data contacts',
           body: { counselor: workerSid, onlyDataContacts: true }, // should match contact1 & broken1 & another1 & noHelpline
           expectCallback: response => {
             const { contacts } = response.body;
@@ -667,14 +716,18 @@ describe('/contacts route', () => {
             expect(contacts.length).toBe(createdContacts.length - 5);
             const createdContactsByTimeOfContact = createdContacts.sort(compareTimeOfContactDesc);
             createdContactsByTimeOfContact
-              .filter((c) => ['Child calling about self', 'Someone calling about a child'].includes(c.rawJson?.callType))
-              .forEach((c)=> {
-              const searchContact = contacts.find(results => results.contactId === c.id);
-              if (searchContact) {
-                // Check that all contacts contains the appropriate info
-                expect(c.rawJson).toMatchObject(searchContact.details);
-              }
-            });
+              .filter(c =>
+                ['Child calling about self', 'Someone calling about a child'].includes(
+                  c.rawJson?.callType,
+                ),
+              )
+              .forEach(c => {
+                const searchContact = contacts.find(results => results.contactId === c.id);
+                if (searchContact) {
+                  // Check that all contacts contains the appropriate info
+                  expect(c.rawJson).toMatchObject(searchContact.details);
+                }
+              });
           },
         },
         ...[
@@ -860,7 +913,11 @@ describe('/contacts route', () => {
       const subRoute = contactId => `${route}/${contactId}`;
 
       test('should return 401', async () => {
-        const createdContact = await contactApi.createContact(accountSid, workerSid, { ...contact1, form: <ContactRawJson>{}, csamReports: [] });
+        const createdContact = await contactApi.createContact(accountSid, workerSid, {
+          ...contact1,
+          form: <ContactRawJson>{},
+          csamReports: [],
+        });
         try {
           const response = await request.patch(subRoute(createdContact.id)).send({});
 
@@ -1085,8 +1142,11 @@ describe('/contacts route', () => {
         ]).test(
           'should $description if that is specified in the payload',
           async ({ patch, original, expected }: TestOptions) => {
-
-            const createdContact = await contactApi.createContact(accountSid, workerSid, { ...contact1WithRawJsonProp, rawJson: original || <ContactRawJson>{}, csamReports: [] });
+            const createdContact = await contactApi.createContact(accountSid, workerSid, {
+              ...contact1WithRawJsonProp,
+              rawJson: original || <ContactRawJson>{},
+              csamReports: [],
+            });
             try {
               const existingContactId = createdContact.id;
               const response = await request
@@ -1106,10 +1166,7 @@ describe('/contacts route', () => {
               });
               // Test the association
               expect(response.body.csamReports).toHaveLength(0);
-              const savedContact = await contactDb.getById(
-                accountSid,
-                existingContactId,
-              );
+              const savedContact = await contactDb.getById(accountSid, existingContactId);
 
               expect(savedContact).toStrictEqual({
                 ...createdContact,
@@ -1127,28 +1184,36 @@ describe('/contacts route', () => {
       });
 
       test('use non-existent contactId should return 404', async () => {
-        const contactToBeDeleted = await contactApi.createContact(accountSid, workerSid, <any>contact1);
+        const contactToBeDeleted = await contactApi.createContact(
+          accountSid,
+          workerSid,
+          <any>contact1,
+        );
         const nonExistingContactId = contactToBeDeleted.id;
         await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
         const response = await request
-        .patch(subRoute(nonExistingContactId))
-        .set(headers)
-        .send({
+          .patch(subRoute(nonExistingContactId))
+          .set(headers)
+          .send({
             rawJson: {
               name: { firstName: 'Lorna', lastName: 'Ballantyne' },
               some: 'property',
             },
           });
 
-          expect(response.status).toBe(404);
-        });
+        expect(response.status).toBe(404);
+      });
 
-        test('malformed payload should return 400', async () => {
-        const contactToBeDeleted = await contactApi.createContact(accountSid, workerSid, <any>contact1);
+      test('malformed payload should return 400', async () => {
+        const contactToBeDeleted = await contactApi.createContact(
+          accountSid,
+          workerSid,
+          <any>contact1,
+        );
         const nonExistingContactId = contactToBeDeleted.id;
         await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
         const response = await request
-        .patch(subRoute(nonExistingContactId))
+          .patch(subRoute(nonExistingContactId))
           .set(headers)
           .send({
             notRawJson: { some: 'crap' },
@@ -1158,16 +1223,20 @@ describe('/contacts route', () => {
       });
 
       test('no body should return 400', async () => {
-        const contactToBeDeleted = await contactApi.createContact(accountSid, workerSid, <any>contact1);
+        const contactToBeDeleted = await contactApi.createContact(
+          accountSid,
+          workerSid,
+          <any>contact1,
+        );
         const nonExistingContactId = contactToBeDeleted.id;
         await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
         const response = await request
-        .patch(subRoute(nonExistingContactId))
+          .patch(subRoute(nonExistingContactId))
           .set(headers)
           .send();
 
-          expect(response.status).toBe(400);
-        });
+        expect(response.status).toBe(400);
+      });
     });
   });
 
@@ -1187,7 +1256,11 @@ describe('/contacts route', () => {
       createdContact = await contactApi.createContact(accountSid, workerSid, <any>contact1);
       createdCase = await caseApi.createCase(case1, accountSid, workerSid);
       anotherCreatedCase = await caseApi.createCase(case2, accountSid, workerSid);
-      const contactToBeDeleted = await contactApi.createContact(accountSid, workerSid, <any>contact1);
+      const contactToBeDeleted = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        <any>contact1,
+      );
       const caseToBeDeleted = await caseApi.createCase(case1, accountSid, workerSid);
 
       existingContactId = createdContact.id;

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -12,10 +12,10 @@ import {
   CompletedRetrieveContactTranscript,
 } from './contact-job-messages';
 import {
-  isS3StoredTranscript,
   getContactById,
   updateConversationMedia,
   S3StoredTranscript,
+  isS3StoredTranscriptPending,
 } from '../contact/contact';
 import { assertExhaustive } from './assertExhaustive';
 
@@ -25,7 +25,7 @@ export const processCompletedRetrieveContactTranscript = async (
   const contact = await getContactById(completedJob.accountSid, completedJob.contactId);
   const { conversationMedia } = contact.rawJson;
 
-  const transcriptEntryIndex = conversationMedia?.findIndex(m => isS3StoredTranscript(m) && !m.url);
+  const transcriptEntryIndex = conversationMedia?.findIndex(isS3StoredTranscriptPending);
 
   if (transcriptEntryIndex < 0) {
     throw new Error(

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -1,15 +1,15 @@
 import { db } from '../connection-pool';
 import { enableCreateContactJobsFlag } from '../featureFlags';
 import {
-  APPEND_MEDIA_URL_SQL,
   UPDATE_CASEID_BY_ID,
   UPDATE_RAWJSON_BY_ID,
+  UPDATE_CONVERSATION_MEDIA_BY_ID,
 } from './sql/contact-update-sql';
 import { SELECT_CONTACT_SEARCH } from './sql/contact-search-sql';
 import { endOfDay, parseISO, startOfDay } from 'date-fns';
 import { selectSingleContactByIdSql, selectSingleContactByTaskId } from './sql/contact-get-sql';
 import { insertContactSql, NewContactRecord } from './sql/contact-insert-sql';
-import { ContactMediaUrl, PersonInformation } from './contact-json';
+import { ContactRawJson, PersonInformation } from './contact-json';
 import { createContactJob, ContactJobType } from '../contact-job/contact-job-data-access';
 import { isChatChannel } from './channelTypes';
 
@@ -227,11 +227,15 @@ export const search = async (
   });
 };
 
-export const appendMediaUrls = async (
+export const updateConversationMedia = async (
   accountSid: string,
   contactId: number,
-  mediaUrls: ContactMediaUrl[],
+  conversationMedia: ContactRawJson['conversationMedia'],
 ): Promise<void> =>
   db.task(async connection =>
-    connection.none(APPEND_MEDIA_URL_SQL, { accountSid, contactId, mediaUrls }),
+    connection.none(UPDATE_CONVERSATION_MEDIA_BY_ID, {
+      accountSid,
+      contactId,
+      conversationMedia,
+    }),
   );

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -9,7 +9,7 @@ import { SELECT_CONTACT_SEARCH } from './sql/contact-search-sql';
 import { endOfDay, parseISO, startOfDay } from 'date-fns';
 import { selectSingleContactByIdSql, selectSingleContactByTaskId } from './sql/contact-get-sql';
 import { insertContactSql, NewContactRecord } from './sql/contact-insert-sql';
-import { ContactRawJson, isS3StoredTranscript, isS3StoredTranscriptPending, PersonInformation } from './contact-json';
+import { ContactRawJson, isS3StoredTranscriptPending, PersonInformation } from './contact-json';
 import { createContactJob, ContactJobType } from '../contact-job/contact-job-data-access';
 import { isChatChannel } from './channelTypes';
 

--- a/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-service/src/contact/contact-data-access.ts
@@ -9,7 +9,7 @@ import { SELECT_CONTACT_SEARCH } from './sql/contact-search-sql';
 import { endOfDay, parseISO, startOfDay } from 'date-fns';
 import { selectSingleContactByIdSql, selectSingleContactByTaskId } from './sql/contact-get-sql';
 import { insertContactSql, NewContactRecord } from './sql/contact-insert-sql';
-import { ContactRawJson, PersonInformation } from './contact-json';
+import { ContactRawJson, isS3StoredTranscript, isS3StoredTranscriptPending, PersonInformation } from './contact-json';
 import { createContactJob, ContactJobType } from '../contact-job/contact-job-data-access';
 import { isChatChannel } from './channelTypes';
 
@@ -160,7 +160,11 @@ export const create = async (
       { csamReportIds },
     );
 
-    if (enableCreateContactJobsFlag && isChatChannel(created.channel)) {
+    if (
+      enableCreateContactJobsFlag &&
+      isChatChannel(created.channel) &&
+      created.rawJson?.conversationMedia?.some(isS3StoredTranscriptPending)
+    ) {
       await createContactJob(connection)({
         jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
         resource: created,

--- a/hrm-service/src/contact/contact-json.ts
+++ b/hrm-service/src/contact/contact-json.ts
@@ -28,6 +28,8 @@ export const isTwilioStoredMedia = (m: ConversationMedia): m is TwilioStoredMedi
   m.store === 'twilio';
 export const isS3StoredTranscript = (m: ConversationMedia): m is S3StoredTranscript =>
   m.store === 'S3' && m.type === ContactMediaType.TRANSCRIPT;
+export const isS3StoredTranscriptPending = (m: ConversationMedia) =>
+  isS3StoredTranscript(m) && !m.url;
 
 /**
  * This and contained types are copied from Flex

--- a/hrm-service/src/contact/contact-json.ts
+++ b/hrm-service/src/contact/contact-json.ts
@@ -4,12 +4,30 @@ export type PersonInformation = NestedInformation & {
   [key: string]: string | boolean | NestedInformation[keyof NestedInformation]; // having NestedInformation[keyof NestedInformation] makes type looser here because of this https://github.com/microsoft/TypeScript/issues/17867. Possible/future solution https://github.com/microsoft/TypeScript/pull/29317
 };
 
-export const enum ContactMediaType {
-  RECORDING = 'recording',
+export type TwilioStoredMedia = {
+  store: 'twilio';
+  reservationSid: string;
+};
+
+export enum ContactMediaType {
+  // RECORDING = 'recording',
   TRANSCRIPT = 'transcript',
 }
 
-export type ContactMediaUrl = { url: string; type: ContactMediaType };
+export type S3StoredTranscript = {
+  store: 'S3';
+  type: ContactMediaType.TRANSCRIPT;
+  url?: string;
+};
+
+type S3StoredMedia = S3StoredTranscript;
+
+export type ConversationMedia = TwilioStoredMedia | S3StoredMedia;
+
+export const isTwilioStoredMedia = (m: ConversationMedia): m is TwilioStoredMedia =>
+  m.store === 'twilio';
+export const isS3StoredTranscript = (m: ConversationMedia): m is S3StoredTranscript =>
+  m.store === 'S3' && m.type === ContactMediaType.TRANSCRIPT;
 
 /**
  * This and contained types are copied from Flex
@@ -24,5 +42,5 @@ export type ContactRawJson = {
     [key: string]: string | boolean | Record<string, Record<string, boolean>>;
   };
   contactlessTask?: { [key: string]: string | boolean };
-  mediaUrls?: ContactMediaUrl[];
+  conversationMedia?: ConversationMedia[];
 };

--- a/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-service/src/contact/contact-routes-v0.ts
@@ -1,17 +1,40 @@
-import { SafeRouter, publicEndpoint, actionsMaps } from '../permissions';
+import { SafeRouter, publicEndpoint, actionsMaps, User } from '../permissions';
 import createError from 'http-errors';
-import { patchContact, connectContactToCase, searchContacts, createContact, getContactById, Contact } from './contact';
+import { patchContact, connectContactToCase, searchContacts, createContact, getContactById, Contact, isS3StoredTranscript } from './contact';
 import { asyncHandler } from '../utils';
 // eslint-disable-next-line prettier/prettier
 import type { Request, Response, NextFunction } from 'express';
+import { setupCanForRules } from '../permissions/setupCanForRules';
 
 const contactsRouter = SafeRouter();
+
+const filterExternalTranscripts = (contact: Contact) => ({ ...contact, rawJson: { ...contact.rawJson, conversationMedia: contact.rawJson.conversationMedia?.filter(m => !isS3StoredTranscript(m)) } });
+
+/**
+ * In contrast to other permission based functions that are middlewares,
+ * this function is applied after the contact records are brought from the DB,
+ * stripping certain properties based on the permissions.
+ * This rules are defined here so they have better visibility,
+ * but this function is "injected" into the business layer that's where we have access to the "raw contact entities".
+ */
+export const applyContactPermissionsBasedTransformer = (can: ReturnType<typeof setupCanForRules>, user: User) =>  (contact: Contact) => {
+  let result: Contact = contact;
+
+  // Filters the external transcript records if user does not have permission on this contact
+  if (!can(user, actionsMaps.contact.VIEW_EXTERNAL_TRANSCRIPT, contact)) {
+    result = filterExternalTranscripts(result);
+  }
+
+  return result;
+};
 
 // example: curl -XPOST -H'Content-Type: application/json' localhost:3000/contacts -d'{"hi": 2}'
 contactsRouter.post('/', publicEndpoint, async (req, res) => {
   const { accountSid, user } = req;
 
-  const contact = await createContact(accountSid, user.workerSid, req.body);
+  const contactPermissionsBasedTransformer = applyContactPermissionsBasedTransformer(req.can, user);
+
+  const contact = await createContact(accountSid, user.workerSid, req.body, contactPermissionsBasedTransformer);
   res.json(contact);
 });
 
@@ -19,12 +42,16 @@ contactsRouter.put('/:contactId/connectToCase', publicEndpoint, async (req, res)
   const { accountSid, user } = req;
   const { contactId } = req.params;
   const { caseId } = req.body;
+
+  const contactPermissionsBasedTransformer = applyContactPermissionsBasedTransformer(req.can, user);
+
   try {
     const updatedContact = await connectContactToCase(
       accountSid,
       user.workerSid,
       contactId,
       caseId,
+      contactPermissionsBasedTransformer,
     );
     res.json(updatedContact);
   } catch (err) {
@@ -39,7 +66,10 @@ contactsRouter.put('/:contactId/connectToCase', publicEndpoint, async (req, res)
 
 contactsRouter.post('/search', publicEndpoint, async (req, res) => {
   const { accountSid } = req;
-  const searchResults = await searchContacts(accountSid, req.body, req.query);
+
+  const contactPermissionsBasedTransformer = applyContactPermissionsBasedTransformer(req.can, req.user);
+
+  const searchResults = await searchContacts(accountSid, req.body, req.query, contactPermissionsBasedTransformer);
   res.json(searchResults);
 });
 
@@ -65,7 +95,7 @@ const canEditContact = asyncHandler(async (req, res, next) => {
         req.unauthorize();
       }
     } catch (err) {
-      if (err instanceof Error && err.message.includes('Contact not found')) {
+      if (err instanceof Error && err.message.toLowerCase().includes('contact not found')) {
         throw createError(404);
       } else {
         throw createError(500);
@@ -80,8 +110,11 @@ const canEditContact = asyncHandler(async (req, res, next) => {
 contactsRouter.patch('/:contactId', validatePatchPayload, canEditContact, async (req, res) => {
   const { accountSid, user } = req;
   const { contactId } = req.params;
+
+  const contactPermissionsBasedTransformer = applyContactPermissionsBasedTransformer(req.can, req.user);
+
   try {
-    const contact = await patchContact(accountSid, user.workerSid, contactId, req.body);
+    const contact = await patchContact(accountSid, user.workerSid, contactId, req.body, contactPermissionsBasedTransformer);
     res.json(contact);
   } catch (err) {
     if (err.message.toLowerCase().includes('contact not found')) {

--- a/hrm-service/src/contact/contact.ts
+++ b/hrm-service/src/contact/contact.ts
@@ -2,6 +2,7 @@ import {
   connectToCase,
   Contact,
   create,
+  getById,
   patch,
   search,
   SearchParameters,
@@ -11,7 +12,8 @@ import { retrieveCategories, getPaginationElements } from '../controllers/helper
 import { NewContactRecord } from './sql/contact-insert-sql';
 
 // Re export as is:
-export { appendMediaUrls, Contact } from './contact-data-access';
+export { updateConversationMedia, Contact } from './contact-data-access';
+export * from './contact-json';
 
 export type PatchPayload = {
   rawJson: Partial<
@@ -59,6 +61,16 @@ export type CreateContactPayload =
 export const usesFormProperty = (
   p: CreateContactPayload,
 ): p is CreateContactPayloadWithFormProperty => (<any>p).form && !(<any>p).rawJson;
+
+export const getContactById = async (accountSid: string, contactId: number) => {
+  const contact = await getById(accountSid, contactId);
+
+  if (!contact) {
+    throw new Error(`Contact not found with id ${contactId}`);
+  }
+
+  return contact;
+};
 
 export const createContact = async (
   accountSid: string,

--- a/hrm-service/src/contact/sql/contact-update-sql.ts
+++ b/hrm-service/src/contact/sql/contact-update-sql.ts
@@ -50,9 +50,9 @@ RETURNING *
 ${selectSingleContactByIdSql('updated')}
 `;
 
-export const APPEND_MEDIA_URL_SQL = `
+export const UPDATE_CONVERSATION_MEDIA_BY_ID = `
   UPDATE "Contacts"
   SET
-    "rawJson" = COALESCE("rawJson", '{}'::JSONB) || jsonb_build_object('mediaUrls', COALESCE("rawJson"->'mediaUrls', '[]'::JSONB) || $<mediaUrls:json>::JSONB)
+    "rawJson" = COALESCE("rawJson", '{}'::JSONB) || jsonb_build_object('conversationMedia', COALESCE($<conversationMedia:json>::JSONB, "rawJson"->'conversationMedia', '[]'::JSONB))
   ${ID_WHERE_CLAUSE}
 `;

--- a/hrm-service/src/permissions/actions.ts
+++ b/hrm-service/src/permissions/actions.ts
@@ -23,6 +23,7 @@ export const actionsMaps = {
   },
   contact: {
     EDIT_CONTACT: 'editContact',
+    VIEW_EXTERNAL_TRANSCRIPT: 'viewExternalTranscript',
   },
   postSurvey: {
     VIEW_POST_SURVEY: 'viewPostSurvey',


### PR DESCRIPTION
## Description
This PR
- Introduces `viewExternalTranscript` action to our permissions framework.
- Adds values for the above to all the existing permissions rules.
- Filters transcripts entries from contacts accordingly from all the `/contacts` endpoints.
- [WIP] Filters transcript entries accordingly from all the `/cases` endpoints.

This is not the permission based behavior we've been using so far (where the request is rejected before reaching the function that handles it, via middlewares). Instead we want to "transform" the results accordingly. For this purpose, in this PR I'm "injecting" the function that captures the required permissions based transformations on a contact, from the presentation into the business layer. I think this will be the easiest way going forward, as more transformations of the same kind could be abstracted within the same function with very little effort. The downside of this is that we'll need to be very disciplined about doing this transformations in future functions/endpoints. 
After some talking with @robert-bo-davis, some deeper layer might be a better place to do this transformations. I'd like to receive early feedback here:
- Is this approach good to you?
- Are there some major concerns that should be addressed now?
- Are there some improvements that you suggest doing in the future?

(Correct me here if I misunderstood :P) As @stephenhand mentioned during standup, the fact that this change requires us to modify not only all the `/contacts`, but also all the `/cases` endpoints is a consequence of our unintended "horizontal dependencies", where contacts associated with a case are just bundled with the case. Instead, we could/should eventually re-design the way our API exposes related entities, by just sending the contacts ids from `/cases` endpoints, and leveraging to the frontend the responsibility of fetching the relevant contacts for that matter, via the `/contacts` endpoints, making our entities to be more "self contained". Same is true for all other relations in our system (CaseSections to Cases, CSAMReports to Contacts).

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1102)
- [x] New tests added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
