### PR TITLE
Fixed CSAMReports migration

### DIFF
--- a/hrm-service/migrations/20221122154821-alter-table-CSAMReport-self-generated.js
+++ b/hrm-service/migrations/20221122154821-alter-table-CSAMReport-self-generated.js
@@ -8,7 +8,7 @@ module.exports = {
     await queryInterface.sequelize.query(
       `
         ALTER TABLE IF EXISTS public."CSAMReports"
-        ADD COLUMN "reportType" TEXT NOT NULL;
+        ADD COLUMN "reportType" TEXT DEFAULT 'counsellor-generated' NOT NULL;
       `,
       { transaction },
     );
@@ -17,19 +17,29 @@ module.exports = {
     await queryInterface.sequelize.query(
       `
         ALTER TABLE IF EXISTS public."CSAMReports"
-        ADD COLUMN "acknowledged" BOOLEAN NOT NULL;
+        ADD COLUMN "acknowledged" BOOLEAN DEFAULT TRUE NOT NULL;
       `,
       { transaction },
     );
-    console.log('Column reportStatus added to CSAMReports');
+    console.log('Column acknowledged added to CSAMReports');
 
     await queryInterface.sequelize.query(
       `
-        UPDATE "CSAMReports" SET "reportType" = 'counsellor-generated', "acknowledged" = TRUE;
+        ALTER TABLE IF EXISTS public."CSAMReports"
+        ALTER COLUMN "reportType" DROP DEFAULT;
       `,
       { transaction },
     );
-    console.log('Set reportType colum to "counsellor-generated" for all records');
+    console.log('Column reportType default constraint droped');
+
+    await queryInterface.sequelize.query(
+      `
+        ALTER TABLE IF EXISTS public."CSAMReports"
+        ALTER COLUMN "acknowledged" DROP DEFAULT;
+      `,
+      { transaction },
+    );
+    console.log('Column acknowledged default constraint droped');
 
     await transaction.commit();
   },


### PR DESCRIPTION
Primary reviewer: @stephenhand (:pray:)

## Description
This PR fixes the migration bundled in https://github.com/techmatters/hrm/pull/268, since it is broken when there are existing records in the `CSAMReports` table. This is causing the [deployments to fail](https://github.com/techmatters/hrm/actions/runs/3596410082) because of the following error

![Screenshot from 2022-12-01 23-52-43](https://user-images.githubusercontent.com/15805319/205204310-5ea0b20c-8776-4b13-a418-a97510ed1d76.png)

The fix in this PR is to include a `DEFAULT` constraint for the columns, so they are properly populated in the same statement they are created, and then dropping such constraint (this way the application is responsible for always providing with non-null value or the statement will fail).


### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
- Checkout the repo to commit [ef47c33](https://github.com/techmatters/hrm/commit/ef47c3309fd66b516182d1a03da96b887157d3ef).
- Start local DB, run migrations, compile, start local server and expose it via ngrok.
- Open Flex, point `Twilio.Flex.Manager.getInstance().serviceConfiguration.attributes.hrm_base_url` to the url provided by ngrok and submit a new CSAM report (at least one - only counsellor generated ones are valid at this point - must be done from the current development or `master` if working on local Flex).
- :exclamation: Do not shut down the DB!
- Query the `CSAMReports` and confirm that the records exist in the DB.
- Checkout to this branch and run the migrations again. Only the recently included `alter-table-CSAMReport-self-generated` migration should be executed, and succeed.
- Query the `CSAMReports` table again and confirm that
  - Existing records are properly updated.
  - The table is left without constraints for the new columns.
