### PR TITLE
start-date end-date params requirements updated

### DIFF
--- a/hrm-domain/hrm-service/src/bin/khpDataPull.ts
+++ b/hrm-domain/hrm-service/src/bin/khpDataPull.ts
@@ -16,27 +16,7 @@
 
 import { pullData } from '../data-pull-task/khp-data-pull-task';
 
-/**
- * Returns an object with the arguments passed to the script.
- *
- * Example:
- * > npm run start:khp-data-pull -- --start-date=2023-05-01 --end-date=2023-05-30
- *
- * returns:
- * { start-date: '2023-05-01', end-date: '2023-05-30' }
- */
-// Question: Should use a lib for this?
-const getNamedArgs = () => {
-  const args = process.argv.slice(2);
-  return args.reduce((acc, currentArg) => {
-    if (!currentArg.startsWith('--') || !currentArg.includes('=')) return acc;
+const startDateISO = process.argv[2];
+const endDateISO = process.argv[3];
 
-    const indexOfEqual = currentArg.indexOf('=');
-    const name = currentArg.substring(2, indexOfEqual);
-    const value = currentArg.substring(indexOfEqual + 1);
-
-    return { ...acc, [name]: value };
-  }, {});
-};
-
-pullData(getNamedArgs());
+pullData(startDateISO, endDateISO);

--- a/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/index.ts
+++ b/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/index.ts
@@ -21,6 +21,9 @@ import isValid from 'date-fns/isValid';
 import { pullCases } from './pull-cases';
 import { pullContacts } from './pull-contacts';
 
+const isNullUndefinedOrEmptyString = (value: string) =>
+  value === null || value === undefined || value === '';
+
 const getDateRangeForPast12Hours = () => {
   const endDate = new Date();
   const startDate = subHours(endDate, 12);
@@ -48,7 +51,8 @@ const getDateRangeFromArgs = (startDateISO?: string, endDateISO?: string) => {
  * In this scenario, it will pull data for the last 12h.
  */
 export const pullData = async (startDateISO?: string, endDateISO?: string) => {
-  const hasNoDateArgs = startDateISO === undefined && endDateISO === undefined;
+  const hasNoDateArgs =
+    isNullUndefinedOrEmptyString(startDateISO) && isNullUndefinedOrEmptyString(endDateISO);
 
   const { startDate, endDate } = hasNoDateArgs
     ? getDateRangeForPast12Hours()

--- a/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/index.ts
+++ b/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/index.ts
@@ -14,17 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import startOfDay from 'date-fns/startOfDay';
-import endOfDay from 'date-fns/endOfDay';
 import subHours from 'date-fns/subHours';
-import parse from 'date-fns/parse';
+import parseISO from 'date-fns/parseISO';
 import isValid from 'date-fns/isValid';
 
 import { pullCases } from './pull-cases';
 import { pullContacts } from './pull-contacts';
-
-const hasNoDateArgs = (args: any) =>
-  args['start-date'] === undefined && args['end-date'] === undefined;
 
 const getDateRangeForPast12Hours = () => {
   const endDate = new Date();
@@ -33,39 +28,31 @@ const getDateRangeForPast12Hours = () => {
   return { startDate, endDate };
 };
 
-const getDateRangeFromArgs = (args: any) => {
-  const startDateFromArgs = args['start-date'];
-  const endDateFromArgs = args['end-date'];
+const getDateRangeFromArgs = (startDateISO?: string, endDateISO?: string) => {
+  const startDate = parseISO(startDateISO);
+  const endDate = endDateISO ? parseISO(endDateISO) : new Date();
 
-  // Question: Should we deal with timezones explicitally?
-  const givenStartDate = parse(startDateFromArgs, 'yyyy-MM-dd', new Date());
-  const givenEndDate = parse(endDateFromArgs, 'yyyy-MM-dd', new Date());
-
-  if (isValid(givenStartDate) && isValid(givenEndDate)) {
-    const startDate = startOfDay(givenStartDate);
-    const endDate = endOfDay(givenEndDate);
-
+  if (isValid(startDate) && isValid(endDate)) {
     return { startDate, endDate };
   } else {
-    // Question: Can throwing errors on ECS Tasks cause any issue?
     throw new Error('Invalid start-date or end-date');
   }
 };
 
 /**
  * This function will pull the data given start-date and end-date.
- * It will set:
- *  - startDate: startOfDay(start-date)
- *  - endDate: endOfDay(end-date)
- * It will throw an error in case one of the given params is invalid.
+ * - It will default end-date to 'Now', if it's not specified
+ * - It will throw an error in case one of the given params is an invalid ISO string.
  *
  * This function can also be called without start-date and end-date.
  * In this scenario, it will pull data for the last 12h.
  */
-export const pullData = async (args: any) => {
-  const { startDate, endDate } = hasNoDateArgs(args)
+export const pullData = async (startDateISO?: string, endDateISO?: string) => {
+  const hasNoDateArgs = startDateISO === undefined && endDateISO === undefined;
+
+  const { startDate, endDate } = hasNoDateArgs
     ? getDateRangeForPast12Hours()
-    : getDateRangeFromArgs(args);
+    : getDateRangeFromArgs(startDateISO, endDateISO);
 
   await Promise.all([pullCases(startDate, endDate), pullContacts(startDate, endDate)]);
 };

--- a/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
@@ -1,0 +1,87 @@
+import subHours from 'date-fns/subHours';
+import differenceInSeconds from 'date-fns/differenceInSeconds';
+import parseISO from 'date-fns/parseISO';
+
+import { pullData } from '../../../src/data-pull-task/khp-data-pull-task';
+import * as pullContactsModule from '../../../src/data-pull-task/khp-data-pull-task/pull-contacts';
+import * as pullCasesModule from '../../../src/data-pull-task/khp-data-pull-task/pull-cases';
+
+jest.mock('../../../src/data-pull-task/khp-data-pull-task/pull-contacts');
+jest.mock('../../../src/data-pull-task/khp-data-pull-task/pull-cases');
+
+const getParamsFromSpy = (spy: jest.SpyInstance) => ({
+  startDate: spy.mock.calls[0][0],
+  endDate: spy.mock.calls[0][1],
+});
+
+const assertSpyHasBeenCalledWithRouhly = (
+  spy: jest.SpyInstance,
+  expectedStartDate: Date,
+  expectedEndDate: Date,
+) => {
+  const { startDate, endDate } = getParamsFromSpy(spy);
+
+  const startDateDelta = differenceInSeconds(expectedStartDate, startDate);
+  const endDateDelta = differenceInSeconds(expectedEndDate, endDate);
+
+  expect(spy).toBeCalledWith(startDate, endDate);
+  expect(startDateDelta).toBeLessThanOrEqual(1);
+  expect(endDateDelta).toBeLessThanOrEqual(1);
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('KHP Data Pull - Params', () => {
+  test('When no params, it should default to the last 12h', async () => {
+    const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
+    const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+
+    const expectedEndDate = new Date();
+    const expectedStartDate = subHours(expectedEndDate, 12);
+
+    await pullData();
+
+    assertSpyHasBeenCalledWithRouhly(pullContactsSpy, expectedStartDate, expectedEndDate);
+    assertSpyHasBeenCalledWithRouhly(pullCasesSpy, expectedStartDate, expectedEndDate);
+  });
+
+  test('Valid start-date and end-date', async () => {
+    const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
+    const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+
+    const startDateISO = '2023-05-01T10:00:00+0000';
+    const endDateISO = '2023-05-30T18:00:00+0000';
+
+    await pullData(startDateISO, endDateISO);
+
+    expect(pullContactsSpy).toHaveBeenCalledWith(parseISO(startDateISO), parseISO(endDateISO));
+    expect(pullCasesSpy).toHaveBeenCalledWith(parseISO(startDateISO), parseISO(endDateISO));
+  });
+
+  test('No end-date should default to now', async () => {
+    const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
+    const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+
+    const startDateISO = '2023-05-01T10:00:00+0000';
+    const now = new Date();
+
+    await pullData(startDateISO);
+
+    assertSpyHasBeenCalledWithRouhly(pullContactsSpy, parseISO(startDateISO), now);
+    assertSpyHasBeenCalledWithRouhly(pullCasesSpy, parseISO(startDateISO), now);
+  });
+
+  test('Ivalid date should throw', async () => {
+    const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
+    const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+
+    const startDateISO = '9999INVALID';
+
+    await expect(pullData(startDateISO)).rejects.toThrow();
+
+    expect(pullContactsSpy).not.toHaveBeenCalled();
+    expect(pullCasesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import subHours from 'date-fns/subHours';
 import differenceInSeconds from 'date-fns/differenceInSeconds';
 import parseISO from 'date-fns/parseISO';

--- a/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/index.test.ts
@@ -57,7 +57,7 @@ describe('KHP Data Pull - Params', () => {
     const expectedEndDate = new Date();
     const expectedStartDate = subHours(expectedEndDate, 12);
 
-    await pullData();
+    await Promise.all([pullData(), pullData(null, null), pullData('', '')]);
 
     assertSpyHasBeenCalledWithRouhly(pullContactsSpy, expectedStartDate, expectedEndDate);
     assertSpyHasBeenCalledWithRouhly(pullCasesSpy, expectedStartDate, expectedEndDate);


### PR DESCRIPTION
## Description
Updates to KHP Pull Data `start-date` and `end-date` params requirements:
- The script does not expect named params anymore
- `end-date` is not required anymore
- `start-date` and `end-date` is now expected to be an ISO string

### Checklist
- [x] New tests added

### Verification steps
Verify`start-date` and `end-date` params work according to the new requirements.
