### PR TITLE
fix: ssmCache expiry time not being updated after it is reached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "aws-cdk": "^2.45.0",
         "aws-cdk-local": "^2.15.0",
         "aws-sdk": "^2.1231.0",
-        "date-fns": "^2.29.3",
         "esbuild": "^0.15.13",
         "eslint": "^8.2.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -12049,6 +12048,9 @@
       "dependencies": {
         "aws-sdk": "^2.1225.0",
         "typescript": "^4.8.4"
+      },
+      "devDependencies": {
+        "date-fns": "^2.29.3"
       }
     },
     "packages/twilio-client": {
@@ -13895,6 +13897,7 @@
       "version": "file:packages/ssm-cache",
       "requires": {
         "aws-sdk": "^2.1225.0",
+        "date-fns": "^2.29.3",
         "typescript": "^4.8.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "aws-cdk": "^2.45.0",
         "aws-cdk-local": "^2.15.0",
         "aws-sdk": "^2.1231.0",
+        "date-fns": "^2.29.3",
         "esbuild": "^0.15.13",
         "eslint": "^8.2.0",
         "eslint-config-airbnb-base": "^15.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13840,7 +13840,7 @@
         "@tech-matters/hrm-types": "^1.0.0",
         "@types/deep-diff": "^1.0.1",
         "@types/express": "^4.17.13",
-        "@types/http-errors": "*",
+        "@types/http-errors": "^2.0.1",
         "@types/node": "^17.0.23",
         "@types/supertest": "^2.0.12",
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "aws-cdk": "^2.45.0",
     "aws-cdk-local": "^2.15.0",
     "aws-sdk": "^2.1231.0",
+    "date-fns": "^2.29.3",
     "esbuild": "^0.15.13",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "aws-cdk": "^2.45.0",
     "aws-cdk-local": "^2.15.0",
     "aws-sdk": "^2.1231.0",
-    "date-fns": "^2.29.3",
     "esbuild": "^0.15.13",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/packages/ssm-cache/index.ts
+++ b/packages/ssm-cache/index.ts
@@ -86,18 +86,18 @@ export type SsmCacheConfig = {
 };
 
 export type LoadSsmCacheParameters = {
-  cacheDuration?: number;
+  cacheDurationMilliseconds?: number;
   // We accept an array of types to allow loading parameters from multiple paths
   configs: SsmCacheConfig[];
 };
 
 export const loadSsmCache = async ({
-  cacheDuration = 3600000,
+  cacheDurationMilliseconds = 3600000,
   configs,
 }: LoadSsmCacheParameters) => {
   if (isConfigNotEmpty() && !hasCacheExpired()) return;
 
-  ssmCache.expiryDate = new Date(Date.now() + cacheDuration);
+  ssmCache.expiryDate = new Date(Date.now() + cacheDurationMilliseconds);
 
   const promises = configs.map(async config => loadPaginated(config));
 

--- a/packages/ssm-cache/index.ts
+++ b/packages/ssm-cache/index.ts
@@ -95,11 +95,9 @@ export const loadSsmCache = async ({
   expiryTime: cacheDuration = 3600000,
   configs,
 }: LoadSsmCacheParameters) => {
-  if (!ssmCache.expiryDate) {
-    ssmCache.expiryDate = new Date(Date.now() + cacheDuration);
-  }
-
   if (isConfigNotEmpty() && !hasCacheExpired()) return;
+
+  ssmCache.expiryDate = new Date(Date.now() + cacheDuration);
 
   const promises = configs.map(async config => loadPaginated(config));
 

--- a/packages/ssm-cache/index.ts
+++ b/packages/ssm-cache/index.ts
@@ -86,13 +86,13 @@ export type SsmCacheConfig = {
 };
 
 export type LoadSsmCacheParameters = {
-  expiryTime?: number;
+  cacheDuration?: number;
   // We accept an array of types to allow loading parameters from multiple paths
   configs: SsmCacheConfig[];
 };
 
 export const loadSsmCache = async ({
-  expiryTime: cacheDuration = 3600000,
+  cacheDuration = 3600000,
   configs,
 }: LoadSsmCacheParameters) => {
   if (isConfigNotEmpty() && !hasCacheExpired()) return;

--- a/packages/ssm-cache/package.json
+++ b/packages/ssm-cache/package.json
@@ -23,5 +23,8 @@
   },
   "scripts": {
     "test:unit": "jest tests/unit"
+  },
+  "devDependencies": {
+    "date-fns": "^2.29.3"
   }
 }

--- a/packages/ssm-cache/tests/unit/index.test.ts
+++ b/packages/ssm-cache/tests/unit/index.test.ts
@@ -1,4 +1,12 @@
-import { addToCache, getSsmParameter, ssmCache, SsmParameterNotFound } from '../../index';
+import { isAfter } from 'date-fns';
+
+import {
+  addToCache,
+  getSsmParameter,
+  loadSsmCache,
+  ssmCache,
+  SsmParameterNotFound,
+} from '../../index';
 
 describe('addToCache', () => {
   it('should add a value to the cache with matching regex', () => {
@@ -24,5 +32,14 @@ describe('addToCache', () => {
 
     expect(ssmCache.values).not.toHaveProperty(ssmParam.Name);
     expect(() => getSsmParameter(ssmParam.Name)).toThrow(SsmParameterNotFound);
+  });
+});
+
+describe('loadCache', () => {
+  it('loading after cache expired should update expiryDate', () => {
+    const initialExpire = new Date(Date.now() - 1000);
+    ssmCache.expiryDate = initialExpire;
+    loadSsmCache({ configs: [] });
+    expect(isAfter(ssmCache.expiryDate, initialExpire)).toBeTruthy();
   });
 });

--- a/packages/ssm-cache/tests/unit/index.test.ts
+++ b/packages/ssm-cache/tests/unit/index.test.ts
@@ -1,12 +1,29 @@
 import { isAfter } from 'date-fns';
 
-import {
-  addToCache,
-  getSsmParameter,
-  loadSsmCache,
-  ssmCache,
-  SsmParameterNotFound,
-} from '../../index';
+import * as SsmCache from '../../index';
+
+let ssmParams = [
+  {
+    Name: '/localstack/test/param',
+    Value: 'value',
+  },
+];
+
+jest.mock('aws-sdk', () => {
+  const SSMMocked = {
+    getParametersByPath: () => {
+      return {
+        promise: jest.fn().mockResolvedValue({
+          Parameters: ssmParams,
+        }),
+      };
+    },
+    promise: jest.fn(),
+  };
+  return {
+    SSM: jest.fn(() => SSMMocked),
+  };
+});
 
 describe('addToCache', () => {
   it('should add a value to the cache with matching regex', () => {
@@ -15,11 +32,11 @@ describe('addToCache', () => {
       Value: 'value',
     };
 
-    addToCache(/param/, ssmParam);
+    SsmCache.addToCache(/param/, ssmParam);
 
-    expect(ssmCache.values).toHaveProperty(ssmParam.Name);
-    expect(ssmCache.values[ssmParam.Name]).toEqual(ssmParam.Value);
-    expect(getSsmParameter(ssmParam.Name)).toEqual(ssmParam.Value);
+    expect(SsmCache.ssmCache.values).toHaveProperty(ssmParam.Name);
+    expect(SsmCache.ssmCache.values[ssmParam.Name]).toEqual(ssmParam.Value);
+    expect(SsmCache.getSsmParameter(ssmParam.Name)).toEqual(ssmParam.Value);
   });
 
   it('should not add a value to the cache with non-matching regex', () => {
@@ -28,18 +45,71 @@ describe('addToCache', () => {
       Value: 'value',
     };
 
-    addToCache(/notRight/, ssmParam);
+    SsmCache.addToCache(/notRight/, ssmParam);
 
-    expect(ssmCache.values).not.toHaveProperty(ssmParam.Name);
-    expect(() => getSsmParameter(ssmParam.Name)).toThrow(SsmParameterNotFound);
+    expect(SsmCache.ssmCache.values).not.toHaveProperty(ssmParam.Name);
+    expect(() => SsmCache.getSsmParameter(ssmParam.Name)).toThrow(SsmCache.SsmParameterNotFound);
   });
 });
 
 describe('loadCache', () => {
-  it('loading after cache expired should update expiryDate', () => {
+  beforeEach(() => {
+    // Reset to default
+    SsmCache.ssmCache.values = {};
+    delete SsmCache.ssmCache.expiryDate;
+  });
+
+  it('loading after cache expired should update expiryDate', async () => {
     const initialExpire = new Date(Date.now() - 1000);
-    ssmCache.expiryDate = initialExpire;
-    loadSsmCache({ configs: [] });
-    expect(isAfter(ssmCache.expiryDate, initialExpire)).toBeTruthy();
+    SsmCache.ssmCache.expiryDate = initialExpire;
+    await SsmCache.loadSsmCache({ configs: [] });
+    expect(isAfter(SsmCache.ssmCache.expiryDate, initialExpire)).toBeTruthy();
+  });
+
+  it('loading after cache expire should cause call fetch new params', async () => {
+    const ssmCacheConfig = {
+      cacheDuration: -1, // set expire to the past to force update because sometimes this is do fast that milliseconds are the same.
+      configs: [
+        {
+          path: `/test/fake/param`,
+          regex: /param/,
+        },
+      ],
+    };
+
+    // Mock initial ssm params
+    ssmParams = [
+      {
+        Name: '/test/fake/param/1',
+        Value: 'value',
+      },
+    ];
+
+    const loadPaginatedSpy = jest.spyOn(SsmCache, 'loadPaginated');
+
+    // Ensure first call returns expected params
+    await SsmCache.loadSsmCache(ssmCacheConfig);
+    expect(loadPaginatedSpy).toHaveBeenCalledTimes(1);
+    expect(SsmCache.ssmCache.values).toHaveProperty('/test/fake/param/1');
+    expect(SsmCache.ssmCache.values).not.toHaveProperty('/test/fake/param/2');
+
+    // Mock adding param to ssm
+    ssmParams = [
+      {
+        Name: '/test/fake/param/1',
+        Value: 'value',
+      },
+      {
+        Name: '/test/fake/param/2',
+        Value: 'value',
+      },
+    ];
+
+    // Ensure second call returns new param
+    await SsmCache.loadSsmCache(ssmCacheConfig);
+    expect(loadPaginatedSpy).toHaveBeenCalledTimes(2);
+
+    expect(SsmCache.ssmCache.values).toHaveProperty('/test/fake/param/1');
+    expect(SsmCache.ssmCache.values).toHaveProperty('/test/fake/param/2');
   });
 });

--- a/packages/ssm-cache/tests/unit/index.test.ts
+++ b/packages/ssm-cache/tests/unit/index.test.ts
@@ -68,7 +68,7 @@ describe('loadCache', () => {
 
   it('loading after cache expire should cause call fetch new params', async () => {
     const ssmCacheConfig = {
-      cacheDuration: -1, // set expire to the past to force update because sometimes this is do fast that milliseconds are the same.
+      cacheDurationMilliseconds: -1, // set expire to the past to force update because sometimes this is do fast that milliseconds are the same.
       configs: [
         {
           path: `/test/fake/param`,


### PR DESCRIPTION
Primary Reviewer: @stephenhand 

## Description
After expiry, ssm cache was being reloaded on every call to loadSsmCache.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues


### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Run unit ### tests
