### PR TITLE
CHI-1601: Resources AS Prod

### DIFF
--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -33,10 +33,10 @@
   "production": {
     "us-east-1": {
       "lambda-groups": {
-        "resources-import-consumer": [],
-        "resources-import-producer": [],
-        "resources-search-complete": [],
-        "resources-search-index": []
+        "resources-import-consumer": ["resources-import-complete","resources-search-complete"],
+        "resources-import-producer": ["resources-import-producer-as"],
+        "resources-search-complete": ["resources-search-index"],
+        "resources-search-index": ["resources-import-complete","resources-search-complete"]
       }
     },
     "eu-west-1": {

--- a/.github/workflows/config/environment-region-map.json
+++ b/.github/workflows/config/environment-region-map.json
@@ -14,7 +14,6 @@
       "lambda-groups": {
         "resources-import-consumer": ["resources-import-consumer"],
         "resources-import-producer": [
-          "resources-import-producer-as",
           "resources-import-producer-ca"
         ],
         "resources-search-index": ["resources-search-index"],


### PR DESCRIPTION
## Description

* Configures lambda deploy to deploy multi-tenant resources lambdas to prod
* Configures lambda deploy to deploy an 'AS' producer to us-east-1 production for Aselo Production

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added

### Related Issues
CHI-1601

### Verification steps

* Apply https://github.com/techmatters/infrastructure-config/pull/253 (already done)
* Deploy all resources-* lambdas to production
* Specify a resources base URL in the Aselo Production 
* Check Datadog & Flex to see if it's working
