### PR TITLE
fix: missing migration on aws deployment. Move to entrypoint

### DIFF
--- a/hrm-service/Dockerfile
+++ b/hrm-service/Dockerfile
@@ -20,6 +20,9 @@ RUN cd /tmp/build \
 
 WORKDIR /home/node
 
+COPY hrm-service/docker-entrypoint /usr/local/bin/docker-entrypoint
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
+
 # RUN npm test
 USER node
 

--- a/hrm-service/docker-entrypoint
+++ b/hrm-service/docker-entrypoint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+node ./service-tests/db-init/migrate
+
+exec "$@"

--- a/hrm-service/docker-entrypoint
+++ b/hrm-service/docker-entrypoint
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 node ./service-tests/db-init/migrate
 


### PR DESCRIPTION
Primary reviewer: @GPaoloni 

## Description
Migrations were removed from startup script and not added back in during workspaces rearrangement. This adds them back in to a docker entrypoint. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
Deploy from this branch to development and verify migrations run.
