### PR TITLE
hotfix: bad merge of node18 update caused jobs to use node16

### DIFF
--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -39,7 +39,7 @@ RUN rsync -a jobs/${lambda_name}/node_modules/ /var/task/node_modules; exit 0
 
 # The added layers from our build increase image size significantly. This flattens the image
 # to reduce the size of the final image.
-FROM public.ecr.aws/lambda/nodejs:16
+FROM public.ecr.aws/lambda/nodejs:18
 COPY --from=build /var/task /var/task
 
 # all of this is a little more fragile than I would like because we have to duplicate the parent repo


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Fixes regression in jobs upgrade to node 18 where container is still using node16 after build.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Run tests