### PR TITLE
fix: jobs e2e test regression

### DIFF
--- a/jobs/contact-retrieve-transcript/tests/e2e/contact-retrieve-transcript.test.ts
+++ b/jobs/contact-retrieve-transcript/tests/e2e/contact-retrieve-transcript.test.ts
@@ -23,7 +23,7 @@ const s3 = new S3({
 });
 
 const sqs = new SQS({
-  region: 'eu-west-1',
+  endpoint: localstackEndpoint,
 });
 
 const lambdaName = 'contact-retrieve-transcript';
@@ -79,6 +79,7 @@ describe('contact-retrieve-transcript', () => {
 
   test('well formed message creates success message in complete queue and file in s3', async () => {
     const message = generateMockMessageBody();
+
     const sqsResp = await sendMessage({ message, lambdaName });
     expect(sqsResp).toHaveProperty('MessageId');
 
@@ -101,6 +102,7 @@ describe('contact-retrieve-transcript', () => {
   test('message with bad accountSid produces failure message in complete queue', async () => {
     const message = { ...generateMockMessageBody(), accountSid: 'badSid' };
     const sqsResp = await sendMessage({ message, lambdaName });
+
     expect(sqsResp).toHaveProperty('MessageId');
 
     const sqsResult = await waitForSQSMessage();

--- a/jobs/tests/sendMessage.ts
+++ b/jobs/tests/sendMessage.ts
@@ -9,7 +9,6 @@ export const sendMessage = async ({
   message: object;
 }) => {
   const sqs = new SQS({
-    region: 'eu-west-1',
     endpoint: 'http://localstack:4566',
   });
 


### PR DESCRIPTION
## Description
This fixes an issue in the sqs client for localstack that is used in local e2e tests where region was breaking use of the localstack endpoint.

### Verification steps
run `npm run test:e2e` locally.
