### PR TITLE
Fix lambda deploy action regressions

### DIFF
--- a/.github/workflows/hrm-lambda-release.yml
+++ b/.github/workflows/hrm-lambda-release.yml
@@ -91,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          file: ./lambdas/Dockerfile
+          file: ./jobs/Dockerfile
           build-args: |
             lambda_name=${{ env.LAMBDA_NAME }}
           push: true

--- a/.github/workflows/hrm-lambda-release.yml
+++ b/.github/workflows/hrm-lambda-release.yml
@@ -73,7 +73,7 @@ jobs:
           case "$ENVIRONMENT" in development) region="us-east-1" ;; staging) region="us-east-1" ;; production) region="us-east-1" ;; *) echo "Invalid environment: ${{ inputs.environment }}" && exit 1 ;; esac
           echo AWS_REGION=$region >> $GITHUB_ENV
           echo AWS_DEFAULT_REGION=$region >> $GITHUB_ENV
-          echo DOCKER_IMAGE_BASE=712893914485.dkr.ecr.${region}.amazonaws.com/${ENVIRONMENT}/hrm-contact- >> $GITHUB_ENV
+          echo DOCKER_IMAGE_BASE=712893914485.dkr.ecr.${region}.amazonaws.com/${ENVIRONMENT}/hrm- >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/hrm-lambda-release.yml
+++ b/.github/workflows/hrm-lambda-release.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Update Lambda and Publish
         run: |
-          aws lambda update-function-code --function-name ${{ env.ENVIRONMENT }}-${{ env.LAMBDA_NAME }} --image-uri ${{ env.DOCKER_IMAGE_BASE }}${{ env.LAMBDA_NAME }}:live --publish
+          aws lambda update-function-code --function-name ${{ env.ENVIRONMENT }}-hrm-${{ env.LAMBDA_NAME }} --image-uri ${{ env.DOCKER_IMAGE_BASE }}${{ env.LAMBDA_NAME }}:live --publish
 
       # Send Slack notifying success
       - name: Slack Aselo channel

--- a/cdk/contact-core-stack.ts
+++ b/cdk/contact-core-stack.ts
@@ -33,5 +33,15 @@ export default class ContactCoreStack extends cdk.Stack {
       parameterName: '/local/twilio/testSid2/auth_token',
       stringValue: 'mockAuthToken',
     });
+
+    new ssm.StringParameter(this, 'twilio_dev_user_sid', {
+      parameterName: `/local/twilio/${process.env.TWILIO_ACCOUNT_SID}/auth_token`,
+      stringValue: `${process.env.TWILIO_AUTH_TOKEN}`,
+    });
+
+    new ssm.StringParameter(this, 's3_dev_user_docs_bucket_name', {
+      parameterName: `/local/s3/${process.env.TWILIO_ACCOUNT_SID}/docs_bucket_name`,
+      stringValue: this.docsBucket.bucketName,
+    });
   }
 }

--- a/cdk/contact-retrieve-stack.ts
+++ b/cdk/contact-retrieve-stack.ts
@@ -93,7 +93,7 @@ export default class ContactRetrieveStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_16_X,
       memorySize: 512,
       handler: 'handler',
-      entry: `./jobs/${id}/index.ts`,
+      entry: `./jobs/contact-${id}/index.ts`,
       environment: {
         NODE_OPTIONS: '--enable-source-maps',
         S3_ENDPOINT: 'http://localstack:4566',

--- a/cdk/init-stack.ts
+++ b/cdk/init-stack.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 /* eslint-disable no-new */
 import * as cdk from '@aws-cdk/core';
+import * as dotenv from 'dotenv';
+
 import ContactCompleteStack from './contact-complete-stack';
 import ContactCoreStack from './contact-core-stack';
 import ContactRetrieveStack from './contact-retrieve-stack';
+
+dotenv.config({ path: './cdk/.env' });
 
 /**
  * We use AWS-CDK to configure localstack because it is the most common example
@@ -44,7 +48,7 @@ const contactComplete = new ContactCompleteStack({
 
 new ContactRetrieveStack({
   scope: app,
-  id: 'contact-retrieve-transcript',
+  id: 'retrieve-transcript',
   params: {
     completeQueue: contactComplete.completeQueue,
     docsBucket: contactCore.docsBucket,
@@ -56,7 +60,7 @@ new ContactRetrieveStack({
 
 new ContactRetrieveStack({
   scope: app,
-  id: 'contact-retrieve-recording-url',
+  id: 'retrieve-recording-url',
   params: {
     completeQueue: contactComplete.completeQueue,
     docsBucket: contactCore.docsBucket,

--- a/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
+++ b/hrm-service/service-tests/contact-job/contact-job-processor.test.ts
@@ -75,7 +75,7 @@ describe('processContactJobs', () => {
       return callback as any;
     });
     const completeSpy = jest
-      .spyOn(contactJobComplete, 'pollAndprocessCompletedContactJobs')
+      .spyOn(contactJobComplete, 'pollAndProcessCompletedContactJobs')
       .mockImplementation(() => Promise.resolve(undefined) as any);
     const publishSpy = jest.spyOn(contactJobPublish, 'publishDueContactJobs');
 
@@ -109,7 +109,7 @@ describe('processContactJobs', () => {
 
     const errorSpy = jest.spyOn(console, 'error');
     const completeSpy = jest
-      .spyOn(contactJobComplete, 'pollAndprocessCompletedContactJobs')
+      .spyOn(contactJobComplete, 'pollAndProcessCompletedContactJobs')
       .mockImplementationOnce(() => {
         throw new Error('Aaaw, snap!');
       });

--- a/hrm-service/service-tests/contact-job/mocks.ts
+++ b/hrm-service/service-tests/contact-job/mocks.ts
@@ -2,7 +2,7 @@ jest.mock('@tech-matters/hrm-ssm-cache');
 
 jest.mock('aws-sdk', () => {
   const SQSMocked = {
-    sendMessage: jest.fn().mockReturnThis(),
+    deleteMessage: () => jest.fn(),
     receiveMessage: jest.fn(() => {
       return {
         promise: jest.fn().mockResolvedValue({
@@ -10,6 +10,7 @@ jest.mock('aws-sdk', () => {
         }),
       };
     }),
+    sendMessage: jest.fn().mockReturnThis(),
     promise: jest.fn(),
   };
   return {

--- a/hrm-service/src/config/ssmCache.ts
+++ b/hrm-service/src/config/ssmCache.ts
@@ -5,7 +5,7 @@ export { getSsmParameter, hasCacheExpired, ssmCache } from '@tech-matters/hrm-ss
 const ssmCacheConfigs = [
   {
     path: `/${process.env.NODE_ENV}/sqs/jobs/contact`,
-    regex: /queue-url-*./,
+    regex: /queue-url-*/,
   },
 ];
 

--- a/hrm-service/src/contact-job/client-sqs.ts
+++ b/hrm-service/src/contact-job/client-sqs.ts
@@ -17,7 +17,7 @@ export const pollCompletedContactJobsFromQueue =
   async (): Promise<SQS.Types.ReceiveMessageResult> => {
     try {
       const QueueUrl = getSsmParameter(
-        `/${process.env.NODE_ENV}/sqs/jobs/contact/queue-url-contact-complete`,
+        `/${process.env.NODE_ENV}/sqs/jobs/contact/queue-url-complete`,
       );
 
       return await getSqsClient()
@@ -28,12 +28,20 @@ export const pollCompletedContactJobsFromQueue =
         })
         .promise();
     } catch (err) {
-      console.error('Error trying to poll messages from SQS queue');
+      console.error('Error trying to poll messages from SQS queue', err);
     }
   };
 
-export const deleteCompletedContactJobsFromQueue = async (ReceiptHandle: any) => {
-  return ReceiptHandle;
+export const deleteCompletedContactJobsFromQueue = async (ReceiptHandle: string) => {
+  try {
+    const QueueUrl = getSsmParameter(
+      `/${process.env.NODE_ENV}/sqs/jobs/contact/queue-url-complete`,
+    );
+
+    return await getSqsClient().deleteMessage({ QueueUrl, ReceiptHandle }).promise();
+  } catch (err) {
+    console.error('Error trying to delete message from SQS queue', err);
+  }
 };
 
 export const publishToContactJobs = async (params: PublishToContactJobsTopicParams) => {
@@ -41,7 +49,7 @@ export const publishToContactJobs = async (params: PublishToContactJobsTopicPara
   //TODO: more robust error handling/messaging
   try {
     const QueueUrl = getSsmParameter(
-      `/${process.env.NODE_ENV}/sqs/jobs/contact/queue-url-contact-${params.jobType}`,
+      `/${process.env.NODE_ENV}/sqs/jobs/contact/queue-url-${params.jobType}`,
     );
 
     return await getSqsClient()
@@ -51,6 +59,6 @@ export const publishToContactJobs = async (params: PublishToContactJobsTopicPara
       })
       .promise();
   } catch (err) {
-    console.error('Error trying to send message to SQS queue');
+    console.error('Error trying to send message to SQS queue', err);
   }
 };

--- a/hrm-service/src/contact-job/contact-job-complete.ts
+++ b/hrm-service/src/contact-job/contact-job-complete.ts
@@ -56,8 +56,10 @@ const processCompletedContactJob = async (completedJob: CompletedContactJobBody)
   }
 };
 
-export const pollAndprocessCompletedContactJobs = async (jobMaxAttempts: number) => {
+export const pollAndProcessCompletedContactJobs = async (jobMaxAttempts: number) => {
   const polledCompletedJobs = await pollCompletedContactJobsFromQueue();
+
+  if (!polledCompletedJobs?.Messages) return;
 
   const { Messages: messages } = polledCompletedJobs;
 

--- a/hrm-service/src/contact-job/contact-job-processor.ts
+++ b/hrm-service/src/contact-job/contact-job-processor.ts
@@ -1,7 +1,7 @@
 import { setInterval } from 'timers';
 import { subMilliseconds } from 'date-fns';
 import { pullDueContactJobs } from './contact-job-data-access';
-import { pollAndprocessCompletedContactJobs } from './contact-job-complete';
+import { pollAndProcessCompletedContactJobs } from './contact-job-complete';
 import { publishDueContactJobs } from './contact-job-publish';
 import { loadSsmCache } from '../config/ssmCache';
 
@@ -25,7 +25,7 @@ export function processContactJobs() {
         await loadSsmCache();
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const completedJobs = await pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+        const completedJobs = await pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
         const dueContactJobs = await pullDueContactJobs(
           subMilliseconds(new Date(), JOB_RETRY_INTERVAL_MILLISECONDS),

--- a/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
+++ b/hrm-service/unit-tests/contact-job/contact-job-complete.test.ts
@@ -9,11 +9,13 @@ import { JOB_MAX_ATTEMPTS } from '../../src/contact-job/contact-job-processor';
 // eslint-disable-next-line prettier/prettier
 import type { CompletedContactJobBody } from '@tech-matters/hrm-types/ContactJob';
 
+jest.mock('../../src/contact-job/client-sqs');
+
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('pollAndprocessCompletedContactJobs', () => {
+describe('pollAndProcessCompletedContactJobs', () => {
   test('Completed jobs are polled from SQS client as expected', async () => {
     const sqsSpy = jest
       .spyOn(SQSClient, 'pollCompletedContactJobsFromQueue')
@@ -21,7 +23,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         Messages: [],
       }));
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+    const result = await contactJobComplete.pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(sqsSpy).toHaveBeenCalled();
     expect(Array.isArray(result)).toBeTruthy();
@@ -64,7 +66,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
       .spyOn(contactJobDataAccess, 'completeContactJob')
       .mockImplementation(async () => 'done' as any);
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+    const result = await contactJobComplete.pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(processCompletedRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledTimes(1);
@@ -121,7 +123,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
       .spyOn(contactJobDataAccess, 'completeContactJob')
       .mockImplementation(async () => 'done' as any);
 
-    const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+    const result = await contactJobComplete.pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
     expect(processCompletedRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(2);
     expect(errorSpy).toHaveBeenCalledTimes(1);
@@ -178,8 +180,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         Messages: [validPayload],
       }));
       const deletedCompletedContactJobsSpy = jest
-        .spyOn(SQSClient, 'deleteCompletedContactJobsFromQueue')
-        .mockImplementation(async () => {});
+        .spyOn(SQSClient, 'deleteCompletedContactJobsFromQueue');
       const processCompletedFunctionSpy = jest
         .spyOn(contactJobComplete, processCompletedFunction)
         .mockImplementation(async () => {});
@@ -187,7 +188,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         .spyOn(contactJobDataAccess, 'completeContactJob')
         .mockImplementation(async () => validPayload as any);
 
-      const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+      const result = await contactJobComplete.pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
       expect(processCompletedFunctionSpy).toHaveBeenCalledWith(job);
       expect(completeContactJobSpy).toHaveBeenCalledWith(job.jobId, {
@@ -255,8 +256,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         Messages: [validPayload],
       }));
       const deletedCompletedContactJobsSpy = jest
-        .spyOn(SQSClient, 'deleteCompletedContactJobsFromQueue')
-        .mockImplementation(async () => {});
+        .spyOn(SQSClient, 'deleteCompletedContactJobsFromQueue');
       const processCompletedFunctionSpy = jest
         .spyOn(contactJobComplete, processCompletedFunction)
         .mockImplementation(async () => {});
@@ -267,7 +267,7 @@ describe('pollAndprocessCompletedContactJobs', () => {
         .spyOn(contactJobDataAccess, 'appendFailedAttemptPayload')
         .mockImplementation(() => job);
 
-      const result = await contactJobComplete.pollAndprocessCompletedContactJobs(JOB_MAX_ATTEMPTS);
+      const result = await contactJobComplete.pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
 
       expect(processCompletedFunctionSpy).not.toHaveBeenCalled();
 

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -8,12 +8,13 @@ ENV lambda_name ${lambda_name}
 # copy the hrm-lib package and labmdas folders so that the file: based
 # dependency in package.json can be resolved
 COPY packages /tmp/build/packages
-COPY jobs /tmp/build/jobs
-COPY package.json package-lock.json tsconfig.base.json tsconfig.build.jobs.json /tmp/build/
+COPY jobs/${lambda_name} /tmp/build/jobs/${lambda_name}
+COPY jobs/tsconfig.json /tmp/build/jobs/tsconfig.json
+COPY package.json package-lock.json tsconfig.json tsconfig.base.json tsconfig.build.jobs.${lambda_name}.json /tmp/build/
 
 RUN cd /tmp/build \
     && npm ci -w jobs/${lambda_name} -w packages/* \
-    && npx tsc -b tsconfig.build.jobs.json \
+    && npx tsc -b tsconfig.build.jobs.${lambda_name}.json \
     && cp jobs/${lambda_name}/dist/*.js /var/task/ \
     && cp -r packages /var/task/ \
     && cp -r node_modules /var/task/ \

--- a/jobs/contact-complete/package.json
+++ b/jobs/contact-complete/package.json
@@ -10,7 +10,8 @@
     "aws-sdk": "^2.1225.0"
   },
   "devDependencies": {
-    "@tech-matters/hrm-types": "^1.0.0"
+    "@tech-matters/hrm-types": "^1.0.0",
+    "@types/aws-lambda": "^8.10.108"
   },
   "scripts": {
     "docker:build": "docker build -t hrm-jobs-contact-complete --build-arg lambda_name=contact-complete -f ../Dockerfile ../../"

--- a/jobs/contact-retrieve-recording-url/index.ts
+++ b/jobs/contact-retrieve-recording-url/index.ts
@@ -25,7 +25,7 @@ const hrmEnv = process.env.NODE_ENV;
 
 const ssmCacheConfigs = [
   {
-    path: `/${hrmEnv}/twilio`,
+    path: `/${hrmEnv}/twilio/`,
     regex: /auth_token/,
   },
   {

--- a/jobs/contact-retrieve-recording-url/package.json
+++ b/jobs/contact-retrieve-recording-url/package.json
@@ -6,14 +6,15 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@tech-matters/hrm-twilio-client": "^1.0.0",
     "@tech-matters/hrm-ssm-cache": "^1.0.0",
+    "@tech-matters/hrm-twilio-client": "^1.0.0",
     "aws-sdk": "^2.1225.0",
     "twilio": "^3.80.0",
     "util": "^0.12.4"
   },
   "devDependencies": {
-    "@tech-matters/hrm-types": "^1.0.0"
+    "@tech-matters/hrm-types": "^1.0.0",
+    "@types/aws-lambda": "^8.10.108"
   },
   "scripts": {
     "docker:build": "docker build -t hrm-jobs-contact-retrieve-recording-url --build-arg lambda_name=contact-retrieve-recording-url -f ../Dockerfile ../../"

--- a/jobs/contact-retrieve-transcript/exportTranscript.ts
+++ b/jobs/contact-retrieve-transcript/exportTranscript.ts
@@ -26,7 +26,7 @@ export const exportTranscript = async ({
     .channels.get(channelSid)
     .messages.list();
 
-  const transcript = messages.map(m => ({
+  const transformed = messages.map(m => ({
     sid: m.sid,
     dateCreated: m.dateCreated,
     from: m.from,
@@ -36,5 +36,10 @@ export const exportTranscript = async ({
     media: m.media,
   }));
 
-  return transcript;
+  return {
+    accountSid,
+    serviceSid,
+    channelSid,
+    messages: transformed,
+  };
 };

--- a/jobs/contact-retrieve-transcript/index.ts
+++ b/jobs/contact-retrieve-transcript/index.ts
@@ -26,7 +26,7 @@ const hrmEnv = process.env.NODE_ENV;
 
 const ssmCacheConfigs = [
   {
-    path: `/${hrmEnv}/twilio`,
+    path: `/${hrmEnv}/twilio/`,
     regex: /auth_token/,
   },
   {

--- a/jobs/contact-retrieve-transcript/package.json
+++ b/jobs/contact-retrieve-transcript/package.json
@@ -7,13 +7,14 @@
   "license": "ISC",
   "dependencies": {
     "@tech-matters/hrm-s3-client": "^1.0.0",
-    "@tech-matters/hrm-twilio-client": "^1.0.0",
     "@tech-matters/hrm-ssm-cache": "^1.0.0",
+    "@tech-matters/hrm-twilio-client": "^1.0.0",
     "aws-sdk": "^2.1225.0",
     "util": "^0.12.4"
   },
   "devDependencies": {
     "@tech-matters/hrm-types": "^1.0.0",
+    "@types/aws-lambda": "^8.10.108",
     "ts-node": "^10.9.1"
   },
   "scripts": {

--- a/jobs/contact-retrieve-transcript/tests/unit/exportTranscript.test.ts
+++ b/jobs/contact-retrieve-transcript/tests/unit/exportTranscript.test.ts
@@ -51,6 +51,11 @@ describe('exportTranscript', () => {
       channelSid: 'channelSid',
     });
 
-    expect(transcript).toEqual(messageList);
+    expect(transcript).toEqual({
+      accountSid: 'accountSid',
+      serviceSid: 'serviceSid',
+      channelSid: 'channelSid',
+      messages: messageList,
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
-        "@types/aws-lambda": "^8.10.72",
+        "@types/aws-lambda": "^8.10.108",
         "@types/jest": "^26.0.24",
         "@types/node": "^14.14.26",
         "@types/node-fetch": "^2.5.10",
@@ -116,7 +116,8 @@
         "aws-sdk": "^2.1225.0"
       },
       "devDependencies": {
-        "@tech-matters/hrm-types": "^1.0.0"
+        "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108"
       }
     },
     "jobs/contact-retrieve-recording-url": {
@@ -131,7 +132,8 @@
         "util": "^0.12.4"
       },
       "devDependencies": {
-        "@tech-matters/hrm-types": "^1.0.0"
+        "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108"
       }
     },
     "jobs/contact-retrieve-transcript": {
@@ -147,6 +149,7 @@
       },
       "devDependencies": {
         "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108",
         "ts-node": "^10.9.1"
       }
     },
@@ -13696,6 +13699,7 @@
       "requires": {
         "@tech-matters/hrm-ssm-cache": "^1.0.0",
         "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108",
         "aws-sdk": "^2.1225.0"
       }
     },
@@ -13705,6 +13709,7 @@
         "@tech-matters/hrm-ssm-cache": "^1.0.0",
         "@tech-matters/hrm-twilio-client": "^1.0.0",
         "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108",
         "aws-sdk": "^2.1225.0",
         "twilio": "^3.80.0",
         "util": "^0.12.4"
@@ -13717,6 +13722,7 @@
         "@tech-matters/hrm-ssm-cache": "^1.0.0",
         "@tech-matters/hrm-twilio-client": "^1.0.0",
         "@tech-matters/hrm-types": "^1.0.0",
+        "@types/aws-lambda": "^8.10.108",
         "aws-sdk": "^2.1225.0",
         "ts-node": "^10.9.1",
         "util": "^0.12.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@aws-cdk/aws-s3": "^1.176.0",
         "@aws-cdk/aws-sqs": "^1.176.0",
         "@aws-cdk/aws-ssm": "^1.176.0",
-        "@aws-cdk/core": "^1.176.0"
+        "@aws-cdk/core": "^1.176.0",
+        "dotenv": "^16.0.3"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
@@ -106,6 +107,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
+    },
+    "hrm-service/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "jobs/contact-complete": {
       "name": "@tech-matters/hrm-jobs-contact-complete",
@@ -4557,11 +4566,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dottie": {
@@ -13783,6 +13792,11 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
           "dev": true
+        },
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
         }
       }
     },
@@ -15205,9 +15219,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dottie": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
-    "@types/aws-lambda": "^8.10.72",
+    "@types/aws-lambda": "^8.10.108",
     "@types/jest": "^26.0.24",
     "@types/node": "^14.14.26",
     "@types/node-fetch": "^2.5.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@aws-cdk/aws-s3": "^1.176.0",
     "@aws-cdk/aws-sqs": "^1.176.0",
     "@aws-cdk/aws-ssm": "^1.176.0",
-    "@aws-cdk/core": "^1.176.0"
+    "@aws-cdk/core": "^1.176.0",
+    "dotenv": "^16.0.3"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",
@@ -53,8 +54,8 @@
     "build-and-start": "run-s build start",
     "build-and-start:service": "run-s build start:service",
     "start": "run-s start:localstack start:service",
-    "start:localstack": "run-s localstack:init",
-    "start:service": "PORT=8080 npm run -w hrm-service start",
+    "start:localstack": "AWS_REGION=eu-west-1 run-s localstack:init",
+    "start:service": "cross-env AWS_REGION=eu-west-1 SSM_ENDPOINT=http://localhost:4566 PORT=8080 npm run -w hrm-service start",
     "docker:build": "npm run docker:build --workspaces --if-present",
     "docker:compose:down": "docker-compose -p hrm down",
     "docker:compose:logs": "docker-compose -p hrm logs -f",
@@ -86,6 +87,9 @@
     "test:docker:jobs:contact-complete": "curl -XPOST \"http://localhost:9000/2015-03-31/functions/function/invocations\" -d \"$(cat jobs/contact-complete/tests/testPayload.json)\"",
     "test:docker:jobs:contact-retrieve-recording-url": "curl -XPOST \"http://localhost:9001/2015-03-31/functions/function/invocations\" -d \"$(cat jobs/contact-retrieve-recording-url/tests/testPayload.json)\"",
     "test:docker:jobs:contact-retrieve-transcript": "curl -XPOST \"http://localhost:9002/2015-03-31/functions/function/invocations\" -d \"$(cat jobs/contact-retrieve-transcript/tests/testPayload.json)\"",
-    "ssm:local": "npm run ssm:local --workspaces --if-present"
+    "ssm:local": "run-p ssm:local:*",
+    "ssm:local:base": "run-p ssm:local:base:*",
+    "ssm:local:base:cdk": "docker run --rm -v ~/.aws:/home/aws/.aws -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY interrobangc/awscli2 ssm get-parameter --name \"/local/hrm/cdk/.env\" --with-decryption --query \"Parameter.Value\" --output text > ./cdk/.env",
+    "ssm:local:workspaces": "npm run ssm:local --workspaces --if-present"
   }
 }

--- a/tsconfig.build.jobs.contact-retrieve-complete.json
+++ b/tsconfig.build.jobs.contact-retrieve-complete.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "packages/ssm-cache" },
+    { "path": "packages/s3-client" },
+    { "path": "packages/twilio-client" },
+    { "path": "jobs/contact-retrieve-recording-url" }
+  ]
+}

--- a/tsconfig.build.jobs.contact-retrieve-complete.json
+++ b/tsconfig.build.jobs.contact-retrieve-complete.json
@@ -1,10 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "files": [],
-  "references": [
-    { "path": "packages/ssm-cache" },
-    { "path": "packages/s3-client" },
-    { "path": "packages/twilio-client" },
-    { "path": "jobs/contact-retrieve-recording-url" }
-  ]
+  "references": [{ "path": "packages/ssm-cache" }, { "path": "jobs/contact-retrieve-complete" }]
 }

--- a/tsconfig.build.jobs.contact-retrieve-recording-url.json
+++ b/tsconfig.build.jobs.contact-retrieve-recording-url.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [{ "path": "packages/ssm-cache" }, { "path": "jobs/contact-retrieve-complete" }]
+}

--- a/tsconfig.build.jobs.contact-retrieve-recording-url.json
+++ b/tsconfig.build.jobs.contact-retrieve-recording-url.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
   "files": [],
-  "references": [{ "path": "packages/ssm-cache" }, { "path": "jobs/contact-retrieve-complete" }]
+  "references": [
+    { "path": "packages/ssm-cache" },
+    { "path": "packages/s3-client" },
+    { "path": "packages/twilio-client" },
+    { "path": "jobs/contact-retrieve-recording-url" }
+  ]
 }

--- a/tsconfig.build.jobs.contact-retrieve-transcript.json
+++ b/tsconfig.build.jobs.contact-retrieve-transcript.json
@@ -1,4 +1,3 @@
-// TODO: This should be job specific and reside in the job folder
 {
   "extends": "./tsconfig.base.json",
   "files": [],
@@ -6,8 +5,6 @@
     { "path": "packages/ssm-cache" },
     { "path": "packages/s3-client" },
     { "path": "packages/twilio-client" },
-    { "path": "jobs/contact-complete" },
-    { "path": "jobs/contact-retrieve-recording-url" },
     { "path": "jobs/contact-retrieve-transcript" }
   ]
 }


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
This fixes regressions introduced to the lambda deploy action by the move to npm workflows.

#261 should be merged before this.

### Verification steps
Run lambda deploy action for contact-retrieve-transcript job from bo-fix_lambda_action branch.
