### PR TITLE
Chi 1418 resource string refs

### DIFF
--- a/resources-service/migrations/20230120154500-create-resources-table.js
+++ b/resources-service/migrations/20230120154500-create-resources-table.js
@@ -98,7 +98,9 @@ module.exports = {
   },
 
   down: async queryInterface => {
-    await queryInterface.sequelize.query(`DROP FUNCTION IF EXISTS resources."Resources"`);
+    await queryInterface.sequelize.query(
+      `DROP FUNCTION IF EXISTS resources."Resources_updateSequence_trigger"`,
+    );
     await queryInterface.sequelize.query(`DROP TABLE IF EXISTS resources."Resources"`);
     await queryInterface.sequelize.query(
       `DROP SEQUENCE IF EXISTS resources."Resources_updates_seq"`,

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -74,7 +74,7 @@ module.exports = {
       WHEN (pg_trigger_depth() = 0)
       EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
     `);
-    console.log('Trigger Resources_update_trigger created');
+    console.log('Trigger ResourceStringAttributes_update_trigger created');
 
     await queryInterface.sequelize.query(`
       CREATE TABLE IF NOT EXISTS resources."Globals"
@@ -87,6 +87,12 @@ module.exports = {
       )
     `);
     console.log('Table "Globals" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."Globals"
+          OWNER to resources;
+    `);
+    console.log('Table "Globals" now owned by resources');
   },
 
   down: async queryInterface => {

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceStringAttributes"
+      (
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "language" text COLLATE pg_catalog."default" NOT NULL,
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceStringAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "language", "value")
+      )
+    `);
+    console.log('Table "ResourceStringAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."ResourceStringAttributes"
+          OWNER to resources;
+    `);
+    console.log('Table "ResourceStringAttributes" now owned by resources');
+
+    await queryInterface.sequelize.query(`
+      CREATE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        NOT LEAKPROOF
+      AS $BODY$
+      BEGIN
+        IF TG_WHEN <> 'BEFORE' THEN
+          RAISE EXCEPTION 'ResourcesLookupTables_updateSequence_trigger() may only run as an BEFORE trigger';
+        END IF;
+
+        IF (TG_LEVEL <> 'ROW' OR (TG_OP <> 'UPDATE')) THEN
+          RAISE EXCEPTION 'ResourcesLookupTables_updateSequence_trigger() added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
+          RETURN NULL;
+        END IF;
+        
+        NEW."updateSequence" = nextval('"Resources_updates_seq"'::regclass);
+        RETURN NEW;
+      END
+      $BODY$;
+    `);
+    console.log('Function "ResourcesLookupTables_updateSequence_trigger" created.');
+
+    await queryInterface.sequelize.query(
+      `ALTER FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"() OWNER TO resources`,
+    );
+    console.log('Function "ResourcesLookupTables_updateSequence_trigger" ownership altered.');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceStringAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceStringAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger Resources_update_trigger created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."Globals"
+      (
+         -- This table is used to store global variables (i.e. not scoped to the account)
+         -- Having a boolean primary key with a CHECK constraint ensures that only one row is ever created
+        "singleRowId" bool NOT NULL PRIMARY KEY DEFAULT true,
+        "lastIndexedUpdateSequence"  bigint NOT NULL DEFAULT 0,
+        CONSTRAINT "singleRow" CHECK("singleRowId" = true)
+      )
+    `);
+    console.log('Table "Globals" created');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`DROP TABLE IF EXISTS resources."Globals"`);
+    console.log('Table "Globals" dropped');
+    await queryInterface.sequelize.query(
+      `DROP FUNCTION IF EXISTS resources."ResourceStringAttributes_update_trigger"`,
+    );
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceStringAttributes"`,
+    );
+    console.log('Table "ResourceStringAttributes" dropped');
+  },
+};

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -102,9 +102,12 @@ module.exports = {
   down: async queryInterface => {
     await queryInterface.sequelize.query(`DROP TABLE IF EXISTS resources."Globals"`);
     console.log('Table "Globals" dropped');
+
     await queryInterface.sequelize.query(
-      `DROP FUNCTION IF EXISTS resources."ResourceStringAttributes_update_trigger"`,
+      `DROP FUNCTION IF EXISTS resources."ResourcesLookupTables_updateSequence_trigger"`,
     );
+    console.log('Function "ResourcesLookupTables_updateSequence_trigger" dropped');
+
     await queryInterface.sequelize.query(
       `DROP TABLE IF EXISTS resources."ResourceStringAttributes"`,
     );

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -27,7 +27,11 @@ module.exports = {
         "info" JSONB,
         "lastUpdated" timestamp with time zone,
         "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
-        CONSTRAINT "ResourceStringAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "language", "value")
+        CONSTRAINT "ResourceStringAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "language", "value"),
+        CONSTRAINT "FK_ResourceStringAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
+            REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
       )
     `);
     console.log('Table "ResourceStringAttributes" created');

--- a/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
+++ b/resources-service/migrations/20230223150400-create-resource-string-attributes-table.js
@@ -93,6 +93,10 @@ module.exports = {
           OWNER to resources;
     `);
     console.log('Table "Globals" now owned by resources');
+    await queryInterface.sequelize.query(`
+      INSERT INTO resources."Globals" DEFAULT VALUES;
+    `);
+    console.log('Table "Globals" now owned by resources');
   },
 
   down: async queryInterface => {

--- a/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
+++ b/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
@@ -110,17 +110,7 @@ module.exports = {
     `);
     console.log('Removed ResourceStringAttributes old primary key');
     await queryInterface.sequelize.query(`
-      ALTER TABLE resources."ResourceStringAttributes" DROP CONSTRAINT IF EXISTS "UQ_Account_Resource_Key_Language_Value";
-    `);
-    console.log(
-      'Removed ResourceStringAttributes unique constraint, in case it already existed for some reason',
-    );
-    await queryInterface.sequelize.query(`
       ALTER TABLE resources."ResourceStringAttributes" ADD PRIMARY KEY (id, "accountSid");
-    `);
-    console.log('Added ResourceStringAttributes unique constraint');
-    await queryInterface.sequelize.query(`
-      ALTER TABLE resources."ResourceStringAttributes" ADD CONSTRAINT "UQ_Account_Resource_Key_Language_Value" UNIQUE ("resourceId", "accountSid", "key", "language", "value");
     `);
     console.log('Added ResourceStringAttributes unique constraint in place of old primary key');
     await queryInterface.sequelize.query(`

--- a/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
+++ b/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceReferenceStringAttributeValues"
+      (
+        id text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "language" text COLLATE pg_catalog."default" NOT NULL,
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceReferenceStringAttributeValues_pkey" PRIMARY KEY (id, "accountSid")
+      )
+    `);
+    console.log('Table "ResourceReferenceStringAttributeValues" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."ResourceReferenceStringAttributeValues"
+          OWNER to resources;
+    `);
+    console.log('Table "ResourceReferenceStringAttributeValues" now owned by resources');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceReferenceStringAttributeValues_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceReferenceStringAttributeValues"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger ResourceReferenceStringAttributeValues_update_trigger created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceReferenceStringAttributes"
+      (
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "referenceId" text COLLATE pg_catalog."default" NOT NULL,
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceReferenceStringAttribute_pkey" PRIMARY KEY ("resourceId", "accountSid", "referenceId"),
+        CONSTRAINT "FK_ResourceReferenceStringAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
+            REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE,
+        CONSTRAINT "FK_ResourceReferenceStringAttributes_ResourceReferenceStringAttributeValues" FOREIGN KEY ("referenceId", "accountSid")
+            REFERENCES resources."ResourceReferenceStringAttributeValues" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+      )
+    `);
+    console.log('Table "ResourceReferenceStringAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS resources."ResourceReferenceStringAttributes"
+          OWNER to resources;
+    `);
+    console.log('Table "ResourceReferenceStringAttributes" now owned by resources');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceReferenceStringAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceReferenceStringAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger ResourceReferenceStringAttributes_update_trigger created');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceReferenceStringAttributes"`,
+    );
+    console.log('Table "ResourceReferenceStringAttributes" dropped');
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceReferenceStringAttributeValues"`,
+    );
+    console.log('Table "ResourceReferenceStringAttributeValues" dropped');
+  },
+};

--- a/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
+++ b/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
@@ -21,12 +21,13 @@ module.exports = {
       (
         id text COLLATE pg_catalog."default" NOT NULL,
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "list" text COLLATE pg_catalog."default" NOT NULL,
         "value" text COLLATE pg_catalog."default" NOT NULL,
         "language" text COLLATE pg_catalog."default" NOT NULL,
         "info" JSONB,
         "lastUpdated" timestamp with time zone,
         "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
-        CONSTRAINT "ResourceReferenceStringAttributeValues_pkey" PRIMARY KEY (id, "accountSid")
+        CONSTRAINT "ResourceReferenceStringAttributeValues_pkey" PRIMARY KEY (id, "list", "accountSid")
       )
     `);
     console.log('Table "ResourceReferenceStringAttributeValues" created');
@@ -60,15 +61,16 @@ module.exports = {
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
         "resourceId" text COLLATE pg_catalog."default" NOT NULL,
         "key" text COLLATE pg_catalog."default" NOT NULL,
+        "list" text COLLATE pg_catalog."default" NOT NULL,
         "referenceId" text COLLATE pg_catalog."default" NOT NULL,
         "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
-        CONSTRAINT "ResourceReferenceStringAttribute_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "referenceId"),
+        CONSTRAINT "ResourceReferenceStringAttribute_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "list", "referenceId"),
         CONSTRAINT "FK_ResourceReferenceStringAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
             REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
             ON UPDATE CASCADE
             ON DELETE CASCADE,
-        CONSTRAINT "FK_ResourceReferenceStringAttributes_ResourceReferenceStringAttributeValues" FOREIGN KEY ("referenceId", "accountSid")
-            REFERENCES resources."ResourceReferenceStringAttributeValues" (id, "accountSid") MATCH SIMPLE
+        CONSTRAINT "FK_ResourceReferenceStringAttributes_ResourceReferenceStringAttributeValues" FOREIGN KEY ("referenceId", "list", "accountSid")
+            REFERENCES resources."ResourceReferenceStringAttributeValues" (id, "list", "accountSid") MATCH SIMPLE
             ON UPDATE CASCADE
             ON DELETE CASCADE
       )

--- a/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
+++ b/resources-service/migrations/20230224164100-create-resource-string-reference-attributes-tables.js
@@ -21,7 +21,6 @@ module.exports = {
       (
         id text COLLATE pg_catalog."default" NOT NULL,
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
-        "key" text COLLATE pg_catalog."default" NOT NULL,
         "value" text COLLATE pg_catalog."default" NOT NULL,
         "language" text COLLATE pg_catalog."default" NOT NULL,
         "info" JSONB,
@@ -39,6 +38,13 @@ module.exports = {
     console.log('Table "ResourceReferenceStringAttributeValues" now owned by resources');
 
     await queryInterface.sequelize.query(`
+      DROP TRIGGER IF EXISTS "ResourceReferenceStringAttributeValues_update_trigger"
+      ON resources."ResourceReferenceStringAttributeValues"
+    `);
+    console.log(
+      'Trigger ResourceReferenceStringAttributeValues_update_trigger dropped (if it existed)',
+    );
+    await queryInterface.sequelize.query(`
       CREATE TRIGGER "ResourceReferenceStringAttributeValues_update_trigger"
       BEFORE UPDATE
       ON resources."ResourceReferenceStringAttributeValues"
@@ -52,10 +58,11 @@ module.exports = {
       CREATE TABLE IF NOT EXISTS resources."ResourceReferenceStringAttributes"
       (
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
-        "referenceId" text COLLATE pg_catalog."default" NOT NULL,
         "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "referenceId" text COLLATE pg_catalog."default" NOT NULL,
         "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
-        CONSTRAINT "ResourceReferenceStringAttribute_pkey" PRIMARY KEY ("resourceId", "accountSid", "referenceId"),
+        CONSTRAINT "ResourceReferenceStringAttribute_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "referenceId"),
         CONSTRAINT "FK_ResourceReferenceStringAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
             REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
             ON UPDATE CASCADE
@@ -73,6 +80,12 @@ module.exports = {
           OWNER to resources;
     `);
     console.log('Table "ResourceReferenceStringAttributes" now owned by resources');
+
+    await queryInterface.sequelize.query(`
+      DROP TRIGGER IF EXISTS "ResourceReferenceStringAttributes_update_trigger"
+      ON resources."ResourceReferenceStringAttributes";
+    `);
+    console.log('Trigger ResourceReferenceStringAttributes_update_trigger dropped (if it existed)');
 
     await queryInterface.sequelize.query(`
       CREATE TRIGGER "ResourceReferenceStringAttributes_update_trigger"

--- a/resources-service/src/resource/resource-data-access.ts
+++ b/resources-service/src/resource/resource-data-access.ts
@@ -36,17 +36,24 @@ export type ReferrableResourceRecord = {
 export const getById = async (
   accountSid: AccountSID,
   resourceId: string,
-): Promise<ReferrableResourceRecord | null> =>
-  db.task(async t =>
+): Promise<ReferrableResourceRecord | null> => {
+  const res = await db.task(async t =>
     t.oneOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds: [resourceId] }),
   );
+  console.debug('Retrieved resource:', JSON.stringify(res, null, 2));
+  return res;
+};
 
 export const getByIdList = async (
   accountSid: AccountSID,
   resourceIds: string[],
 ): Promise<ReferrableResourceRecord[]> => {
   console.debug('Retrieving resources with IDs:', resourceIds);
-  return db.task(async t => t.manyOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds }));
+  const res = await db.task(async t =>
+    t.manyOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds }),
+  );
+  console.debug('Retrieved resources:', JSON.stringify(res, null, 2));
+  return res;
 };
 
 export const getWhereNameContains = async (

--- a/resources-service/src/resource/resource-data-access.ts
+++ b/resources-service/src/resource/resource-data-access.ts
@@ -17,29 +17,34 @@
 import { db } from '../connection-pool';
 import { AccountSID } from '@tech-matters/twilio-worker-auth';
 import {
-  SELECT_RESOURCE_BY_ID,
   SELECT_RESOURCE_IDS_WHERE_NAME_CONTAINS,
   SELECT_RESOURCE_IN_IDS,
 } from './sql/resource-get-sql';
 
-export type ReferrableResourceSearchResult = {
-  name: string;
-  id: string;
+export type ReferrableResourceAttribute = {
+  value: string;
+  language: string;
+  info?: any;
 };
 
-// The full resource & the search result are synonyms for now, but the full resource should grow to be a superset
-export type ReferrableResource = ReferrableResourceSearchResult;
+export type ReferrableResourceRecord = {
+  name: string;
+  id: string;
+  attributes: (ReferrableResourceAttribute & { key: string })[];
+};
 
 export const getById = async (
   accountSid: AccountSID,
   resourceId: string,
-): Promise<ReferrableResource | null> =>
-  db.task(async t => t.oneOrNone(SELECT_RESOURCE_BY_ID, { accountSid, resourceId }));
+): Promise<ReferrableResourceRecord | null> =>
+  db.task(async t =>
+    t.oneOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds: [resourceId] }),
+  );
 
 export const getByIdList = async (
   accountSid: AccountSID,
   resourceIds: string[],
-): Promise<ReferrableResource[]> => {
+): Promise<ReferrableResourceRecord[]> => {
   console.debug('Retrieving resources with IDs:', resourceIds);
   return db.task(async t => t.manyOrNone(SELECT_RESOURCE_IN_IDS, { accountSid, resourceIds }));
 };

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -23,7 +23,7 @@ LEFT JOIN LATERAL (
         FROM resources."ResourceStringAttributes" AS rsa
         WHERE rsa."accountSid" = r."accountSid" AND rsa."resourceId" = r.id
       UNION ALL 
-        SELECT rrsav."key", rrsav."value", rrsav."language", rrsav."info"
+        SELECT rrsa."key", rrsav."value", rrsav."language", rrsav."info"
         FROM 
         resources."ResourceReferenceStringAttributes" AS rrsa
         INNER JOIN resources."ResourceReferenceStringAttributeValues" AS rrsav ON rrsav."accountSid" = rrsa."accountSid" AND rrsav."id" = rrsa."referenceId"

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -14,9 +14,15 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const SELECT_RESOURCE_BY_ID = `SELECT id, "name" FROM resources."Resources" AS r WHERE r."accountSid" = $<accountSid> AND r."id" = $<resourceId>`;
-
-export const SELECT_RESOURCE_IN_IDS = `SELECT id, "name" FROM resources."Resources" AS r WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)`;
+export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att.attribute_objects AS "attributes" FROM 
+resources."Resources" AS r 
+LEFT JOIN LATERAL (
+  SELECT COALESCE(jsonb_agg(to_jsonb(rsa)), '[]') AS attribute_objects
+  FROM "ResourceStringAttributes" AS rsa
+  WHERE rsa."accountSid" = $<accountSid> AND rsa."resourceId" IN ($<resourceIds:csv>)
+) AS att ON true
+WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)
+`;
 
 export const SELECT_RESOURCE_IDS_WHERE_NAME_CONTAINS = `
   SELECT id 

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -14,12 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att.attribute_objects AS "attributes" FROM 
+export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att."attributes" FROM 
 resources."Resources" AS r 
 LEFT JOIN LATERAL (
-  SELECT COALESCE(jsonb_agg(to_jsonb(rsa)), '[]') AS attribute_objects
+  SELECT COALESCE(jsonb_agg((SELECT attributeRow FROM (SELECT rsa."key", rsa."value", rsa."language", rsa."info") AS attributeRow)), '[]') AS attributes
   FROM "ResourceStringAttributes" AS rsa
-  WHERE rsa."accountSid" = $<accountSid> AND rsa."resourceId" IN ($<resourceIds:csv>)
+  WHERE rsa."accountSid" = r."accountSid" AND rsa."resourceId" = r.id
 ) AS att ON true
 WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)
 `;

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -17,9 +17,18 @@
 export const SELECT_RESOURCE_IN_IDS = `SELECT r.id, r."name", att."attributes" FROM 
 resources."Resources" AS r 
 LEFT JOIN LATERAL (
-  SELECT COALESCE(jsonb_agg((SELECT attributeRow FROM (SELECT rsa."key", rsa."value", rsa."language", rsa."info") AS attributeRow)), '[]') AS attributes
-  FROM "ResourceStringAttributes" AS rsa
-  WHERE rsa."accountSid" = r."accountSid" AND rsa."resourceId" = r.id
+  SELECT COALESCE(jsonb_agg((SELECT attributeRow FROM (SELECT ra."key", ra."value", ra."language", ra."info") AS attributeRow)), '[]') AS attributes
+    FROM (
+        SELECT rsa."key", rsa."value", rsa."language", rsa."info" 
+        FROM resources."ResourceStringAttributes" AS rsa
+        WHERE rsa."accountSid" = r."accountSid" AND rsa."resourceId" = r.id
+      UNION ALL 
+        SELECT rrsav."key", rrsav."value", rrsav."language", rrsav."info"
+        FROM 
+        resources."ResourceReferenceStringAttributes" AS rrsa
+        INNER JOIN resources."ResourceReferenceStringAttributeValues" AS rrsav ON rrsav."accountSid" = rrsa."accountSid" AND rrsav."id" = rrsa."referenceId"
+        WHERE rrsa."accountSid" = r."accountSid" AND rrsa."resourceId" = r.id
+    ) AS ra
 ) AS att ON true
 WHERE r."accountSid" = $<accountSid> AND r."id" IN ($<resourceIds:csv>)
 `;

--- a/resources-service/src/resource/sql/resource-get-sql.ts
+++ b/resources-service/src/resource/sql/resource-get-sql.ts
@@ -26,7 +26,10 @@ LEFT JOIN LATERAL (
         SELECT rrsa."key", rrsav."value", rrsav."language", rrsav."info"
         FROM 
         resources."ResourceReferenceStringAttributes" AS rrsa
-        INNER JOIN resources."ResourceReferenceStringAttributeValues" AS rrsav ON rrsav."accountSid" = rrsa."accountSid" AND rrsav."id" = rrsa."referenceId"
+        INNER JOIN resources."ResourceReferenceStringAttributeValues" AS rrsav  ON 
+          rrsav."accountSid" = rrsa."accountSid" 
+          AND rrsav."list" = rrsa."list" 
+          AND rrsav."id" = rrsa."referenceId"
         WHERE rrsa."accountSid" = r."accountSid" AND rrsa."resourceId" = r.id
     ) AS ra
 ) AS att ON true

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -18,7 +18,7 @@ import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/
 import { headers, getRequest, getServer } from './server';
 import { db } from '../../src/connection-pool';
 import each from 'jest-each';
-import { ReferrableResource } from '../../src/resource/resource-data-access';
+import { ReferrableResource } from '../../src/resource/resource-model';
 
 export const workerSid = 'WK-worker-sid';
 
@@ -70,6 +70,7 @@ describe('GET /resource', () => {
     expect(response.body).toStrictEqual({
       id: 'RESOURCE_1',
       name: 'Resource 1 (Account 1)',
+      attributes: {},
     });
   });
 });
@@ -96,14 +97,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -119,14 +123,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_4',
           name: 'Resource 4 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -140,22 +147,27 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_4',
           name: 'Resource 4 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -178,18 +190,22 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_3',
           name: 'Resource 3 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 4,
@@ -203,10 +219,12 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 4,
@@ -224,10 +242,12 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 5,
@@ -243,14 +263,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 3,
@@ -266,14 +289,17 @@ describe('POST /search', () => {
         {
           id: 'RESOURCE_0',
           name: 'Resource 0 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_2',
           name: 'Resource 2 (Account 1)',
+          attributes: {},
         },
         {
           id: 'RESOURCE_1',
           name: 'Resource 1 (Account 1)',
+          attributes: {},
         },
       ],
       expectedTotalCount: 3,

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -113,11 +113,10 @@ describe('GET /resource', () => {
               range((parseInt(valueIndex) % 2) + 1).map(
                 // alternate between 1 and 2  language values
                 languageIndex =>
-                  `INSERT INTO resources."ResourceReferenceStringAttributeValues" (id, "accountSid", "key", "value", "language", "info") 
+                  `INSERT INTO resources."ResourceReferenceStringAttributeValues" (id, "accountSid", "value", "language", "info") 
                         VALUES (
                             'REF_${keyIndex}_${valueIndex}_${languageIndex}', 
                             'REFERENCES_TEST_ACCOUNT_${accountIndex}', 
-                            'REFERENCE_KEY_${keyIndex}', 
                             'REFERENCE_VALUE_${valueIndex}', 
                             'LANGUAGE_${languageIndex}', 
                             ${
@@ -154,8 +153,8 @@ describe('GET /resource', () => {
         description: `Single referenced attribute value - returns referenced value`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-            ("accountSid", "resourceId", "referenceId")
-            VALUES ('REFERENCES_TEST_ACCOUNT_0','RESOURCE_0', 'REF_1_0_0')`,
+            ("accountSid", "resourceId", "key", "referenceId")
+            VALUES ('REFERENCES_TEST_ACCOUNT_0','RESOURCE_0', 'REFERENCE_KEY_1', 'REF_1_0_0')`,
         ],
         nameSubstring: 'Resource 0',
         expectedResult: {
@@ -179,8 +178,8 @@ describe('GET /resource', () => {
         setupSqlStatements: range(3).map(
           valueIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_7_${valueIndex}_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_7', 'REF_7_${valueIndex}_0')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -201,8 +200,8 @@ describe('GET /resource', () => {
         setupSqlStatements: range(2).map(
           languageIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_5_3_${languageIndex}')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_5', 'REF_5_3_${languageIndex}')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -226,9 +225,10 @@ describe('GET /resource', () => {
         setupSqlStatements: range(3).map(
           keyIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_${parseInt(keyIndex) +
-                  6}_5_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_${parseInt(
+                  keyIndex,
+                ) + 6}', 'REF_${parseInt(keyIndex) + 6}_5_0')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -253,8 +253,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under different keys - returns ALL values under their respective keys`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'INLINE_KEY', 'INLINE_VALUE', 'INLINE_LANGUAGE')`,
@@ -286,8 +286,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under same keys - returns all values under the one key`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'INLINE_VALUE', 'LANGUAGE_0')`,
@@ -317,8 +317,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under same keys with same values but different languages - returns all values under the one key`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REFERENCE_VALUE_5', 'INLINE_LANGUAGE')`,
@@ -348,8 +348,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes keys exist for same resource with same key value and language - returns both values`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language", "info") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REFERENCE_VALUE_5', 'LANGUAGE_0', '{ "different": "info" }')`,
@@ -663,17 +663,16 @@ describe('POST /search', () => {
     beforeEach(async () => {
       await db.multi(`
 INSERT INTO resources."ResourceReferenceStringAttributeValues" 
-  (id, "accountSid", "key", "value", "language", "info") 
+  (id, "accountSid", "value", "language", "info") 
   VALUES (
       'REF_SEARCH_TEST_ATTRIBUTE', 
       'ACCOUNT_1', 
-      'REFERENCE_KEY', 
       'REFERENCE_VALUE', 
       'REFERENCE_LANGUAGE', 
       '{ "property": "VALUE" }');
 INSERT INTO resources."ResourceReferenceStringAttributes" 
-  ("accountSid", "resourceId", "referenceId") 
-  VALUES ('ACCOUNT_1', 'RESOURCE_1', 'REF_SEARCH_TEST_ATTRIBUTE');
+  ("accountSid", "resourceId", "key", "referenceId") 
+  VALUES ('ACCOUNT_1', 'RESOURCE_1', 'REFERENCE_KEY', 'REF_SEARCH_TEST_ATTRIBUTE');
       `);
     });
     test('should return the resource with the referenced attributes', async () => {

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -113,10 +113,11 @@ describe('GET /resource', () => {
               range((parseInt(valueIndex) % 2) + 1).map(
                 // alternate between 1 and 2  language values
                 languageIndex =>
-                  `INSERT INTO resources."ResourceReferenceStringAttributeValues" (id, "accountSid", "value", "language", "info") 
+                  `INSERT INTO resources."ResourceReferenceStringAttributeValues" (id, "accountSid", "list", "value", "language", "info") 
                         VALUES (
-                            'REF_${keyIndex}_${valueIndex}_${languageIndex}', 
+                            'REF_${valueIndex}_${languageIndex}', 
                             'REFERENCES_TEST_ACCOUNT_${accountIndex}', 
+                            'LIST_${keyIndex}',
                             'REFERENCE_VALUE_${valueIndex}', 
                             'LANGUAGE_${languageIndex}', 
                             ${
@@ -153,8 +154,8 @@ describe('GET /resource', () => {
         description: `Single referenced attribute value - returns referenced value`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-            ("accountSid", "resourceId", "key", "referenceId")
-            VALUES ('REFERENCES_TEST_ACCOUNT_0','RESOURCE_0', 'REFERENCE_KEY_1', 'REF_1_0_0')`,
+            ("accountSid", "resourceId", "key", "list", "referenceId")
+            VALUES ('REFERENCES_TEST_ACCOUNT_0','RESOURCE_0', 'REFERENCE_KEY_1', 'LIST_1', 'REF_0_0')`,
         ],
         nameSubstring: 'Resource 0',
         expectedResult: {
@@ -178,8 +179,8 @@ describe('GET /resource', () => {
         setupSqlStatements: range(3).map(
           valueIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_7', 'REF_7_${valueIndex}_0')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_7', 'LIST_7', 'REF_${valueIndex}_0')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -200,8 +201,8 @@ describe('GET /resource', () => {
         setupSqlStatements: range(2).map(
           languageIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_5', 'REF_5_3_${languageIndex}')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_5', 'LIST_5', 'REF_3_${languageIndex}')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -225,10 +226,10 @@ describe('GET /resource', () => {
         setupSqlStatements: range(3).map(
           keyIndex =>
             `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_${parseInt(
                   keyIndex,
-                ) + 6}', 'REF_${parseInt(keyIndex) + 6}_5_0')`,
+                ) + 6}', 'LIST_${parseInt(keyIndex) + 6}', 'REF_5_0')`,
         ),
         expectedResult: {
           id: 'RESOURCE_0',
@@ -253,8 +254,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under different keys - returns ALL values under their respective keys`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'LIST_6', 'REF_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'INLINE_KEY', 'INLINE_VALUE', 'INLINE_LANGUAGE')`,
@@ -286,8 +287,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under same keys - returns all values under the one key`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'LIST_6', 'REF_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'INLINE_VALUE', 'LANGUAGE_0')`,
@@ -317,8 +318,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes under same keys with same values but different languages - returns all values under the one key`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'LIST_6', 'REF_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REFERENCE_VALUE_5', 'INLINE_LANGUAGE')`,
@@ -348,8 +349,8 @@ describe('GET /resource', () => {
         description: `Referenced attribute values and inline attributes keys exist for same resource with same key value and language - returns both values`,
         setupSqlStatements: [
           `INSERT INTO resources."ResourceReferenceStringAttributes" 
-                ("accountSid", "resourceId", "key", "referenceId") 
-                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REF_6_5_0')`,
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'LIST_6', 'REF_5_0')`,
           `INSERT INTO resources."ResourceStringAttributes" 
                 ("accountSid", "resourceId", "key", "value", "language", "info") 
                 VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE_KEY_6', 'REFERENCE_VALUE_5', 'LANGUAGE_0', '{ "different": "info" }')`,
@@ -663,16 +664,17 @@ describe('POST /search', () => {
     beforeEach(async () => {
       await db.multi(`
 INSERT INTO resources."ResourceReferenceStringAttributeValues" 
-  (id, "accountSid", "value", "language", "info") 
+  (id, "accountSid", "list", "value", "language", "info") 
   VALUES (
       'REF_SEARCH_TEST_ATTRIBUTE', 
       'ACCOUNT_1', 
+      'REFERENCE_LIST',
       'REFERENCE_VALUE', 
       'REFERENCE_LANGUAGE', 
       '{ "property": "VALUE" }');
 INSERT INTO resources."ResourceReferenceStringAttributes" 
-  ("accountSid", "resourceId", "key", "referenceId") 
-  VALUES ('ACCOUNT_1', 'RESOURCE_1', 'REFERENCE_KEY', 'REF_SEARCH_TEST_ATTRIBUTE');
+  ("accountSid", "resourceId", "key", "list", "referenceId") 
+  VALUES ('ACCOUNT_1', 'RESOURCE_1', 'REFERENCE_KEY', 'REFERENCE_LIST', 'REF_SEARCH_TEST_ATTRIBUTE');
       `);
     });
     test('should return the resource with the referenced attributes', async () => {

--- a/resources-service/tests/unit/resource/resource-data-access.test.ts
+++ b/resources-service/tests/unit/resource/resource-data-access.test.ts
@@ -35,7 +35,7 @@ describe('getById', () => {
 
     expect(oneOrNoneSpy).toHaveBeenCalledWith(expect.stringContaining('Resources'), {
       accountSid: 'AC_FAKE',
-      resourceId: 'FAKE_RESOURCE',
+      resourceIds: ['FAKE_RESOURCE'],
     });
     expect(result).toStrictEqual({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
   });

--- a/resources-service/tests/unit/resource/resource-data-access.test.ts
+++ b/resources-service/tests/unit/resource/resource-data-access.test.ts
@@ -26,10 +26,15 @@ beforeEach(() => {
 
 describe('getById', () => {
   test('Runs a SELECT against the Resources table on the DB', async () => {
+    const dbRecord = {
+      name: 'Fake Resource',
+      id: 'FAKE_RESOURCE',
+      attributes: [
+        { key: 'attribute1', value: 'value1', language: 'es-ES', info: { some: 'stuff' } },
+      ],
+    };
     mockTask(conn);
-    const oneOrNoneSpy = jest
-      .spyOn(conn, 'oneOrNone')
-      .mockResolvedValue({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
+    const oneOrNoneSpy = jest.spyOn(conn, 'oneOrNone').mockResolvedValue(dbRecord);
 
     const result = await resourceDb.getById('AC_FAKE', 'FAKE_RESOURCE');
 
@@ -37,21 +42,22 @@ describe('getById', () => {
       accountSid: 'AC_FAKE',
       resourceIds: ['FAKE_RESOURCE'],
     });
-    expect(result).toStrictEqual({ name: 'Fake Resource', id: 'FAKE_RESOURCE' });
+    expect(result).toStrictEqual(dbRecord);
   });
 });
 
 describe('getByIdList', () => {
   test('Runs a SELECT against the Resources table on the DB, takes the results from the first DB result set and the count from the second', async () => {
     const results = [
-      { name: 'Fake Resource', id: 'FAKE_RESOURCE' },
+      {
+        name: 'Fake Resource',
+        id: 'FAKE_RESOURCE',
+        attributes: [{ key: 'attribute1', value: 'value1', language: 'es-ES', info: {} }],
+      },
       { name: 'Other Fake Resource', id: 'OTHER_FAKE_RESOURCE' },
     ];
     mockTask(conn);
-    const manyOrNoneSpy = jest.spyOn(conn, 'manyOrNone').mockResolvedValue([
-      { name: 'Fake Resource', id: 'FAKE_RESOURCE' },
-      { name: 'Other Fake Resource', id: 'OTHER_FAKE_RESOURCE' },
-    ]);
+    const manyOrNoneSpy = jest.spyOn(conn, 'manyOrNone').mockResolvedValue(results);
 
     const result = await resourceDb.getByIdList('AC_FAKE', [
       'FAKE_RESOURCE',

--- a/resources-service/tests/unit/resource/resources-routes-v0.test.ts
+++ b/resources-service/tests/unit/resource/resources-routes-v0.test.ts
@@ -16,8 +16,7 @@
 
 import { Request, Response, Router } from 'express';
 import resourceRoutes from '../../../src/resource/resource-routes-v0';
-import { searchResources } from '../../../src/resource/resource-model';
-import { ReferrableResource } from '../../../src/resource/resource-data-access';
+import { ReferrableResource, searchResources } from '../../../src/resource/resource-model';
 
 jest.mock('express', () => ({
   Router: jest.fn(),
@@ -60,11 +59,20 @@ describe('POST /search', () => {
   });
 
   test('Takes limit & start from query string, search parameters from body and returns resources from model as JSON', async () => {
-    const modelResult = {
+    const modelResult: { totalCount: number; results: ReferrableResource[] } = {
       totalCount: 100,
       results: [
-        { id: 'RESOURCE_1', name: 'Resource 1' },
-        { id: 'RESOURCE_2', name: 'Resource 2' },
+        {
+          id: 'RESOURCE_1',
+          name: 'Resource 1',
+          attributes: {
+            someAttribute: [
+              { value: 'some value', language: 'en-US' },
+              { value: 'some value', language: 'fr-FR' },
+            ],
+          },
+        },
+        { id: 'RESOURCE_2', name: 'Resource 2', attributes: {} },
       ],
     };
     mockSearchResources.mockResolvedValue(modelResult);


### PR DESCRIPTION
## Description

* Adds schema support for 'reference attributes' (i.e. ones where the same value can be referenced by many resources) of string type
* Adds API support for returning any such attributes referenced by a resource returned by the `GET resource/{id}` or `POST resource/search` endpoints
* Service tests

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
CHI-1418

### Verification steps

Automated tests cover the new functionality