### PR TITLE
fix: use new DRY flex-plugin install before e2e tests

### DIFF
--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Install Flex Plugin
         uses: ./flex-plugins/.github/actions/install-flex-plugin
+        with:
+          path: ./flex-plugins
 
       # Build Playwright
       - name: Install e2e-tests dependencies

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -99,7 +99,7 @@ jobs:
 
       # Run E2E tests against actual E2E Flex instance
       - name: Run Playwright tests
-        run: npm run test:local
+        run: npm run test:development:e2e
         working-directory: ./flex-plugins/e2e-tests
 
       # Upload artifacts

--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -13,7 +13,7 @@
 # along with this program.  If not, see https://www.gnu.org/licenses/.
 
 # Workflow to create a new pre-release with qa suffix
-name: "Create a QA candidate release"
+name: 'Create a QA candidate release'
 # Controls when the action will run.
 on:
   workflow_dispatch:
@@ -53,6 +53,7 @@ jobs:
       send-slack-message: 'false'
       environment: 'development'
       lambda_name: ${{ matrix.lambda_name }}
+
   run-e2e-tests:
     needs:
       - build-and-deploy-service
@@ -63,28 +64,44 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
       # Clone flex-plugins repo
       - name: Clone flex-plugins repo
         run: git clone https://github.com/techmatters/flex-plugins
         shell: bash
+
+      - name: Install Flex Plugin
+        uses: ./flex-plugins/.github/actions/install-flex-plugin
+
       # Build Playwright
       - name: Install e2e-tests dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./flex-plugins/e2e-tests
+
       - name: Setup dependencies for playwright/browsers
         uses: microsoft/playwright-github-action@v1
+
       - name: Install Playwright CLI
         run: npx playwright install
         working-directory: ./flex-plugins/e2e-tests
+
       # Run E2E tests against actual E2E Flex instance
       - name: Run Playwright tests
-        run: DEBUG=pw:api PLAYWRIGHT_BASEURL=${{secrets.PLAYWRIGHT_BASEURL_E2E}} PLAYWRIGHT_USER_USERNAME=${{secrets.PLAYWRIGHT_USER_USERNAME}} PLAYWRIGHT_USER_PASSWORD=${{secrets.PLAYWRIGHT_USER_PASSWORD}} TWILIO_ACCOUNT_SID=${{secrets.E2E_DEV_ACCOUNT_SID}} TWILIO_AUTH_TOKEN=${{secrets.E2E_DEV_AUTH_TOKEN}} npx playwright test --workers 1
+        run: npm run test:local
         working-directory: ./flex-plugins/e2e-tests
+
       # Upload artifacts
       # TODO: this is not working and cant tell why :(
       - uses: actions/upload-artifact@v2
@@ -121,6 +138,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-          slack-message: "`[HRM]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:."
+          slack-message: '`[HRM]` Release from ${{ github.ref_type }} `${{ github.ref_name }}` requested by `${{ github.triggering_actor }}` completed with SHA ${{ github.sha }}. Release tag is `${{ steps.create_pre_release.outputs.generated-pre-release-tag }}` :rocket:.'
         env:
           SLACK_BOT_TOKEN: ${{ env.GITHUB_ACTIONS_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
This fixes a regression introduced by the new ui e2e tests where the e2e tests now depend on plugin-hrm-form which depends on hrm-form-definitions. I created a reusable action in flex-plugins to handle the install chain for plugin-hrm-form and this uses that before running e2e tests. This also moves to the new internal SSM based configuration in the e2e-tests.

This depends on https://github.com/techmatters/flex-plugins/pull/1474