### PR TITLE
[draft] chore: add sonarjs plugin to eslint to get cognitive complexity scores

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,14 +15,16 @@
  */
 
 module.exports = {
-  extends: ['airbnb-typescript/base', 'plugin:prettier/recommended'],
-  plugins: ['prettier', 'jest', 'import'],
+  extends: ['airbnb-typescript/base', 'plugin:prettier/recommended', 'plugin:sonarjs/recommended'],
+  plugins: ['prettier', 'jest', 'import', 'sonarjs'],
   rules: {
     'prettier/prettier': ['error'],
     'no-console': 'off',
     '@typescript-eslint/indent': 'off',
     '@typescript-eslint/quotes': 'off',
     'import/prefer-default-export': 'off',
+    'sonarjs/no-duplicate-string': 'off',
+    'sonarjs/no-nested-template-literals': 'off',
   },
   settings: {
     'import/resolver': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-jest": "^23.8.2",
         "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-sonarjs": "^0.19.0",
         "jest": "^28.1.3",
         "jest-config": "^28.1.3",
         "npm-run-all": "^4.1.5",
@@ -7331,6 +7332,18 @@
         }
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz",
+      "integrity": "sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -13466,7 +13479,6 @@
         "@tech-matters/types": "^1.0.0"
       },
       "devDependencies": {
-        "@tech-matters/resources-search-config": "^1.0.0",
         "@types/node": "^18.15.11",
         "jest-each": "^29.5.0",
         "lodash": "^4.17.21"
@@ -16683,7 +16695,6 @@
       "version": "file:packages/elasticsearch-client",
       "requires": {
         "@elastic/elasticsearch": "^8.7.0",
-        "@tech-matters/resources-search-config": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
         "@tech-matters/types": "^1.0.0",
         "@types/node": "^18.15.11",
@@ -18503,6 +18514,13 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
+    },
+    "eslint-plugin-sonarjs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz",
+      "integrity": "sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-prettier": "^3.4.1",
+    "eslint-plugin-sonarjs": "^0.19.0",
     "jest": "^28.1.3",
     "jest-config": "^28.1.3",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This adds sonarjs rules to eslint primarily to give us cognitive complexity linting, but there are a few other useful rules it adds.
