### PR TITLE
CHI-1951: Configure resource imports for E2E

### DIFF
--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -3,7 +3,7 @@
     "us-east-1": {
       "lambda-groups": {
         "resources-import-consumer": ["resources-import-consumer"],
-        "resources-import-producer": ["resources-import-producer-as"],
+        "resources-import-producer": ["resources-import-producer-as", "resources-import-producer-e2e"],
         "resources-search-index": ["resources-search-index"],
         "job-complete": ["resources-import-complete","resources-search-complete"]
       }

--- a/resources-domain/resources-import-producer/src/index.ts
+++ b/resources-domain/resources-import-producer/src/index.ts
@@ -25,6 +25,7 @@ import parseISO from 'date-fns/parseISO';
 import { publishToImportConsumer, ResourceMessage } from './clientSqs';
 import getConfig from './config';
 import { transformKhpResourceToApiResource } from './transformExternalResourceToApiResource';
+import path from 'path';
 
 declare var fetch: typeof import('undici').fetch;
 
@@ -100,10 +101,13 @@ const pullUpdates =
     remaining = maxApiResources,
   ): Promise<KhpApiResponse | HttpError> => {
     const fetchUrl = new URL(
-      `api/resources?startSequence=${from}&endSequence=${to}&limit=${Math.min(
-        remaining,
-        maxApiResources,
-      )}`,
+      path.join(
+        externalApiBaseUrl.pathname,
+        `api/resources?startSequence=${from}&endSequence=${to}&limit=${Math.min(
+          remaining,
+          maxApiResources,
+        )}`,
+      ),
       externalApiBaseUrl,
     );
     const response = await fetch(fetchUrl, {


### PR DESCRIPTION
## Description

* Added producer lambda for E2E test account
* Updated producer function so that the base external URL can have a path, not just be a host name

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added

### Related Issues
CHI-1951

### Verification steps

See https://github.com/techmatters/infrastructure-config/pull/249
