### PR TITLE
fix: twilio-client returns wrong client when getClient() called with two account configs.

### DIFF
--- a/packages/twilio-client/index.ts
+++ b/packages/twilio-client/index.ts
@@ -32,7 +32,7 @@ const getClientOrMock = ({
   authToken: string;
 }): Twilio => {
   if (authToken === 'mockAuthToken') {
-    const mock = (getMockClient() as unknown) as Twilio;
+    const mock = (getMockClient({ accountSid }) as unknown) as Twilio;
     return mock;
   }
 

--- a/packages/twilio-client/index.ts
+++ b/packages/twilio-client/index.ts
@@ -18,7 +18,11 @@ import { Twilio } from 'twilio';
 
 import { getMockClient } from './mockClient';
 
-let client: Twilio;
+type ClientCache = {
+  [accountSid: string]: Twilio;
+};
+
+let clientCache: ClientCache = {};
 
 const getClientOrMock = ({
   accountSid,
@@ -42,9 +46,9 @@ export const getClient = ({
   accountSid: string;
   authToken: string;
 }): Twilio => {
-  if (!client) {
-    client = getClientOrMock({ accountSid, authToken });
+  if (!clientCache[accountSid]) {
+    clientCache[accountSid] = getClientOrMock({ accountSid, authToken });
   }
 
-  return client;
+  return clientCache[accountSid];
 };

--- a/packages/twilio-client/index.ts
+++ b/packages/twilio-client/index.ts
@@ -22,7 +22,7 @@ type ClientCache = {
   [accountSid: string]: Twilio;
 };
 
-let clientCache: ClientCache = {};
+const clientCache: ClientCache = {};
 
 const getClientOrMock = ({
   accountSid,

--- a/packages/twilio-client/jest.config.js
+++ b/packages/twilio-client/jest.config.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+module.exports = config => {
+  return (
+    config || {
+      preset: 'ts-jest',
+      rootDir: './tests',
+      maxWorkers: 1,
+      globals: {
+        'ts-jest': {
+          // to give support to const enum. Not working, conflicting with module resolution
+          useExperimentalLanguageServer: true,
+        },
+      },
+    }
+  );
+};

--- a/packages/twilio-client/mockClient/getMockClient.ts
+++ b/packages/twilio-client/mockClient/getMockClient.ts
@@ -17,8 +17,13 @@
 import RestException from 'twilio/lib/base/RestException';
 import { chatMessageList } from './chatMessageList';
 
-export const getMockClient = () => {
+export const getMockClient = ({ accountSid }: { accountSid: string }) => {
   return {
+    tokens: {
+      toJSON: () => ({
+        accountSid,
+      }),
+    },
     chat: {
       v2: {
         services: () => ({

--- a/packages/twilio-client/package.json
+++ b/packages/twilio-client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test:unit": "jest tests/unit"
   },
   "author": "",
   "license": "AGPL",

--- a/packages/twilio-client/tests/unit/index.test.ts
+++ b/packages/twilio-client/tests/unit/index.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import * as twilioClient from '../../index';
+
+describe('getClient', () => {
+  it('when called in a single session with multiple accountSids should return twilio client for multiple accounts', async () => {
+    const clientAccountSid1 = twilioClient.getClient({
+      accountSid: 'accountSid1',
+      authToken: 'mockAuthToken',
+    });
+
+    expect(clientAccountSid1.tokens.toJSON().accountSid).toBe('accountSid1');
+
+    const clientAccountSid2 = twilioClient.getClient({
+      accountSid: 'accountSid2',
+      authToken: 'mockAuthToken',
+    });
+
+    expect(clientAccountSid2.tokens.toJSON().accountSid).toBe('accountSid2');
+  });
+});


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This should fix the "Service instance not found" issue.


### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #CHI-1761

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

Run tests
