### PR TITLE
excessive eslint memory use in local dev

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,5 +42,11 @@ module.exports = {
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
   },
-  ignorePatterns: ['cdk.out/**', '**/dist/**', '**/coverage/**'],
+  ignorePatterns: [
+    'cdk.out/**',
+    '**/dist/**',
+    '**/coverage/**',
+    'node_modules/**',
+    '**/node_modules/**',
+  ],
 };

--- a/.github/workflows/hrm-ci.yml
+++ b/.github/workflows/hrm-ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Run Lint
-        run: npm run lint --if-present
+        run: npm run lint
 
   test:
     runs-on: ubuntu-latest

--- a/hrm-service/migrations/20230106122325-add-contact-jobs-failures.js
+++ b/hrm-service/migrations/20230106122325-add-contact-jobs-failures.js
@@ -18,7 +18,7 @@
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-  async up(queryInterface, Sequelize) {
+  async up(queryInterface) {
     await queryInterface.sequelize.query(`
     CREATE SEQUENCE IF NOT EXISTS public."ContactJobsFailures_id_seq"
         INCREMENT 1
@@ -71,7 +71,7 @@ module.exports = {
     console.log('Index ContactJobs_poll_due_idx created');
   },
 
-  async down(queryInterface, Sequelize) {
+  async down(queryInterface) {
     await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "ContactJobs_poll_due_idx";`);
 
     await queryInterface.sequelize.query(`

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-module.exports = (config) => {
+module.exports = config => {
   return (
     config || {
       preset: 'ts-jest',

--- a/jobs/contact-retrieve-transcript/index.ts
+++ b/jobs/contact-retrieve-transcript/index.ts
@@ -18,7 +18,7 @@
 import { SQS } from 'aws-sdk';
 
 import { ContactJobProcessorError } from '@tech-matters/hrm-job-errors';
-import { getSsmParameter } from '@tech-matters/hrm-ssm-cache';
+import { getSsmParameter, loadSsmCache } from '@tech-matters/hrm-ssm-cache';
 import { exportTranscript } from './exportTranscript';
 import { uploadTranscript } from './uploadTranscript';
 

--- a/jobs/contact-retrieve-transcript/index.ts
+++ b/jobs/contact-retrieve-transcript/index.ts
@@ -18,7 +18,7 @@
 import { SQS } from 'aws-sdk';
 
 import { ContactJobProcessorError } from '@tech-matters/hrm-job-errors';
-import { getSsmParameter, loadSsmCache } from '@tech-matters/hrm-ssm-cache';
+import { getSsmParameter } from '@tech-matters/hrm-ssm-cache';
 import { exportTranscript } from './exportTranscript';
 import { uploadTranscript } from './uploadTranscript';
 

--- a/jobs/contact-retrieve-transcript/jest.config.js
+++ b/jobs/contact-retrieve-transcript/jest.config.js
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-module.exports = (config) => {
+module.exports = config => {
   return (
     config || {
       preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "docker:compose:jobs:up": "completed_sqs_queue_url=$(npx ts-node jobs/tests/getContactCompleteQueueUrl.ts) docker-compose -p hrm -f jobs/docker-compose.yml up -d",
     "docker:compose:localstack:up": "docker-compose -p hrm up -d",
     "docker:compose:service:up": "docker-compose -p hrm -f hrm-service/docker-compose.yml up -d",
-    "lint": "cross-env NODE_OPTIONS=--max-old-space-size=8096 eslint --ext ts .",
+    "lint": "cross-env eslint .",
     "lint:fix": "npm run lint -- --fix",
     "localstack:bootstrap": "cross-env AWS_REGION=eu-west-1 cdklocal bootstrap",
     "localstack:deploy": "cross-env AWS_REGION=eu-west-1 cdklocal deploy --all --outputs-file ./cdk/outputs.json",

--- a/packages/ssm-cache/jest.config.js
+++ b/packages/ssm-cache/jest.config.js
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-module.exports = (config) => {
+module.exports = config => {
   return (
     config || {
       preset: 'ts-jest',

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "include": [".eslintrc.js", "jest.config.js", "**/*.ts", "**/*.js"],
-  "exclude": ["**/coverage/**"]
+  "exclude": ["cdk.out/**", "**/dist/**", "**/coverage/**", "node_modules/**", "**/node_modules/**"]
 }


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Fixes a nit where eslint was building/checking ts within node_modules which was using an enormous amount of memory.

Also `.js` files weren't being linted because the call to eslint was specifying `--ext ts`.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Run `npm run lint` and/or `npm run lint:fix` from top level and it should detect issues in full project and not run out of memory.
