### PR TITLE
CHI-1831: Add attribute tables for other types, fix KHP mapping issue

### DIFF
--- a/resources-service/migrations/20230330122300-create-resource-attributes-tables-other-types.js
+++ b/resources-service/migrations/20230330122300-create-resource-attributes-tables-other-types.js
@@ -22,7 +22,7 @@ module.exports = {
         "resourceId" text COLLATE pg_catalog."default" NOT NULL,
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
         "key" text COLLATE pg_catalog."default" NOT NULL,
-        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "value" bool NOT NULL,
         "info" JSONB,
         "lastUpdated" timestamp with time zone,
         "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),

--- a/resources-service/migrations/20230330122300-create-resource-attributes-tables-other-types.js
+++ b/resources-service/migrations/20230330122300-create-resource-attributes-tables-other-types.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceBooleanAttributes"
+      (
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceBooleanAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "value"),
+        CONSTRAINT "FK_ResourceBooleanAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
+            REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+      )
+    `);
+    console.log('Table "ResourceBooleanAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceBooleanAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceBooleanAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger ResourceBooleanAttributes_update_trigger created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceNumberAttributes"
+      (
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        -- Using double precision because that matches the JavaScript Number type it will be passed in from
+        -- If we need precise decimal values, we should store them as strings
+        "value" double precision NOT NULL, 
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceNumberAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "value"),
+        CONSTRAINT "FK_ResourceNumberAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
+            REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+      )
+    `);
+    console.log('Table "ResourceNumberAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceNumberAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceNumberAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger ResourceNumberAttributes_update_trigger created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS resources."ResourceDateTimeAttributes"
+      (
+        "resourceId" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "key" text COLLATE pg_catalog."default" NOT NULL,
+        "value" text COLLATE pg_catalog."default" NOT NULL,
+        "info" JSONB,
+        "lastUpdated" timestamp with time zone,
+        "updateSequence"  bigint NOT NULL DEFAULT nextval('"Resources_updates_seq"'::regclass),
+        CONSTRAINT "ResourceDateTimeAttributes_pkey" PRIMARY KEY ("resourceId", "accountSid", "key", "value"),
+        CONSTRAINT "FK_ResourceDateTimeAttributes_Resources" FOREIGN KEY ("resourceId", "accountSid")
+            REFERENCES resources."Resources" (id, "accountSid") MATCH SIMPLE
+            ON UPDATE CASCADE
+            ON DELETE CASCADE
+      )
+    `);
+    console.log('Table "ResourceDateTimeAttributes" created');
+
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER "ResourceDateTimeAttributes_update_trigger"
+      BEFORE UPDATE
+      ON resources."ResourceDateTimeAttributes"
+      FOR EACH ROW
+      WHEN (pg_trigger_depth() = 0)
+      EXECUTE FUNCTION resources."ResourcesLookupTables_updateSequence_trigger"();
+    `);
+    console.log('Trigger ResourceDateTimeAttributes_update_trigger created');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceDateTimeAttributes"`,
+    );
+    console.log('Table "ResourceDateTimeAttributes" dropped');
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceNumberAttributes"`,
+    );
+    console.log('Table "ResourceNumberAttributes" dropped');
+    await queryInterface.sequelize.query(
+      `DROP TABLE IF EXISTS resources."ResourceBooleanAttributes"`,
+    );
+    console.log('Table "ResourceBooleanAttributes" dropped');
+  },
+};

--- a/resources-service/scripts/README.md
+++ b/resources-service/scripts/README.md
@@ -7,12 +7,12 @@ A set of utility scripts to maintain the resources service & associated data
 Build first, then run:
 ````bash
 npm run build-scripts
-npm run import-khp-json ACxxx [-- --generate-sql-only]
+npm run import-khp-json ACxxx [-- --only-generate-sql]
 ````
 
 Single command:
 ````bash
-npm run build-and-import-khp-json ACxxx [-- --generate-sql-only]
+npm run build-and-import-khp-json ACxxx [-- --only-generate-sql]
 ````
 
 This script imports resources into the Aselo resource database from a JSON file. It is intended to be run from the root directory of the resources-service package.
@@ -31,4 +31,4 @@ Currently, the script is hardcoded to read the input from `./resource-json/khp-s
 
 The script has one mandatory argument, the SID of the Twilio account to import resources for. This argument must be first (see example above).
 
-It also has one optional argument, `--generate-sql-only`, which will cause the script to skip the final step of running the generated SQL statements against the target database. You can then take these scripts and run them manually in pgAdmin or similar, they will run against any database with a valid resources schema.
+It also has one optional argument, `--only-generate-sql`, which will cause the script to skip the final step of running the generated SQL statements against the target database. You can then take these scripts and run them manually in pgAdmin or similar, they will run against any database with a valid resources schema.

--- a/resources-service/scripts/aselo-resource.ts
+++ b/resources-service/scripts/aselo-resource.ts
@@ -2,20 +2,25 @@ export type InlineAttributeTable =
   | 'ResourceStringAttributes'
   | 'ResourceBooleanAttributes'
   | 'ResourceNumberAttributes'
-  | 'ResourceDateAttributes';
+  | 'ResourceDateTimeAttributes';
 
 export type AseloInlineResourceAttribute<T extends InlineAttributeTable> = {
   key: string;
   value: AttributeValue<T>;
-  language: string;
   info: Record<string, any> | null;
+};
+
+export type AseloTranslatableResourceAttribute = AseloInlineResourceAttribute<
+  'ResourceStringAttributes'
+> & {
+  language: string;
 };
 
 export type AseloResource = {
   id: string;
   name: string;
   attributes: {
-    ResourceStringAttributes: AseloInlineResourceAttribute<'ResourceStringAttributes'>[];
+    ResourceStringAttributes: AseloTranslatableResourceAttribute[];
     ResourceReferenceStringAttributes: {
       key: string;
       value: string;
@@ -25,7 +30,7 @@ export type AseloResource = {
     }[];
     ResourceBooleanAttributes: AseloInlineResourceAttribute<'ResourceBooleanAttributes'>[];
     ResourceNumberAttributes: AseloInlineResourceAttribute<'ResourceNumberAttributes'>[];
-    ResourceDateAttributes: AseloInlineResourceAttribute<'ResourceDateAttributes'>[];
+    ResourceDateTimeAttributes: AseloInlineResourceAttribute<'ResourceDateTimeAttributes'>[];
   };
 };
 
@@ -35,6 +40,6 @@ export type AttributeValue<T extends AttributeTable> = T extends 'ResourceBoolea
   ? boolean
   : T extends 'ResourceNumberAttributes'
   ? number
-  : T extends 'ResourceDateAttributes'
+  : T extends 'ResourceDateTimeAttributes'
   ? Date
   : string;

--- a/resources-service/scripts/generate-aselo-sql.ts
+++ b/resources-service/scripts/generate-aselo-sql.ts
@@ -38,7 +38,6 @@ export const generateAseloResourceSql = (
   ON CONFLICT ON CONSTRAINT "Resources_pkey" 
   DO UPDATE SET "name" = EXCLUDED."name"`);
   const nonTranslatableTables = [
-    'ResourceStringAttributes',
     'ResourceNumberAttributes',
     'ResourceBooleanAttributes',
     'ResourceDateTimeAttributes',
@@ -63,7 +62,7 @@ export const generateAseloResourceSql = (
             key,
             value,
             info,
-            language,
+            language: language ?? '',
           },
           ['accountSid', 'resourceId', 'key', 'value', 'language', 'info'],
           { schema: 'resources', table: 'ResourceStringAttributes' },

--- a/resources-service/scripts/khp-mapping.ts
+++ b/resources-service/scripts/khp-mapping.ts
@@ -4,6 +4,7 @@ import {
   KhpMappingNode,
   khpReferenceAttributeMapping,
   khpResourceFieldMapping,
+  khpTranslatableAttributeMapping,
   substitueCaptureTokens,
 } from './khp-aselo-converter';
 
@@ -94,14 +95,14 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
         children: {
           name: {
             children: {
-              '{language}': khpAttributeMapping('ResourceStringAttributes', siteKey('name'), {
+              '{language}': khpTranslatableAttributeMapping(siteKey('name'), {
                 language: context => context.captures.language,
               }),
             },
           },
           details: {
             children: {
-              '{language}': khpAttributeMapping('ResourceStringAttributes', siteKey('details'), {
+              '{language}': khpTranslatableAttributeMapping(siteKey('details'), {
                 value: siteKey('details'),
                 info: context => context.currentValue,
                 language: context => context.captures.language,
@@ -111,7 +112,7 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
           isActive: khpAttributeMapping('ResourceBooleanAttributes', siteKey('isActive')),
           isLocationPrivate: khpAttributeMapping(
             'ResourceBooleanAttributes',
-            'agency/isLocationPrivate',
+            siteKey('isLocationPrivate'),
           ),
           location: {
             children: {
@@ -141,15 +142,11 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
             children: {
               '{dayIndex}': {
                 children: {
-                  '{language}': khpAttributeMapping(
-                    'ResourceStringAttributes',
-                    siteKey('operations/{dayIndex}'),
-                    {
-                      value: context => context.currentValue.day,
-                      info: context => context.currentValue,
-                      language: context => context.captures.language,
-                    },
-                  ),
+                  '{language}': khpTranslatableAttributeMapping(siteKey('operations/{dayIndex}'), {
+                    value: context => context.currentValue.day,
+                    info: context => context.currentValue,
+                    language: context => context.captures.language,
+                  }),
                 },
               },
             },
@@ -169,7 +166,7 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
   name: khpResourceFieldMapping('name', context => context.currentValue.en),
   nameDetails: {
     children: {
-      '{language}': khpAttributeMapping('ResourceStringAttributes', 'nameDetails', {
+      '{language}': khpTranslatableAttributeMapping('nameDetails', {
         value: ctx => ctx.currentValue.official,
         info: context => context.currentValue,
         language: context => context.captures.language,
@@ -180,7 +177,7 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
     children: {
       '{dayIndex}': {
         children: {
-          '{language}': khpAttributeMapping('ResourceStringAttributes', 'operations/{dayIndex}', {
+          '{language}': khpTranslatableAttributeMapping('operations/{dayIndex}', {
             value: context => context.currentValue.day,
             info: context => context.currentValue,
             language: context => context.captures.language,
@@ -203,20 +200,20 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
       email: khpAttributeMapping('ResourceStringAttributes', 'mainContact/email'),
       title: {
         children: {
-          '{language}': khpAttributeMapping('ResourceStringAttributes', 'mainContact/title', {
+          '{language}': khpTranslatableAttributeMapping('mainContact/title', {
             language: context => context.captures.language,
           }),
         },
       },
       phoneNumber: khpAttributeMapping('ResourceStringAttributes', 'mainContact/phoneNumber'),
-      isPrivate: khpAttributeMapping('ResourceStringAttributes', 'mainContact/isPrivate'),
+      isPrivate: khpAttributeMapping('ResourceBooleanAttributes', 'mainContact/isPrivate'),
     },
   },
   website: khpAttributeMapping('ResourceStringAttributes', 'website'),
   status: khpReferenceAttributeMapping('status', 'khp-resource-statuses'),
   description: {
     children: {
-      '{language}': khpAttributeMapping('ResourceStringAttributes', 'description', {
+      '{language}': khpTranslatableAttributeMapping('description', {
         value: 'description',
         info: context => ({ text: context.currentValue }),
         language: context => context.captures.language,
@@ -264,7 +261,14 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
   keywords: khpAttributeMapping('ResourceStringAttributes', 'keywords'),
   accessibility: khpReferenceAttributeMapping('accessibility', 'khp-accessibility'),
   applicationProcess: khpReferenceAttributeMapping('applicationProcess', 'khp-application-process'),
-  documentsRequired: khpAttributeMapping('ResourceBooleanAttributes', 'documentsRequired'),
+  documentsRequired: {
+    children: {
+      '{documentIndex}': khpAttributeMapping(
+        'ResourceStringAttributes',
+        'documentsRequired/{documentIndex}',
+      ),
+    },
+  },
   languages: khpReferenceAttributeMapping('languages', 'khp-languages', {
     value: context => context.currentValue.language,
   }),
@@ -273,8 +277,8 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
   taxonomyCode: khpAttributeMapping('ResourceStringAttributes', 'taxonomyCode'),
   timestamps: {
     children: {
-      createdAt: khpAttributeMapping('ResourceDateAttributes', 'sourceCreatedAt'),
-      updatedAt: khpAttributeMapping('ResourceDateAttributes', 'sourceUpdatedAt'),
+      createdAt: khpAttributeMapping('ResourceDateTimeAttributes', 'sourceCreatedAt'),
+      updatedAt: khpAttributeMapping('ResourceDateTimeAttributes', 'sourceUpdatedAt'),
     },
   },
 };

--- a/resources-service/scripts/khp-mapping.ts
+++ b/resources-service/scripts/khp-mapping.ts
@@ -29,66 +29,6 @@ const siteKey = (subsection: string) => (context: FieldMappingContext) => {
  */
 export const KHP_MAPPING_NODE: KhpMappingNode = {
   resourceID: khpResourceFieldMapping('id'),
-  /*agency: {
-    children: {
-      name: {
-        children: {
-          '{language}': khpAttributeMapping('ResourceStringAttributes', 'agency/name', {
-            language: context => context.captures.language,
-          }),
-        },
-      },
-      details: {
-        children: {
-          '{language}': khpAttributeMapping('ResourceStringAttributes', 'agency/details', {
-            value: 'agency/details',
-            info: context => context.currentValue,
-            language: context => context.captures.language,
-          }),
-        },
-      },
-      isLocationPrivate: khpAttributeMapping(
-        'ResourceBooleanAttributes',
-        'agency/isLocationPrivate',
-      ),
-      location: {
-        children: {
-          address1: khpAttributeMapping('ResourceStringAttributes', 'agency/location/address1'),
-          address2: khpAttributeMapping('ResourceStringAttributes', 'agency/location/address2'),
-          city: khpAttributeMapping('ResourceStringAttributes', 'agency/location/city'),
-          county: khpAttributeMapping('ResourceStringAttributes', 'agency/location/county'),
-          province: khpReferenceAttributeMapping('agency/location/province', 'canadian-provinces'),
-          country: khpReferenceAttributeMapping('agency/location/country', 'khp-countries'),
-          postalCode: khpAttributeMapping('ResourceStringAttributes', 'agency/location/postalCode'),
-        },
-      },
-      email: khpAttributeMapping('ResourceStringAttributes', 'agency/email'),
-      operations: {
-        children: {
-          '{dayIndex}': {
-            children: {
-              '{language}': khpAttributeMapping(
-                'ResourceStringAttributes',
-                'agency/operations/{dayIndex}',
-                {
-                  value: context => context.currentValue.day,
-                  info: context => context.currentValue,
-                },
-              ),
-            },
-          },
-        },
-      },
-      phoneNumbers: {
-        children: {
-          '{phoneNumberType}': khpAttributeMapping(
-            'ResourceStringAttributes',
-            'agency/phone/{phoneNumberType}',
-          ),
-        },
-      },
-    },
-  },*/
   sites: {
     children: {
       '{siteIndex}': {
@@ -186,14 +126,18 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
       },
     },
   },
-  /*phoneNumbers: {
+  phoneNumbers: {
     children: {
-      '{phoneNumberType}': khpAttributeMapping(
+      '{phoneNumberIndex}': khpAttributeMapping(
         'ResourceStringAttributes',
-        'phone/{phoneNumberType}',
+        ctx => `phoneNumbers/${ctx.currentValue.type ?? ctx.captures.phoneNumberIndex}`,
+        {
+          info: context => context.currentValue,
+          value: context => context.currentValue.number,
+        },
       ),
     },
-  },*/
+  },
   mainContact: {
     children: {
       name: khpAttributeMapping('ResourceStringAttributes', 'mainContact/name'),
@@ -249,7 +193,10 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
     'ResourceBooleanAttributes',
     'interpretationTranslationServicesAvailable',
   ),
-  feeStructureSource: khpAttributeMapping('ResourceNumberAttributes', 'eligibilityMaxAge'),
+  feeStructureSource: khpReferenceAttributeMapping(
+    'feeStructureSource',
+    'khp-fee-structure-source',
+  ),
   howToAccessSupport: khpReferenceAttributeMapping(
     'howToAccessSupport',
     'khp-how-to-access-support',
@@ -258,7 +205,10 @@ export const KHP_MAPPING_NODE: KhpMappingNode = {
     'howIsServiceOffered',
     'khp-how-is-service-offered',
   ),
-  keywords: khpAttributeMapping('ResourceStringAttributes', 'keywords'),
+  keywords: khpAttributeMapping('ResourceStringAttributes', 'keywords', {
+    value: ctx => ctx.currentValue.join(' '),
+    info: ctx => ({ keywords: ctx.currentValue }),
+  }),
   accessibility: khpReferenceAttributeMapping('accessibility', 'khp-accessibility'),
   applicationProcess: khpReferenceAttributeMapping('applicationProcess', 'khp-application-process'),
   documentsRequired: {

--- a/resources-service/src/resource/resource-data-access.ts
+++ b/resources-service/src/resource/resource-data-access.ts
@@ -21,16 +21,22 @@ import {
   SELECT_RESOURCE_IN_IDS,
 } from './sql/resource-get-sql';
 
-export type ReferrableResourceAttribute = {
-  value: string;
-  language: string;
+export type ReferrableResourceAttribute<T> = {
+  value: T;
   info?: any;
+};
+
+export type ReferrableResourceTranslatableAttribute = ReferrableResourceAttribute<string> & {
+  language: string;
 };
 
 export type ReferrableResourceRecord = {
   name: string;
   id: string;
-  attributes: (ReferrableResourceAttribute & { key: string })[];
+  stringAttributes: (ReferrableResourceTranslatableAttribute & { key: string })[];
+  booleanAttributes: (ReferrableResourceAttribute<boolean> & { key: string })[];
+  numberAttributes: (ReferrableResourceAttribute<number> & { key: string })[];
+  datetimeAttributes: (ReferrableResourceAttribute<string> & { key: string })[];
 };
 
 export const getById = async (
@@ -44,7 +50,7 @@ export const getById = async (
   if (res) {
     delete res.accountSid;
   }
-  return res;
+  return res as ReferrableResourceRecord;
 };
 
 export const getByIdList = async (

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -414,7 +414,7 @@ describe('GET /resource', () => {
           keyA.localeCompare(keyB),
         );
         const expectedAttributeEntries = Object.entries(
-          expectedAttributes as Record<string, ReferrableResourceAttribute[]>,
+          expectedAttributes as Record<string, ReferrableResourceAttribute<unknown>[]>,
         ).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
         expect(responseAttributeEntries).toHaveLength(expectedAttributeEntries.length);
         responseAttributeEntries.forEach(([key, value], index) => {

--- a/resources-service/tests/service/resources.test.ts
+++ b/resources-service/tests/service/resources.test.ts
@@ -455,6 +455,59 @@ describe('GET /resource', () => {
       expect(response.body).toStrictEqual(expectedResult);
     });
   });
+
+  describe('Inline attributes of non string types', () => {
+    const dateVal = new Date(2010, 15, 11, 13, 30, 15);
+    beforeEach(async () => {
+      await db.multi(`
+INSERT INTO resources."ResourceBooleanAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'BOOLEAN_ATTRIBUTE', true, '{ "some": "json" }');
+INSERT INTO resources."ResourceNumberAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'NUMBER_ATTRIBUTE', 1337.42, '{ "some": "json" }');
+INSERT INTO resources."ResourceDateTimeAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'DATETIME_ATTRIBUTE', '${dateVal.toISOString()}', '{ "some": "json" }');
+       `);
+    });
+    test('should return the resource with the attributes', async () => {
+      const response = await request.get(`${basePath}/RESOURCE_1`).set(headers);
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({
+        id: 'RESOURCE_1',
+        name: 'Resource 1 (Account 1)',
+        attributes: {
+          BOOLEAN_ATTRIBUTE: [
+            {
+              value: true,
+              info: { some: 'json' },
+            },
+          ],
+          NUMBER_ATTRIBUTE: [
+            {
+              value: 1337.42,
+              info: { some: 'json' },
+            },
+          ],
+          DATETIME_ATTRIBUTE: [
+            {
+              value: dateVal.toISOString(),
+              info: { some: 'json' },
+            },
+          ],
+          ATTRIBUTE_0: [
+            {
+              value: 'VALUE_0',
+              language: 'en-US',
+              info: { some: 'json' },
+            },
+          ],
+        },
+      });
+    });
+    afterEach(async () => {
+      await db.multi(`
+DELETE FROM resources."ResourceBooleanAttributes";
+DELETE FROM resources."ResourceNumberAttributes";
+DELETE FROM resources."ResourceDateTimeAttributes";
+      `);
+    });
+  });
 });
 
 describe('POST /searchByName', () => {


### PR DESCRIPTION
Description

* Fixes mapping issue with isLocationPrivate property
* Adds tables for boolean, number and datetime attributes
* Updates API to return attributes from all those tables
* Updates import script to write attributes to the correct table for their type

@mythilytm - there are some changes to the resources produced by the API that might be incompatible with your UI code:

Boolean & number attributes come through with their correct type, not as strings.
Boolean, number & date fields no longer have a language property

The API is also passing back phone numbers in a 'phoneNumbers' object, keyed by type - the value is a string of the number, and the info is the full set of information about the phone number

Checklist:

[X] New tersts added

Steps To Verify

* Import has already been applied to HRM Dev
* Regression test resources features with this branch deployed