### PR TITLE
refactor: use complex config to specify per region lambda deployments

### DIFF
--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -1,26 +1,41 @@
 {
   "development": {
     "us-east-1": {
-      "resources-import-producer": ["resources-import-producer-as"]
+      "lambda-groups": {
+        "resources-import-producer": ["resources-import-producer-as"]
+      }
     }
   },
   "staging": {
     "us-east-1": {
-      "resources-import-producer": ["resources-import-producer-khp"]
+      "lambda-groups": {
+        "resources-import-producer": [
+          "resources-import-producer-as",
+          "resources-import-producer-khp"
+        ]
+      }
     },
     "eu-west-1": {
-      "resources-import-producer": []
+      "lambda-groups": {
+        "resources-import-producer": []
+      }
     }
   },
   "production": {
     "us-east-1": {
-      "resources-import-producer": []
+      "lambda-groups": {
+        "resources-import-producer": []
+      }
     },
     "eu-west-1": {
-      "resources-import-producer": []
+      "lambda-groups": {
+        "resources-import-producer": []
+      }
     },
     "ca-central-1": {
-      "resources-import-producer": ["resources-import-producer-khp"]
+      "lambda-groups": {
+        "resources-import-producer": ["resources-import-producer-khp"]
+      }
     }
   }
 }

--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -1,5 +1,26 @@
 {
-  "development": ["us-east-1"],
-  "staging": ["us-east-1", "eu-west-1"],
-  "production": ["us-east-1", "eu-west-1", "ca-central-1"]
+  "development": {
+    "us-east-1": {
+      "resources-import-producer": ["resources-import-producer-as"]
+    }
+  },
+  "staging": {
+    "us-east-1": {
+      "resources-import-producer": ["resources-import-producer-khp"]
+    },
+    "eu-west-1": {
+      "resources-import-producer": []
+    }
+  },
+  "production": {
+    "us-east-1": {
+      "resources-import-producer": []
+    },
+    "eu-west-1": {
+      "resources-import-producer": []
+    },
+    "ca-central-1": {
+      "resources-import-producer": ["resources-import-producer-khp"]
+    }
+  }
 }

--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -2,10 +2,7 @@
   "development": {
     "us-east-1": {
       "lambda-groups": {
-        "resources-import-producer": [
-          "resources-import-producer-as",
-          "resources-import-producer-e2e"
-        ]
+        "resources-import-producer": ["resources-import-producer-as"]
       }
     }
   },

--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -2,7 +2,10 @@
   "development": {
     "us-east-1": {
       "lambda-groups": {
-        "resources-import-producer": ["resources-import-producer-as"]
+        "resources-import-producer": [
+          "resources-import-producer-as",
+          "resources-import-producer-e2e"
+        ]
       }
     }
   },

--- a/.github/workflows/hrm-ecs-deploy.yml
+++ b/.github/workflows/hrm-ecs-deploy.yml
@@ -86,7 +86,7 @@ jobs:
 
       - id: generate-output
         run: |
-          regions=$(jq --arg key "${{ inputs.environment }}" '.[$key]' ./.github/workflows/config/environment-region-map.json)
+          regions=$(jq --arg env "${{ inputs.environment }}" '.[$env] | keys[]' ./.github/workflows/config/environment-region-map.json)
           echo "regions=$(echo $regions)" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ inputs.environment }}-hrm-${{ github.sha }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -79,13 +79,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Test
-        id: test
-        run: |
-          jq --version
-          cat ./.github/workflows/config/environment-region-map.json
-          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -115,6 +108,8 @@ jobs:
         id: generate-output
         run: |
           jq --version
+          cat ./.github/workflows/config/environment-region-map.json
+          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
           matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -93,16 +93,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v4
-        with:
-          context: ./
-          file: ./jobs/Dockerfile
-          build-args: |
-            lambda_name=${{ inputs.lambda_name }}
-            lambda_dir=${{ (startsWith(inputs.lambda_name, 'resources') && 'resources') || 'hrm' }}-domain
-          push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+      # TODO: uncomment this once debugged
+      # - name: Build and Push Docker Image
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: ./
+      #     file: ./jobs/Dockerfile
+      #     build-args: |
+      #       lambda_name=${{ inputs.lambda_name }}
+      #       lambda_dir=${{ (startsWith(inputs.lambda_name, 'resources') && 'resources') || 'hrm' }}-domain
+      #     push: true
+      #     tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
       - name: Generate output
         id: generate-output
@@ -142,6 +143,7 @@ jobs:
       # that is pushed in the primary region available in all other regions.
       - name: Update Lambda and Publish
         run: |
+          echo "${{ matrix.include }}"
           DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.include.region }}/g')
           aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.include.lambda }} --image-uri "$DOCKER_IMAGE" --publish
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -83,8 +83,8 @@ jobs:
         id: test
         run: |
           jq --version
-          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
-          echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
+          cat ./.github/workflows/config/environment-region-map.json
+          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -125,11 +125,6 @@ jobs:
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 
-  generate_deploy_lambda_matrix:
-    needs: build_lambda
-    name: Generate deploy lambda matrix
-    runs-on: ubuntu-latest
-
   deploy_lambdas:
     needs: build_lambda
     name: Deploy to Amazon ECS

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Test
+        id: test
+        run: |
+          jq --version
+          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
+          echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -107,6 +114,7 @@ jobs:
       - name: Generate output
         id: generate-output
         run: |
+          jq --version
           matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
@@ -122,7 +130,6 @@ jobs:
 
     env:
       DOCKER_IMAGE: ${{ needs.build_lambda.outputs.docker_image }}
-      LAMBDA_INSTANCE_NAME: ${{ (inputs.lambda_instance_id != '' && format('{0}-{1}', inputs.lambda_name, inputs.lambda_instance_id)) || inputs.lambda_name }}
 
     steps:
       - name: Configure AWS credentials
@@ -141,7 +148,7 @@ jobs:
       - name: Update Lambda and Publish
         run: |
           DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.region }}/g')
-          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ env.LAMBDA_INSTANCE_NAME }} --image-uri "$DOCKER_IMAGE" --publish
+          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ inputs.lambda_name }} --image-uri "$DOCKER_IMAGE" --publish
 
       # reconfigure AWS credentials to use the default region for SSM Parameter Store.
       # aws-actions/configure-aws-credentials@v2 overrides env.AWS_DEFAULT_REGION, so

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           # output to logs
           jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else $lambda_name end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
-          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else $lambda_name end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
+          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else $lambda_name end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -132,7 +132,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.generate_deploy_lambda_matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.build_lambda.outputs.matrix) }}
 
     env:
       DOCKER_IMAGE: ${{ needs.build_lambda.outputs.docker_image }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -107,11 +107,7 @@ jobs:
       - name: Generate output
         id: generate-output
         run: |
-          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{
-              include: [
-                (.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})
-              ]
-            }' ./.github/workflows/config/environment-region-map.json)
+          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -107,9 +107,8 @@ jobs:
       - name: Generate output
         id: generate-output
         run: |
-          jq --version
-          cat ./.github/workflows/config/environment-region-map.json
-          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
+          # output to logs for debugging
+          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
           matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
@@ -121,7 +120,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.build_lambda.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.build_lambda.outputs.matrix_json) }}
 
     env:
       DOCKER_IMAGE: ${{ needs.build_lambda.outputs.docker_image }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -107,9 +107,9 @@ jobs:
       - name: Generate output
         id: generate-output
         run: |
-          # output to logs for debugging
-          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
-          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
+          # output to logs
+          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | (if $region_entry.value[$lambda_name] == null then [$lambda_name] else $region_entry.value[$lambda_name] end)[] | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
+          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | (if $region_entry.value[$lambda_name] == null then [$lambda_name] else $region_entry.value[$lambda_name] end)[] | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 
@@ -120,7 +120,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.build_lambda.outputs.matrix_json) }}
+      matrix:
+        include: ${{ fromJson(needs.build_lambda.outputs.matrix_json) }}
 
     env:
       DOCKER_IMAGE: ${{ needs.build_lambda.outputs.docker_image }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -104,6 +104,14 @@ jobs:
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
+      # The matrix build supports `lambda-groups` defined in the environment-region-map.json file
+      # This allows us to deploy multiple lambdas to specific env/region combos that use a common docker image
+      # That is some pretty intense JQ, but it works.
+      # The current behavior is: If a key that matches the lambda name is found in the lambda-groups object, then
+      # created separate entries for each region/lambda combo. Otherwise, just use the lambda name and deploy to all
+      # regions that exist for that environment.
+      # matrices don't support complex object structures, so we generate a a flat array of objects that contain the
+      # region and lambda name. If there are multiple lambdas, the region will be repeated for each lambda.
       - name: Generate output
         id: generate-output
         run: |

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -38,11 +38,6 @@ on:
           - resources-import-producer
           - resources-search-complete
           - resources-search-index
-      lambda_instance_id:
-        description: The instance ID of the lambda to deploy. Currently only needed for resources-import-producer, where it is the lower case helpline code
-        required: false
-        type: string
-        default: ''
 
   workflow_call:
     secrets:
@@ -60,11 +55,6 @@ on:
         description: 'hrm lambda name'
         required: true
         type: string
-      lambda_instance_id:
-        description: The instance ID of the lambda to deploy. Currently only needed for resources-import-producer, where it is the lower case helpline code
-        required: false
-        type: string
-        default: ''
       send-slack-message:
         description: 'Specifies if should send a Slack message at the end of successful run. Defaults to true'
         required: false
@@ -90,7 +80,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -104,7 +94,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: ./jobs/Dockerfile
@@ -117,7 +107,7 @@ jobs:
       - name: Generate output
         id: generate-output
         run: |
-          matrix_json=$(jq --argjson lambda_name "${{ inputs.lambda_name }}" --argjson env "${{ inputs.environment }}" '{
+          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{
               include: [
                 (.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})
               ]
@@ -140,7 +130,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -158,10 +148,10 @@ jobs:
           aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ env.LAMBDA_INSTANCE_NAME }} --image-uri "$DOCKER_IMAGE" --publish
 
       # reconfigure AWS credentials to use the default region for SSM Parameter Store.
-      # aws-actions/configure-aws-credentials@v1 overrides env.AWS_DEFAULT_REGION, so
+      # aws-actions/configure-aws-credentials@v2 overrides env.AWS_DEFAULT_REGION, so
       # we name our env var PRIMARY_AWS_REGION to avoid that.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -108,8 +108,8 @@ jobs:
         id: generate-output
         run: |
           # output to logs
-          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else [$lambda_name] end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
-          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else [$lambda_name] end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json)
+          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else $lambda_name end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
+          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else $lambda_name end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -143,7 +143,7 @@ jobs:
       # that is pushed in the primary region available in all other regions.
       - name: Update Lambda and Publish
         run: |
-          echo "${{ matrix.include }}"
+          echo "${{ matrix }}"
           DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.include.region }}/g')
           aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.include.lambda }} --image-uri "$DOCKER_IMAGE" --publish
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -108,8 +108,8 @@ jobs:
         id: generate-output
         run: |
           # output to logs
-          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | (if $region_entry.value[$lambda_name] == null then [$lambda_name] else $region_entry.value[$lambda_name] end)[] | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
-          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | (if $region_entry.value[$lambda_name] == null then [$lambda_name] else $region_entry.value[$lambda_name] end)[] | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json)
+          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else [$lambda_name] end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json
+          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '[.[$env] | to_entries[] | . as $region_entry | if $region_entry.value["lambda-groups"][$lambda_name] then $region_entry.value["lambda-groups"][$lambda_name][] else [$lambda_name] end | {region: $region_entry.key, lambda: .}]' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      regions: ${{ steps.generate-output.outputs.regions }}
+      matrix_json: ${{ steps.generate-output.outputs.matrix_json }}
       docker_image: ${{ steps.generate-output.outputs.docker_image}}
 
     steps:
@@ -114,11 +114,21 @@ jobs:
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
-      - id: generate-output
+      - name: Generate output
+        id: generate-output
         run: |
-          regions=$(jq --arg key "${{ inputs.environment }}" '.[$key]' ./.github/workflows/config/environment-region-map.json)
-          echo "regions=$(echo $regions)" >> $GITHUB_OUTPUT
+          matrix_json=$(jq --argjson lambda_name "${{ inputs.lambda_name }}" --argjson env "${{ inputs.environment }}" '{
+              include: [
+                (.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})
+              ]
+            }' ./.github/workflows/config/environment-region-map.json)
+          echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
+
+  generate_deploy_lambda_matrix:
+    needs: build_lambda
+    name: Generate deploy lambda matrix
+    runs-on: ubuntu-latest
 
   deploy_lambdas:
     needs: build_lambda
@@ -127,8 +137,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        region: ${{ fromJson(needs.build_lambda.outputs.regions) }}
+      matrix: ${{ fromJson(needs.generate_deploy_lambda_matrix.outputs.matrix) }}
 
     env:
       DOCKER_IMAGE: ${{ needs.build_lambda.outputs.docker_image }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -93,17 +93,16 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      # TODO: uncomment this once debugged
-      # - name: Build and Push Docker Image
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: ./
-      #     file: ./jobs/Dockerfile
-      #     build-args: |
-      #       lambda_name=${{ inputs.lambda_name }}
-      #       lambda_dir=${{ (startsWith(inputs.lambda_name, 'resources') && 'resources') || 'hrm' }}-domain
-      #     push: true
-      #     tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./jobs/Dockerfile
+          build-args: |
+            lambda_name=${{ inputs.lambda_name }}
+            lambda_dir=${{ (startsWith(inputs.lambda_name, 'resources') && 'resources') || 'hrm' }}-domain
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:live,${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
       - name: Generate output
         id: generate-output
@@ -143,9 +142,8 @@ jobs:
       # that is pushed in the primary region available in all other regions.
       - name: Update Lambda and Publish
         run: |
-          echo "${{ toJson(matrix) }}"
-          DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.include.region }}/g')
-          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.include.lambda }} --image-uri "$DOCKER_IMAGE" --publish
+          DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.region }}/g')
+          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.lambda }} --image-uri "$DOCKER_IMAGE" --publish
 
       # reconfigure AWS credentials to use the default region for SSM Parameter Store.
       # aws-actions/configure-aws-credentials@v2 overrides env.AWS_DEFAULT_REGION, so
@@ -176,7 +174,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.14.0
         with:
           channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-          slack-message: '`[HRM lambdas - ${{ matrix.include.lambda }}]` Deployment of ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }} to region `${{ matrix.region }}`, environment `${{ inputs.environment }}` :rocket:.'
+          slack-message: '`[HRM lambdas - ${{ matrix.lambda }}]` Deployment of ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }} to region `${{ matrix.region }}`, environment `${{ inputs.environment }}` :rocket:.'
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
         if: ${{ inputs.send-slack-message != 'false' }}

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -143,7 +143,7 @@ jobs:
       # that is pushed in the primary region available in all other regions.
       - name: Update Lambda and Publish
         run: |
-          echo "${{ matrix }}"
+          echo "${{ toJson(matrix) }}"
           DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.include.region }}/g')
           aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.include.lambda }} --image-uri "$DOCKER_IMAGE" --publish
 

--- a/.github/workflows/hrm-lambda-deploy.yml
+++ b/.github/workflows/hrm-lambda-deploy.yml
@@ -109,8 +109,8 @@ jobs:
         run: |
           jq --version
           cat ./.github/workflows/config/environment-region-map.json
-          jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
-          matrix_json=$(jq --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
+          jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json
+          matrix_json=$(jq -c --arg lambda_name "${{ inputs.lambda_name }}" --arg env "${{ inputs.environment }}" '{include: [(.[$env] | to_entries[] | {region: .key, lambda: (if .value[$lambda_name] == null then [$lambda_name] else .value[$lambda_name] end)})]}' ./.github/workflows/config/environment-region-map.json)
           echo "matrix_json=$matrix_json" >> $GITHUB_OUTPUT
           echo "docker_image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 
@@ -142,8 +142,8 @@ jobs:
       # that is pushed in the primary region available in all other regions.
       - name: Update Lambda and Publish
         run: |
-          DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.region }}/g')
-          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ inputs.lambda_name }} --image-uri "$DOCKER_IMAGE" --publish
+          DOCKER_IMAGE=$(echo "${{ env.DOCKER_IMAGE }}" | sed -r 's/${{ env.PRIMARY_AWS_REGION }}/${{ matrix.include.region }}/g')
+          aws lambda update-function-code --function-name ${{ inputs.environment }}-hrm-${{ matrix.include.lambda }} --image-uri "$DOCKER_IMAGE" --publish
 
       # reconfigure AWS credentials to use the default region for SSM Parameter Store.
       # aws-actions/configure-aws-credentials@v2 overrides env.AWS_DEFAULT_REGION, so
@@ -174,7 +174,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.14.0
         with:
           channel-id: ${{ env.ASELO_DEPLOYS_CHANNEL_ID }}
-          slack-message: '`[HRM lambdas - ${{ env.LAMBDA_INSTANCE_NAME }}]` Deployment of ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }} to region `${{ matrix.region }}`, environment `${{ inputs.environment }}` :rocket:.'
+          slack-message: '`[HRM lambdas - ${{ matrix.include.lambda }}]` Deployment of ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }} to region `${{ matrix.region }}`, environment `${{ inputs.environment }}` :rocket:.'
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}
         if: ${{ inputs.send-slack-message != 'false' }}


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This updates the env/region config file to use a more complex structure which allows us to deploy multiple per env/region lambdas using a single ECR image.

The behavior is this:
1. If a key matching the `input.lambda_name` exists in a region, only those keys are used in to build out the deploy matrix
2. If there is no key, the the lambda_name is used as a fallback and deployed to all regions.

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
