### PR TITLE
CHI-1136: Inline resource attributes

### DIFF
--- a/resources-service/migrations/20230120154500-create-resources-table.js
+++ b/resources-service/migrations/20230120154500-create-resources-table.js
@@ -98,7 +98,9 @@ module.exports = {
   },
 
   down: async queryInterface => {
-    await queryInterface.sequelize.query(`DROP FUNCTION IF EXISTS resources."Resources"`);
+    await queryInterface.sequelize.query(
+      `DROP FUNCTION IF EXISTS resources."Resources_updateSequence_trigger"`,
+    );
     await queryInterface.sequelize.query(`DROP TABLE IF EXISTS resources."Resources"`);
     await queryInterface.sequelize.query(
       `DROP SEQUENCE IF EXISTS resources."Resources_updates_seq"`,

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -74,7 +74,7 @@ module.exports = {
       WHEN (pg_trigger_depth() = 0)
       EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
     `);
-    console.log('Trigger Resources_update_trigger created');
+    console.log('Trigger ResourceStringAttributes_update_trigger created');
 
     await queryInterface.sequelize.query(`
       CREATE TABLE IF NOT EXISTS resources."Globals"
@@ -87,6 +87,12 @@ module.exports = {
       )
     `);
     console.log('Table "Globals" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."Globals"
+          OWNER to resources;
+    `);
+    console.log('Table "Globals" now owned by resources');
   },
 
   down: async queryInterface => {

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceStringAttributes"
+      (
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "language" text COLLATE pg_catalog."default" NOT NULL,
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceStringAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "language", "value")
+      )
+    `);
+    console.log('Table "ResourceStringAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."ResourceStringAttributes"
+          OWNER to resources;
+    `);
+    console.log('Table "ResourceStringAttributes" now owned by resources');
+
+    await queryInterface.sequelize.query(`
+      CREATE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        NOT LEAKPROOF
+      AS $BODY$
+      BEGIN
+        IF TG_WHEN <> 'BEFORE' THEN
+          RAISE EXCEPTION 'ResourcesLookupTables_updateSequence_trigger() may only run as an BEFORE trigger';
+        END IF;
+
+        IF (TG_LEVEL <> 'ROW' OR (TG_OP <> 'UPDATE')) THEN
+          RAISE EXCEPTION 'ResourcesLookupTables_updateSequence_trigger() added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
+          RETURN NULL;
+        END IF;
+        
+        NEW."updateSequence" = nextval('"Resources_updates_seq"'::regclass);
+        RETURN NEW;
+      END
+      $BODY$;
+    `);
+    console.log('Function "ResourcesLookupTables_updateSequence_trigger" created.');
+
+    await queryInterface.sequelize.query(
+      `ALTER FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"() OWNER TO resources`,
+    );
+    console.log('Function "ResourcesLookupTables_updateSequence_trigger" ownership altered.');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceStringAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceStringAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger Resources_update_trigger created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."Globals"
+      (
+         -- This table is used to store global variables (i.e. not scoped to the account)
+         -- Having a boolean primary key with a CHECK constraint ensures that only one row is ever created
+        "singleRowId" bool NOT NULL PRIMARY KEY DEFAULT true,
+        "lastIndexedUpdateSequence"  bigint NOT NULL DEFAULT 0,
+        CONSTRAINT "singleRow" CHECK("singleRowId" = true)
+      )
+    `);
+    console.log('Table "Globals" created');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS resources."Globals"`);
+    console.log('Table "Globals" dropped');
+    await queryInterface.sequelize.query(
+      `DROP FUNCTION IF EXISTS resources."ResourceStringAttributes_update_trigger"`,
+    );
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceStringAttributes"`,
+    );
+    console.log('Table "ResourceStringAttributes" dropped');
+  },
+};

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -93,6 +93,10 @@ module.exports = {
           OWNER to resources;
     `);
     console.log('Table "Globals" now owned by resources');
+    await queryInterface.sequelize.query(`
+      INSERT INTO resources."Globals" DEFAULT VALUES;
+    `);
+    console.log('Table "Globals" now owned by resources');
   },
 
   down: async queryInterface => {

--- a/resources-service/src/resource/resource-data-access.ts
+++ b/resources-service/src/resource/resource-data-access.ts
@@ -17,29 +17,34 @@
 import { db } from '../connection-pool';
 import { AccountSID } from '@tech-matters/twilio-worker-auth';
 import {
-  SELECT_RESOURCE_BY_ID,
   SELECT_RESOURCE_IDS_WHERE_NAME_CONTAINS,
   SELECT_RESOURCE_IN_IDS,
 } from './sql/resource-get-sql';
 
-export type ReferrableResourceSearchResult = {
-  name: string;
-  id: string;
+export type ReferrableResourceAttribute = {
+  value: string;
+  language: string;
+  info?: any;
 };
 
-// The full resource & the search result are synonyms for now, but the full resource should grow to be a superset
-export type ReferrableResource = ReferrableResourceSearchResult;
+export type ReferrableResourceRecord = {
+  name: string;
+  id: string;
+  attributes: (ReferrableResourceAttribute & { key: string })[];
+};
 
 export const getById = async (
   accountSid: AccountSID,
   resourceId: string,
-): Promise<ReferrableResource | null> =>
-  db.task(async t => t.oneOrNone(SELECT_RESOURCE_BY_ID, { accountSid, resourceId }));
+): Promise<ReferrableResourceRecord | null> =>
+  db.task(async t =>
+    t.oneOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds: [resourceId] }),
+  );
 
 export const getByIdList = async (
   accountSid: AccountSID,
   resourceIds: string[],
-): Promise<ReferrableResource[]> => {
+): Promise<ReferrableResourceRecord[]> => {
   console.debug('Retrieving resources with IDs:', resourceIds);
   return db.task(async t => t.manyOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds }));
 };

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -14,9 +14,15 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const SELECT_RESOURCE_BY_ID = `SELECT id, "name" FROM resources."Resources" AS r WHERE r."accountSid" = $<accountSid> AND r."id" = $<resourceId>`;
-
-export const SELECT_RESOURCE_IN_IDS = `SELECT id, "name" FROM resources."Resources" AS r WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)`;
+export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att.attribute_objects AS "attributes" FROM 
+resources."Resources" AS r 
+LEFT JOIN LATERAL (
+  SELECT COALESCE(jsonb_agg(to_jsonb(rsa)), '[]') AS attribute_objects
+  FROM "ResourceStringAttributes" AS rsa
+  WHERE rsa."accountSid" = $<accountSid> AND rsa."resourceId" IN ($<resourceIds:csv>)
+) AS att ON true
+WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)
+`;
 
 export const SELECT_RESOURCE_IDS_WHERE_NAME_CONTAINS = `
   SELECT id 

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -14,12 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att.attribute_objects AS "attributes" FROM 
+export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att."attributes" FROM 
 resources."Resources" AS r 
 LEFT JOIN LATERAL (
-  SELECT COALESCE(jsonb_agg(to_jsonb(rsa)), '[]') AS attribute_objects
+  SELECT COALESCE(jsonb_agg((SELECT attributeRow FROM (SELECT rsa."key", rsa."value", rsa."language", rsa."info") AS attributeRow)), '[]') AS attributes
   FROM "ResourceStringAttributes" AS rsa
-  WHERE rsa."accountSid" = $<accountSid> AND rsa."resourceId" IN ($<resourceIds:csv>)
+  WHERE rsa."accountSid" = r."accountSid" AND rsa."resourceId" = r.id
 ) AS att ON true
 WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)
 `;

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -18,7 +18,7 @@ import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/
 import { headers, getRequest, getServer } from './server';
 import { db } from '../../src/connection-pool';
 import each from 'jest-each';
-import { ReferrableResource } from '../../src/resource/resource-data-access';
+import { ReferrableResource } from '../../src/resource/resource-model';
 
 export const workerSid = 'WK-worker-sid';
 
@@ -70,6 +70,7 @@ describe('GET /resource', () => {
     expect(response.body).toStrictEqual({
       id: 'RESOURCE_1',
       name: 'Resource 1 (Account 1)',
+      attributes: {},
     });
   });
 });
@@ -96,14 +97,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -119,14 +123,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_4',
           name: 'Resource 4 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -140,22 +147,27 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_4',
           name: 'Resource 4 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -178,18 +190,22 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 4,
@@ -203,10 +219,12 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 4,
@@ -224,10 +242,12 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -243,14 +263,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 3,
@@ -266,14 +289,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 3,

--- a/resources-service/tests/unit/resource/resource-data-access.test.ts
+++ b/resources-service/tests/unit/resource/resource-data-access.test.ts
@@ -35,7 +35,7 @@ describe('getById', () => {
 
     expect(oneOrNoneSpy).toHaveBeenCalledWith(expect.stringContaining('Resources'), {
       accountSid: 'AC_FAKE',
-      resourceId: 'FAKE_RESOURCE',
+      resourceIds: ['FAKE_RESOURCE'],
     });
     expect(result).toStrictEqual({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
   });

--- a/resources-service/tests/unit/resource/resource-data-access.test.ts
+++ b/resources-service/tests/unit/resource/resource-data-access.test.ts
@@ -26,10 +26,15 @@ beforeEach(() => {
 
 describe('getById', () => {
   test('Runs a SELECT against the Resources table on the DB', async () => {
+    const dbRecord = {
+      name: 'Fake Resource',
+      id: 'FAKE_RESOURCE',
+      attributes: [
+        { key: 'attribute1', value: 'value1', language: 'es-ES', info: { some: 'stuff' } },
+      ],
+    };
     mockTask(conn);
-    const oneOrNoneSpy = jest
-      .spyOn(conn, 'oneOrNone')
-      .mockResolvedValue({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
+    const oneOrNoneSpy = jest.spyOn(conn, 'oneOrNone').mockResolvedValue(dbRecord);
 
     const result = await resourceDb.getById('AC_FAKE', 'FAKE_RESOURCE');
 
@@ -37,21 +42,22 @@ describe('getById', () => {
       accountSid: 'AC_FAKE',
       resourceIds: ['FAKE_RESOURCE'],
     });
-    expect(result).toStrictEqual({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
+    expect(result).toStrictEqual(dbRecord);
   });
 });
 
 describe('getByIdList', () => {
   test('Runs a SELECT against the Resources table on the DB, takes the results from the first DB result set and the count from the second', async () => {
     const results = [
-      { name: 'Fake Resource', id: 'FAKE_RESOURCE' },
+      {
+        name: 'Fake Resource',
+        id: 'FAKE_RESOURCE',
+        attributes: [{ key: 'attribute1', value: 'value1', language: 'es-ES', info: {} }],
+      },
       { name: 'Other Fake Resource', id: 'OTHER_FAKE_RESOURCE' },
     ];
     mockTask(conn);
-    const manyOrNoneSpy = jest.spyOn(conn, 'manyOrNone').mockResolvedValue([
-      { name: 'Fake Resource', id: 'FAKE_RESOURCE' },
-      { name: 'Other Fake Resource', id: 'OTHER_FAKE_RESOURCE' },
-    ]);
+    const manyOrNoneSpy = jest.spyOn(conn, 'manyOrNone').mockResolvedValue(results);
 
     const result = await resourceDb.getByIdList('AC_FAKE', [
       'FAKE_RESOURCE',

--- a/resources-service/tests/unit/resource/resources-routes-v0.test.ts
+++ b/resources-service/tests/unit/resource/resources-routes-v0.test.ts
@@ -16,8 +16,7 @@
 
 import { Request, Response, Router } from 'express';
 import resourceRoutes from '../../../src/resource/resource-routes-v0';
-import { searchResources } from '../../../src/resource/resource-model';
-import { ReferrableResource } from '../../../src/resource/resource-data-access';
+import { ReferrableResource, searchResources } from '../../../src/resource/resource-model';
 
 jest.mock('express', () => ({
   Router: jest.fn(),
@@ -60,11 +59,20 @@ describe('POST /search', () => {
   });
 
   test('Takes limit & start from query string, search parameters from body and returns resources from model as JSON', async () => {
-    const modelResult = {
+    const modelResult: { totalCount: number; results: ReferrableResource[] } = {
       totalCount: 100,
       results: [
-        { id: 'RESOURCE_1', name: 'Resource 1' },
-        { id: 'RESOURCE_2', name: 'Resource 2' },
+        {
+          id: 'RESOURCE_1',
+          name: 'Resource 1',
+          attributes: {
+            someAttribute: [
+              { value: 'some value', language: 'en-US' },
+              { value: 'some value', language: 'fr-FR' },
+            ],
+          },
+        },
+        { id: 'RESOURCE_2', name: 'Resource 2', attributes: {} },
       ],
     };
     mockSearchResources.mockResolvedValue(modelResult);


### PR DESCRIPTION
## Description

* Adds storage for inline string attributes that can be attached to Resources
* Adds API support for reading any attributes attached to resources as part of searches & single resource retrievals
* Adds a 'Globals' table where we can read & update the lastIndexId that tracks how much of the resource data is indexed in cloudsearch

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
CHI-1136

### Verification steps

* Automated Service Tests cover the new functions, and it will be further tested by the UI when it is added in future stories
