### PR TITLE
CHI-1864: Fix basic auth for post survey

### DIFF
--- a/hrm-service/service-tests/post-surveys.test.ts
+++ b/hrm-service/service-tests/post-surveys.test.ts
@@ -79,6 +79,20 @@ describe('/postSurveys route', () => {
         expect(response.body.error).toBe('Authorization failed');
       });
 
+      test('returns 401 if you try to use basic auth', async () => {
+        const response = await request.get(shouldExist).set(basicHeaders);
+
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe('Authorization failed');
+      });
+
+      test('returns 401 if you try to fool it into allowing basic auth', async () => {
+        const response = await request.get(`${shouldExist}?x=/postSurveys`).set(basicHeaders);
+
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe('Authorization failed');
+      });
+
       test('should return 200 (no matches)', async () => {
         const response = await request.get(shouldNotExist).set(headers);
 

--- a/hrm-service/service-tests/post-surveys.test.ts
+++ b/hrm-service/service-tests/post-surveys.test.ts
@@ -91,6 +91,10 @@ describe('/postSurveys route', () => {
 
         expect(response.status).toBe(401);
         expect(response.body.error).toBe('Authorization failed');
+        const bookmarkResponse = await request.get(`${shouldExist}#/postSurveys`).set(basicHeaders);
+
+        expect(bookmarkResponse.status).toBe(401);
+        expect(bookmarkResponse.body.error).toBe('Authorization failed');
       });
 
       test('should return 200 (no matches)', async () => {

--- a/hrm-service/service-tests/server.ts
+++ b/hrm-service/service-tests/server.ts
@@ -69,3 +69,8 @@ export const headers = {
   'Content-Type': 'application/json',
   Authorization: `Bearer bearing a bear (rawr)`,
 };
+
+export const basicHeaders = {
+  'Content-Type': 'application/json',
+  Authorization: `Basic BBC`,
+};

--- a/hrm-service/setTestEnvVars.js
+++ b/hrm-service/setTestEnvVars.js
@@ -38,6 +38,7 @@ process.env.PERMISSIONS_dev = 'dev';
 process.env.PERMISSIONS_e2e = 'e2e';
 process.env.PERMISSIONS_notConfigured = '';
 process.env.PERMISSIONS_notExistsInRulesMap = 'notExistsInRulesMap';
+process.env.STATIC_KEY_ACCOUNT_SID = 'BBC';
 
 process.env.INCLUDE_ERROR_IN_RESPONSE = true;
 

--- a/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
+++ b/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
@@ -40,7 +40,7 @@ declare global {
  * IMPORTANT: This kind of static key acces should never be used to retrieve sensitive information.
  */
 const canAccessResourceWithStaticKey = (path: string, method: string): boolean => {
-  return path === '/postSurveys' && method === 'POST';
+  return path.endsWith('/postSurveys') && method === 'POST';
 };
 
 type TokenValidatorResponse = { worker_sid: string; roles: string[] };
@@ -85,7 +85,7 @@ export const getAuthorizationMiddleware = (authTokenLookup: (accountSid: string)
   }
 
   if (authorization.startsWith('Basic')) {
-    if (canAccessResourceWithStaticKey(req.path, req.method)) {
+    if (canAccessResourceWithStaticKey(req.originalUrl, req.method)) {
       try {
         const staticSecretKey = `STATIC_KEY_${accountSid}`;
         const staticSecret = process.env[staticSecretKey];


### PR DESCRIPTION
## Description

The 'path' for the purposes of checking if a URL is valid for basic authentication is no longer '/postSurveys' for inserting post surveys, 'postSurveys' is now part of the base URL so the 'path' is '/' - so fails the filter check.

I updated the filter check to check against the end of the full parsed URL, so it can still check it is '/postSurveys'

Also added service tests that check basic auth - including attempts to circumvent it for other endpoints

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added


### Related Issues
Fixes CHI-1864

### Verification steps

Deploy to Aselo Development and complete a post survey, it should save & send you back to chat opening page