### PR TITLE
CHI-1136: Resource API now returns attributes where slash separated keys are interpreted as object graphs

### DIFF
--- a/resources-service/scripts/khp-mapping.ts
+++ b/resources-service/scripts/khp-mapping.ts
@@ -94,7 +94,9 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
         children: {
           name: {
             children: {
-              '{language}': khpAttributeMapping('ResourceStringAttributes', siteKey('name')),
+              '{language}': khpAttributeMapping('ResourceStringAttributes', siteKey('name'), {
+                language: context => context.captures.language,
+              }),
             },
           },
           details: {
@@ -102,6 +104,7 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
               '{language}': khpAttributeMapping('ResourceStringAttributes', siteKey('details'), {
                 value: siteKey('details'),
                 info: context => context.currentValue,
+                language: context => context.captures.language,
               }),
             },
           },
@@ -144,6 +147,7 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
                     {
                       value: context => context.currentValue.day,
                       info: context => context.currentValue,
+                      language: context => context.captures.language,
                     },
                   ),
                 },
@@ -199,7 +203,9 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
       email: khpAttributeMapping('ResourceStringAttributes', 'mainContact/email'),
       title: {
         children: {
-          '{language}': khpAttributeMapping('ResourceStringAttributes', 'mainContact/title'),
+          '{language}': khpAttributeMapping('ResourceStringAttributes', 'mainContact/title', {
+            language: context => context.captures.language,
+          }),
         },
       },
       phoneNumber: khpAttributeMapping('ResourceStringAttributes', 'mainContact/phoneNumber'),

--- a/resources-service/src/resource/resource-model.ts
+++ b/resources-service/src/resource/resource-model.ts
@@ -47,7 +47,7 @@ const attributeObjectGraphFromKeys = (
     const { key, ...withoutKey } = attribute;
     // Split on / but not on \/ (escaped /), but doesn't misinterpret preceding escaped \ (i.e. \\) as escaping the / (see unit tests)
     const attributeKeySections = key.split(/(?<!(?:[^\\]|^)\\(?:\\{2})*)\//).filter(s => s.length);
-    let currentObject = groupedAttributes;
+    let currentObject: ResourceAttributeNode = groupedAttributes as ResourceAttributeNode;
     attributeKeySections.forEach((escapedSection, index) => {
       const section = escapedSection.replace(/\\([\\\/])/g, '$1');
       if (index === attributeKeySections.length - 1) {

--- a/resources-service/src/resource/resource-model.ts
+++ b/resources-service/src/resource/resource-model.ts
@@ -34,14 +34,41 @@ export type SearchParameters = {
 const EMPTY_RESULT = { totalCount: 0, results: [] };
 const MAX_SEARCH_RESULTS = 200;
 
-const groupAttributesByKeys = (
+type ResourceAttributeNode = Record<
+  string,
+  ReferrableResourceAttribute[] | Record<string, ReferrableResourceAttribute[]>
+>;
+
+const attributeObjectGraphFromKeys = (
   attributesWithKeys: (ReferrableResourceAttribute & { key: string })[],
-): Record<string, ReferrableResourceAttribute[]> => {
-  const groupedAttributes: Record<string, ReferrableResourceAttribute[]> = {};
+): ResourceAttributeNode => {
+  const groupedAttributes: ResourceAttributeNode = {};
   attributesWithKeys.forEach(attribute => {
-    groupedAttributes[attribute.key] = groupedAttributes[attribute.key] || [];
     const { key, ...withoutKey } = attribute;
-    groupedAttributes[attribute.key].push(withoutKey);
+    // Split on / but not on \/ (escaped /), but doesn't misinterpret preceding escaped \ (i.e. \\) as escaping the / (see unit tests)
+    const attributeKeySections = key.split(/(?<!(?:[^\\]|^)\\(?:\\{2})*)\//).filter(s => s.length);
+    let currentObject = groupedAttributes;
+    attributeKeySections.forEach((escapedSection, index) => {
+      const section = escapedSection.replace(/\\([\\\/])/g, '$1');
+      if (index === attributeKeySections.length - 1) {
+        currentObject[section] = currentObject[section] || [];
+        const currentValue = currentObject[section];
+        if (Array.isArray(currentValue)) {
+          currentValue.push(withoutKey);
+        } else {
+          // Workaround for when we attach a value to an intermediate node
+          currentValue.__values__ = [...(currentValue.__values__ ?? []), withoutKey];
+        }
+      } else {
+        currentObject[section] = currentObject[section] || {};
+        const currentValue = currentObject[section];
+        if (Array.isArray(currentValue)) {
+          // Workaround for when we attach a value to an intermediate node
+          currentObject[section] = { __values__: currentValue };
+        }
+      }
+      currentObject = currentObject[section] as ResourceAttributeNode;
+    });
   });
   return groupedAttributes;
 };
@@ -49,7 +76,7 @@ const groupAttributesByKeys = (
 export type ReferrableResource = {
   name: string;
   id: string;
-  attributes: Record<string, ReferrableResourceAttribute[]>;
+  attributes: ResourceAttributeNode;
 };
 
 // The full resource & the search result are synonyms for now, but the full resource should grow to be a superset
@@ -60,7 +87,7 @@ export const getResource = async (
   resourceId: string,
 ): Promise<ReferrableResource | null> => {
   const record = await getById(accountSid, resourceId);
-  return record ? { ...record, attributes: groupAttributesByKeys(record.attributes) } : null;
+  return record ? { ...record, attributes: attributeObjectGraphFromKeys(record.attributes) } : null;
 };
 
 export const searchResources = async (
@@ -99,7 +126,7 @@ export const searchResources = async (
   return {
     results: results.map(record => ({
       ...record,
-      attributes: groupAttributesByKeys(record.attributes),
+      attributes: attributeObjectGraphFromKeys(record.attributes),
     })),
     totalCount,
   };

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -19,6 +19,7 @@ import { headers, getRequest, getServer } from './server';
 import { db } from '../../src/connection-pool';
 import each from 'jest-each';
 import { ReferrableResource } from '../../src/resource/resource-model';
+import { ReferrableResourceAttribute } from '../../src/resource/resource-data-access';
 
 export const workerSid = 'WK-worker-sid';
 
@@ -400,9 +401,9 @@ describe('GET /resource', () => {
         const responseAttributeEntries = Object.entries(responseAttributes).sort(([keyA], [keyB]) =>
           keyA.localeCompare(keyB),
         );
-        const expectedAttributeEntries = Object.entries(expectedAttributes).sort(([keyA], [keyB]) =>
-          keyA.localeCompare(keyB),
-        );
+        const expectedAttributeEntries = Object.entries(
+          expectedAttributes as Record<string, ReferrableResourceAttribute[]>,
+        ).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
         expect(responseAttributeEntries).toHaveLength(expectedAttributeEntries.length);
         responseAttributeEntries.forEach(([key, value], index) => {
           const [expectedKey, expectedValue] = expectedAttributeEntries[index];

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -418,6 +418,35 @@ describe('GET /resource', () => {
         });
       },
     );
+    test('Referenced attribute slash separated key paths are returned as nested objects', async () => {
+      await db.none(`INSERT INTO resources."ResourceReferenceStringAttributes" 
+                ("accountSid", "resourceId", "key", "list", "referenceId") 
+                VALUES ('REFERENCES_TEST_ACCOUNT_0', 'RESOURCE_0', 'REFERENCE/KEY/6', 'LIST_6', 'REF_5_0')`);
+      const response = await request
+        .get(`/v0/accounts/REFERENCES_TEST_ACCOUNT_0/resources/resource/RESOURCE_0`)
+        .set(headers);
+      expect(response.status).toBe(200);
+      const expectedResult = {
+        id: 'RESOURCE_0',
+        name: 'Resource 0',
+        attributes: {
+          REFERENCE: {
+            KEY: {
+              6: [
+                {
+                  value: 'REFERENCE_VALUE_5',
+                  language: 'LANGUAGE_0',
+                  info: {
+                    [`property_6`]: `VALUE_5`,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      expect(response.body).toStrictEqual(expectedResult);
+    });
   });
 });
 

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -20,6 +20,7 @@ import { db } from '../../src/connection-pool';
 import each from 'jest-each';
 import { ReferrableResource } from '../../src/resource/resource-model';
 import { ReferrableResourceAttribute } from '../../src/resource/resource-data-access';
+import { AssertionError } from 'assert';
 
 export const workerSid = 'WK-worker-sid';
 
@@ -75,14 +76,18 @@ const verifyResourcesAttributes = (resource: ReferrableResource) => {
     const attribute = resource.attributes[`ATTRIBUTE_${attributeIdx}`];
     expect(attribute).toBeDefined();
     const expectedValues = (parseInt(attributeIdx) % 2) + 1;
-    expect(attribute).toHaveLength(expectedValues);
-    range(expectedValues).forEach(valueIdx => {
-      expect(attribute[parseInt(valueIdx)]).toStrictEqual({
-        info: { some: 'json' },
-        language: 'en-US',
-        value: `VALUE_${valueIdx}`,
+    if (Array.isArray(expectedValues)) {
+      expect(attribute).toHaveLength(expectedValues);
+      range(expectedValues).forEach(valueIdx => {
+        expect(attribute[parseInt(valueIdx)]).toStrictEqual({
+          info: { some: 'json' },
+          language: 'en-US',
+          value: `VALUE_${valueIdx}`,
+        });
       });
-    });
+    } else {
+      throw new AssertionError({ message: 'Expected attribute value to be an array' });
+    }
   });
 };
 

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -76,7 +76,7 @@ const verifyResourcesAttributes = (resource: ReferrableResource) => {
     const attribute = resource.attributes[`ATTRIBUTE_${attributeIdx}`];
     expect(attribute).toBeDefined();
     const expectedValues = (parseInt(attributeIdx) % 2) + 1;
-    if (Array.isArray(expectedValues)) {
+    if (Array.isArray(attribute)) {
       expect(attribute).toHaveLength(expectedValues);
       range(expectedValues).forEach(valueIdx => {
         expect(attribute[parseInt(valueIdx)]).toStrictEqual({

--- a/resources-service/tests/unit/resource/resource-model.test.ts
+++ b/resources-service/tests/unit/resource/resource-model.test.ts
@@ -363,6 +363,187 @@ describe('searchResources', () => {
         ],
       },
     },
+    {
+      description:
+        'Resource returned has attribute entries with keys that have forward slashes in their names - creates a nested object from the path',
+      attributeRecords: [
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute entries with path keys that share a common root - attributes with a common root path share a common root object',
+      attributeRecords: [
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested2/attribute',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+          nested2: {
+            attribute: [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute entries with forward slashes escaped with backslashes - removes backslashes and treats the forward slash as part of the path text',
+      attributeRecords: [
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested2\\/attribute',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+          'nested2/attribute': [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute keys with forward slashes after escaped backslash - unescapes backslash and treats the forward slash as a separator',
+      attributeRecords: [
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested2\\\\/attribute',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+          'nested2\\': {
+            attribute: [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute keys with adjacent forward slashes - treats adjacent forward slashes as a single separator',
+      attributeRecords: [
+        {
+          key: 'test///nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested2////attribute',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+          nested2: {
+            attribute: [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute keys that form ancestor paths of other keys - values for ancestors are put on a __values__ property of the ancestor object',
+      attributeRecords: [
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+            __values__: [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
+    {
+      description:
+        'Resource returned has attribute keys that form ancestor paths of other keys but ancestor is added first - values for ancestors are still put on a __values__ property of the ancestor object',
+      attributeRecords: [
+        {
+          key: 'test/nested',
+          value: 'testValue2',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+        {
+          key: 'test/nested/attribute',
+          value: 'testValue',
+          language: 'Klingon',
+          info: { qa: 'pla' },
+        },
+      ],
+      expectedAttributes: {
+        test: {
+          nested: {
+            attribute: [{ value: 'testValue', language: 'Klingon', info: { qa: 'pla' } }],
+            __values__: [{ value: 'testValue2', language: 'Klingon', info: { qa: 'pla' } }],
+          },
+        },
+      },
+    },
   ]).test('$description', async ({ attributeRecords, expectedAttributes }) => {
     const resultSet = [
       {


### PR DESCRIPTION
## Description

* Keys with forward slashes returned as nested objects, e.g. `{ "a/b/c": "d" }` becomes `{ "a": { "b": { "c": "d" } } }` 
* Forward slashes and backslashes are escaped with backslashes
* If a value is assigned to an ancestor path of another attribute, it is moved onto a property called '__values__'

e.g. 
```
{
  "a/b/c": "d"
  "a/b": "e"
}
```

becomes

```
{
  "a": {
    "b": {
      "c": "d"
      "__values__": "e"
    }
  }
}
```
### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
CHI-1136

### Verification steps

Verify that the KHP examples are being nested as expected
