### PR TITLE
chore: add ignores to license add script

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,11 @@
     "ssm:local:base": "run-p ssm:local:base:*",
     "ssm:local:base:cdk": "docker run --rm -v ~/.aws:/home/aws/.aws -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY interrobangc/awscli2 ssm get-parameter --name \"/local/hrm/cdk/.env\" --with-decryption --query \"Parameter.Value\" --output text > ./cdk/.env",
     "ssm:local:workspaces": "npm run ssm:local --workspaces --if-present",
-    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -f license-header.tpl .",
-    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -f license-header.tpl ."
+    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"cdk.out/**\" -f license-header.tpl .",
+    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"cdk.out/**\" -f license-header.tpl .",
+    "license:add:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"cdk.out/**\" -f license-header.tpl .",
+    "license:check:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -ignore \"cdk.out/**\" -f license-header.tpl .",
+    "license:add:windows:local": "addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl .",
+    "license:check:windows:local": "addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl ."
   }
 }


### PR DESCRIPTION
Adds ignore patterns (not all but the important ones... hopefully?) to the license add command and windows versions.