### PR TITLE
CHI-1746: Add resource import unit tests, add lastUpdated & created to import query

### DIFF
--- a/packages/testing/mock-pgpromise.ts
+++ b/packages/testing/mock-pgpromise.ts
@@ -87,7 +87,7 @@ export const mockTransaction = (db: IDatabase<unknown>, mockConn: pgPromise.ITas
 };
 
 // eslint-disable-next-line prettier/prettier
-type PgQuerySpy = jest.SpyInstance<any, [query: QueryParam, values?:any]> | jest.SpyInstance<any, [query: QueryParam, values:any, cb: any, thisArg?: any]>;
+type PgQuerySpy = jest.SpyInstance<any, [query: QueryParam, values?:any]> | jest.SpyInstance<any, [query: QueryParam, values?:any, cb?: any, thisArg?: any]>;
 
 export const getSqlStatement = (mockQueryMethod: PgQuerySpy, callIndex = -1): string => {
   expect(mockQueryMethod).toHaveBeenCalled();

--- a/packages/testing/mock-pgpromise.ts
+++ b/packages/testing/mock-pgpromise.ts
@@ -87,9 +87,15 @@ export const mockTransaction = (db: IDatabase<unknown>, mockConn: pgPromise.ITas
 };
 
 // eslint-disable-next-line prettier/prettier
-type PgQueryParameters = [query: QueryParam, values?:any] | [query: QueryParam, values?:any, cb?: any, thisArg?: any];
+type PgQuerySpy = jest.SpyInstance<any, [query: QueryParam, values?:any]> | jest.SpyInstance<any, [query: QueryParam, values:any, cb: any, thisArg?: any]>;
 
-export const getSqlStatement = (mockQueryMethod: jest.SpyInstance<any, PgQueryParameters>, callIndex = -1): string => {
+export const getSqlStatement = (mockQueryMethod: PgQuerySpy, callIndex = -1): string => {
+  expect(mockQueryMethod).toHaveBeenCalled();
+  return mockQueryMethod.mock.calls[callIndex < 0 ? mockQueryMethod.mock.calls.length + callIndex : callIndex][0].toString();
+};
+
+
+export const getSqlStatementFromNone = (mockQueryMethod: jest.SpyInstance<any, [query: QueryParam, values?:any]>, callIndex = -1): string => {
   expect(mockQueryMethod).toHaveBeenCalled();
   return mockQueryMethod.mock.calls[callIndex < 0 ? mockQueryMethod.mock.calls.length + callIndex : callIndex][0].toString();
 };

--- a/resources-service/src/import/importService.ts
+++ b/resources-service/src/import/importService.ts
@@ -61,9 +61,12 @@ const importService = () => {
               throw err;
             }
             const result = await upsert(accountSid, resource);
+            if (!result.success) {
+              throw result.error;
+            }
             results.push(result);
           }
-          const { id, updatedAt } = resources.sort((a, b) =>
+          const { id, updatedAt } = [...resources].sort((a, b) =>
             a.updatedAt > b.updatedAt ? 1 : a.updatedAt < b.updatedAt ? -1 : a.id > b.id ? 1 : -1,
           )[resources.length - 1];
           await updateImportProgress(t)(accountSid, {

--- a/resources-service/src/import/sql.ts
+++ b/resources-service/src/import/sql.ts
@@ -25,12 +25,12 @@ export const generateUpsertSqlFromImportResource = (
   const sqlBatch: string[] = [];
 
   sqlBatch.push(`${pgp.helpers.insert(
-    { ...resourceRecord, accountSid },
-    ['id', 'name', 'accountSid'],
+    { ...resourceRecord, accountSid, created: resourceRecord.updatedAt },
+    ['id', 'name', 'accountSid', 'created'],
     { schema: 'resources', table: 'Resources' },
   )} 
   ON CONFLICT ON CONSTRAINT "Resources_pkey" 
-  DO UPDATE SET "name" = EXCLUDED."name"`);
+  DO UPDATE SET "name" = EXCLUDED."name", "lastUpdated" = EXCLUDED."lastUpdated"`);
   const nonTranslatableTables = [
     'ResourceNumberAttributes',
     'ResourceBooleanAttributes',

--- a/resources-service/tests/unit/import/importDataAccess.test.ts
+++ b/resources-service/tests/unit/import/importDataAccess.test.ts
@@ -1,0 +1,151 @@
+import * as pgPromise from 'pg-promise';
+import { subHours } from 'date-fns';
+import { mockConnection, mockTransaction } from '../mock-db';
+import { updateImportProgress, upsertImportedResource } from '../../../src/import/importDataAccess';
+import { ImportApiResource } from '@tech-matters/types';
+import { getSqlStatement } from '@tech-matters/testing';
+
+let conn: pgPromise.ITask<unknown>;
+
+const BASELINE_DATE = new Date(2012, 11, 4);
+
+const BLANK_ATTRIBUTES: ImportApiResource['attributes'] = {
+  ResourceStringAttributes: [],
+  ResourceReferenceStringAttributes: [],
+  ResourceBooleanAttributes: [],
+  ResourceNumberAttributes: [],
+  ResourceDateTimeAttributes: [],
+};
+
+beforeEach(() => {
+  conn = mockConnection();
+});
+
+describe('upsertImportedResource', () => {
+  test('No attributes - should run an insert', async () => {
+    mockTransaction(conn);
+    const noneSpy = jest.spyOn(conn, 'none').mockResolvedValue(null);
+    const result = await upsertImportedResource()('AC_FAKE', {
+      name: 'Test Resource',
+      id: 'TEST_RESOURCE',
+      attributes: BLANK_ATTRIBUTES,
+      updatedAt: BASELINE_DATE.toISOString(),
+    });
+    const insertSql = getSqlStatement(noneSpy);
+    expect(insertSql).toContain('Resources');
+    expect(insertSql).toContain('TEST_RESOURCE');
+    expect(insertSql).toContain('Test Resource');
+    expect(insertSql).toContain(BASELINE_DATE.toISOString());
+    expect(insertSql).toContain('AC_FAKE');
+    expect(result).toStrictEqual({ id: 'TEST_RESOURCE', success: true });
+  });
+  test('Inline attributes - should run an insert per attribute', async () => {
+    mockTransaction(conn);
+    const noneSpy = jest.spyOn(conn, 'none').mockResolvedValue(null);
+    const result = await upsertImportedResource()('AC_FAKE', {
+      name: 'Test Resource',
+      id: 'TEST_RESOURCE',
+      attributes: {
+        ...BLANK_ATTRIBUTES,
+        ResourceStringAttributes: [
+          {
+            key: 'Test String Attribute',
+            value: 'Test String Value',
+            info: {},
+            language: 'en-IE',
+          },
+        ],
+        ResourceNumberAttributes: [
+          {
+            key: 'Test Number Attribute',
+            value: 1337,
+            info: {},
+          },
+        ],
+        ResourceBooleanAttributes: [
+          {
+            key: 'Test Boolean Attribute',
+            value: true,
+            info: {},
+          },
+        ],
+        ResourceDateTimeAttributes: [
+          {
+            key: 'Test DateTime Attribute',
+            value: subHours(BASELINE_DATE, 1).toISOString(),
+            info: {},
+          },
+        ],
+      },
+      updatedAt: BASELINE_DATE.toISOString(),
+    });
+    const insertSql = getSqlStatement(noneSpy);
+    expect(insertSql).toContain('Resources');
+    expect(insertSql).toContain('TEST_RESOURCE');
+    expect(insertSql).toContain('Test Resource');
+    expect(insertSql).toContain(BASELINE_DATE.toISOString());
+    expect(insertSql).toContain('AC_FAKE');
+    expect(insertSql).toContain('Test String Attribute');
+    expect(insertSql).toContain('Test String Value');
+    expect(insertSql).toContain("'en-IE'");
+    expect(insertSql).toContain('Test Boolean Attribute');
+    expect(insertSql).toContain('true');
+    expect(insertSql).toContain('{}');
+    expect(insertSql).toContain('Test Number Attribute');
+    expect(insertSql).toContain('1337');
+    expect(insertSql).toContain('Test DateTime Attribute');
+    expect(insertSql).toContain(subHours(BASELINE_DATE, 1).toISOString());
+    expect(result).toStrictEqual({ id: 'TEST_RESOURCE', success: true });
+  });
+  test('Reference attributes - should run an insert per attribute', async () => {
+    mockTransaction(conn);
+    const noneSpy = jest.spyOn(conn, 'none').mockResolvedValue(null);
+    const result = await upsertImportedResource()('AC_FAKE', {
+      name: 'Test Resource',
+      id: 'TEST_RESOURCE',
+      attributes: {
+        ...BLANK_ATTRIBUTES,
+        ResourceReferenceStringAttributes: [
+          {
+            key: 'Test Reference Attribute',
+            value: 'Test Reference Value',
+            language: 'en-IE',
+            list: "List o' strings",
+          },
+        ],
+      },
+      updatedAt: BASELINE_DATE.toISOString(),
+    });
+    const insertSql = getSqlStatement(noneSpy);
+    expect(insertSql).toContain('Resources');
+    expect(insertSql).toContain('TEST_RESOURCE');
+    expect(insertSql).toContain('Test Resource');
+    expect(insertSql).toContain(BASELINE_DATE.toISOString());
+    expect(insertSql).toContain('AC_FAKE');
+    expect(insertSql).toContain('Test Reference Attribute');
+    expect(insertSql).toContain('Test Reference Value');
+    expect(insertSql).toContain("List o'' strings");
+    expect(result).toStrictEqual({ id: 'TEST_RESOURCE', success: true });
+  });
+});
+
+describe('updateImportProgress', () => {
+  test('Should upsert progress against account key', async () => {
+    mockTransaction(conn);
+    const noneSpy = jest.spyOn(conn, 'none').mockResolvedValue(null);
+    await updateImportProgress()('AC_FAKE', {
+      fromDate: subHours(BASELINE_DATE, 12).toISOString(),
+      toDate: BASELINE_DATE.toISOString(),
+      total: 1234,
+      lastProcessedDate: subHours(BASELINE_DATE, 6).toISOString(),
+      lastProcessedId: 'TEST_RESOURCE',
+    });
+    const insertSql = getSqlStatement(noneSpy);
+    expect(insertSql).toContain('Accounts');
+    expect(insertSql).toContain('1234');
+    expect(insertSql).toContain('AC_FAKE');
+    expect(insertSql).toContain(BASELINE_DATE.toISOString());
+    expect(insertSql).toContain(subHours(BASELINE_DATE, 12).toISOString());
+    expect(insertSql).toContain(subHours(BASELINE_DATE, 6).toISOString());
+  });
+});

--- a/resources-service/tests/unit/import/importDataAccess.test.ts
+++ b/resources-service/tests/unit/import/importDataAccess.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import * as pgPromise from 'pg-promise';
 import { subHours } from 'date-fns';
 import { mockConnection, mockTransaction } from '../mock-db';

--- a/resources-service/tests/unit/import/importService.test.ts
+++ b/resources-service/tests/unit/import/importService.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { subHours, subSeconds } from 'date-fns';
+import { mockConnection, mockTransaction } from '../mock-db';
+import { updateImportProgress, upsertImportedResource } from '../../../src/import/importDataAccess';
+import { ImportApiResource, ImportBatch, ImportProgress } from '@tech-matters/types';
+import importService from '../../../src/import/importService';
+import { AccountSID } from '@tech-matters/twilio-worker-auth/dist';
+jest.mock('../../../src/import/importDataAccess', () => ({
+  updateImportProgress: jest.fn(),
+  upsertImportedResource: jest.fn(),
+}));
+const conn = mockConnection();
+
+const mockUpdateImportProgress = updateImportProgress as jest.MockedFunction<
+  typeof updateImportProgress
+>;
+let mockUpdateProgress: jest.MockedFunction<ReturnType<typeof updateImportProgress>> = jest.fn();
+const mockUpsertImportedResource = upsertImportedResource as jest.MockedFunction<
+  typeof upsertImportedResource
+>;
+let mockUpsert: jest.MockedFunction<ReturnType<typeof upsertImportedResource>> = jest.fn();
+
+const BASELINE_DATE = new Date(2012, 11, 4);
+
+const BLANK_ATTRIBUTES: ImportApiResource['attributes'] = {
+  ResourceStringAttributes: [],
+  ResourceReferenceStringAttributes: [],
+  ResourceBooleanAttributes: [],
+  ResourceNumberAttributes: [],
+  ResourceDateTimeAttributes: [],
+};
+
+const BASELINE_BATCH: ImportBatch = {
+  total: 100,
+  fromDate: subHours(BASELINE_DATE, 12).toISOString(),
+  toDate: BASELINE_DATE.toISOString(),
+};
+
+const SAMPLE_RESOURCES: ImportApiResource[] = [
+  {
+    name: 'Test Resource 50',
+    id: 'TEST_RESOURCE_50',
+    attributes: BLANK_ATTRIBUTES,
+    updatedAt: subSeconds(BASELINE_DATE, 1).toISOString(),
+  },
+  {
+    name: 'Test Resource 1',
+    id: 'TEST_RESOURCE_1',
+    attributes: BLANK_ATTRIBUTES,
+    updatedAt: subHours(BASELINE_DATE, 6).toISOString(),
+  },
+  {
+    name: 'Test Resource 20',
+    id: 'TEST_RESOURCE_20',
+    attributes: BLANK_ATTRIBUTES,
+    updatedAt: subSeconds(BASELINE_DATE, 30).toISOString(),
+  },
+];
+
+let upsertResources: ReturnType<typeof importService>['upsertResources'];
+
+beforeEach(() => {
+  mockTransaction(conn);
+  mockUpdateImportProgress.mockReturnValue(mockUpdateProgress);
+
+  mockUpsertImportedResource.mockReturnValue(mockUpsert);
+  mockUpsert.mockImplementation((accountSid, { id }) => Promise.resolve({ id, success: true }));
+  upsertResources = importService().upsertResources;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('upsertResources', () => {
+  test('No resources - noop', async () => {
+    await upsertResources('AC_FAKE', [], BASELINE_BATCH);
+    expect(mockUpsertImportedResource).not.toHaveBeenCalled();
+    expect(mockUpdateImportProgress).not.toHaveBeenCalled();
+  });
+  test('Several resources - inserted in document order in a transaction, and update progress set to ID with latest updated date in batch', async () => {
+    const result = await upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH);
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+    expect(mockUpsert).toHaveBeenCalledTimes(3);
+    mockUpsert.mock.calls.forEach(([accountSid, resource], index) => {
+      expect(accountSid).toBe('AC_FAKE');
+      expect(resource).toEqual(SAMPLE_RESOURCES[index]);
+    });
+    expect(mockUpdateProgress).toHaveBeenCalledWith<[AccountSID, ImportProgress]>('AC_FAKE', {
+      ...BASELINE_BATCH,
+      lastProcessedId: 'TEST_RESOURCE_50',
+      lastProcessedDate: subSeconds(BASELINE_DATE, 1).toISOString(),
+    });
+    expect(result).toEqual(SAMPLE_RESOURCES.map(({ id }) => ({ id, success: true })));
+  });
+  test('A resource update throws - aborts transaction & throws', async () => {
+    const bork = new Error('bork');
+    mockUpsert.mockImplementation(async (accountSid, { id }) => {
+      if (id === 'TEST_RESOURCE_1') {
+        throw bork;
+      }
+      return { id, success: true };
+    });
+    await expect(upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH)).rejects.toThrow(
+      bork,
+    );
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    mockUpsert.mock.calls.slice(0, 2).forEach(([accountSid, resource], index) => {
+      expect(accountSid).toBe('AC_FAKE');
+      expect(resource).toEqual(SAMPLE_RESOURCES[index]);
+    });
+    expect(mockUpdateProgress).not.toHaveBeenCalled();
+  });
+  test('A resource update rejects - aborts transaction & throws', async () => {
+    const bork = new Error('bork');
+    mockUpsert.mockImplementation(async (accountSid, { id }) => {
+      if (id === 'TEST_RESOURCE_1') {
+        return Promise.reject(bork);
+      }
+      return { id, success: true };
+    });
+    await expect(upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH)).rejects.toThrow(
+      bork,
+    );
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    mockUpsert.mock.calls.slice(0, 2).forEach(([accountSid, resource], index) => {
+      expect(accountSid).toBe('AC_FAKE');
+      expect(resource).toEqual(SAMPLE_RESOURCES[index]);
+    });
+    expect(mockUpdateProgress).not.toHaveBeenCalled();
+  });
+  test('A resource update fails - aborts transaction & throws', async () => {
+    const bork = new Error('bork');
+    mockUpsert.mockImplementation(async (accountSid, { id }) => {
+      return { id, success: false, error: bork };
+    });
+    await expect(upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH)).rejects.toThrow(
+      bork,
+    );
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [accountSid, resource] = mockUpsert.mock.calls[0];
+    expect(accountSid).toBe('AC_FAKE');
+    expect(resource).toEqual(SAMPLE_RESOURCES[0]);
+
+    expect(mockUpdateProgress).not.toHaveBeenCalled();
+  });
+
+  test('A resource fails validation - rolls back transaction & returns validation error', async () => {
+    const brokenResources = [...SAMPLE_RESOURCES];
+    const { name, updatedAt, ...invalidResource } = brokenResources[1];
+    brokenResources[1] = invalidResource as ImportApiResource;
+    const result = await upsertResources('AC_FAKE', brokenResources, BASELINE_BATCH);
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [accountSid, resource] = mockUpsert.mock.calls[0];
+    expect(accountSid).toBe('AC_FAKE');
+    expect(resource).toEqual(SAMPLE_RESOURCES[0]);
+
+    expect(mockUpdateProgress).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      resource: brokenResources[1],
+      reason: 'missing field',
+      fields: ['name', 'updatedAt'],
+    });
+  });
+
+  test('Progress update rejects - rolls back transaction & throws error', async () => {
+    const bork = new Error('bork');
+    mockUpdateProgress.mockRejectedValue(bork);
+    await expect(upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH)).rejects.toThrow(
+      bork,
+    );
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+    expect(mockUpsert).toHaveBeenCalledTimes(3);
+    expect(mockUpdateProgress).toHaveBeenCalledWith<[AccountSID, ImportProgress]>('AC_FAKE', {
+      ...BASELINE_BATCH,
+      lastProcessedId: 'TEST_RESOURCE_50',
+      lastProcessedDate: subSeconds(BASELINE_DATE, 1).toISOString(),
+    });
+  });
+
+  test('Progress update throws - rolls back transaction & throws error', async () => {
+    const bork = new Error('bork');
+    mockUpdateProgress.mockImplementation(() => {
+      throw bork;
+    });
+    await expect(upsertResources('AC_FAKE', SAMPLE_RESOURCES, BASELINE_BATCH)).rejects.toThrow(
+      bork,
+    );
+    expect(mockUpsertImportedResource).toHaveBeenCalledWith(expect.anything());
+    expect(mockUpsert).toHaveBeenCalledTimes(3);
+    expect(mockUpdateProgress).toHaveBeenCalledWith<[AccountSID, ImportProgress]>('AC_FAKE', {
+      ...BASELINE_BATCH,
+      lastProcessedId: 'TEST_RESOURCE_50',
+      lastProcessedDate: subSeconds(BASELINE_DATE, 1).toISOString(),
+    });
+  });
+});


### PR DESCRIPTION
## Description

* Backfill unit tests for CHI-1746
* Add some missing fields to resource import query
* Rollback transaction & error if any resource upsert gives a failure response

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added


### Related Issues
CHI-1746

### Verification steps

Automated tests