### PR TITLE
CHI-2009: Fix taxonomies

### DIFF
--- a/resources-domain/packages/resources-search-config/convertIndexDocument.ts
+++ b/resources-domain/packages/resources-search-config/convertIndexDocument.ts
@@ -18,7 +18,7 @@ import { FlatResource, ReferrableResourceAttribute } from '@tech-matters/types';
 import { CreateIndexConvertedDocument } from '@tech-matters/elasticsearch-client';
 import {
   isHighBoostGlobalField,
-  getMappingField,
+  getMappingFields,
   resourceIndexDocumentMappings,
   FieldAndMapping,
 } from './resourceIndexDocumentMappings';
@@ -64,12 +64,15 @@ export const convertIndexDocument = (
     key: string,
     attribute: ReferrableResourceAttribute<boolean | string | number>,
   ) => {
-    const fieldAndMapping = getMappingField(resourceIndexDocumentMappings, key);
-    if (fieldAndMapping) {
-      return pushValueToMappedField(
-        fieldAndMapping,
-        fieldAndMapping.mapping.indexValueGenerator?.(attribute) ?? attribute.value,
-      );
+    const fieldAndMappings = getMappingFields(resourceIndexDocumentMappings, key);
+    if (fieldAndMappings.length) {
+      for (const fieldAndMapping of fieldAndMappings) {
+        pushValueToMappedField(
+          fieldAndMapping,
+          fieldAndMapping.mapping.indexValueGenerator?.(attribute) ?? attribute.value,
+        );
+      }
+      return;
     }
     // We don't really want booleans & numbers in the general purpose buckets
     if (typeof attribute.value === 'string') {

--- a/resources-domain/packages/resources-search-config/convertIndexDocument.ts
+++ b/resources-domain/packages/resources-search-config/convertIndexDocument.ts
@@ -65,7 +65,7 @@ export const convertIndexDocument = (
     attribute: ReferrableResourceAttribute<boolean | string | number>,
   ) => {
     const fieldAndMappings = getMappingFields(resourceIndexDocumentMappings, key);
-    if (fieldAndMappings.length) {
+    if (fieldAndMappings.length > 0) {
       for (const fieldAndMapping of fieldAndMappings) {
         pushValueToMappedField(
           fieldAndMapping,

--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -132,6 +132,8 @@ export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
     taxonomyLevelName: {
       type: 'keyword',
       copyTo: ['taxonomyLevelNameCompletion'],
+      isArrayField: true,
+      attributeKeyPattern: /^taxonomies\/(.*)$/,
     },
     taxonomyLevelNameCompletion: {
       type: 'completion',

--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -131,12 +131,13 @@ export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
     },
     taxonomyLevelName: {
       type: 'keyword',
-      copyTo: ['taxonomyLevelNameCompletion'],
       isArrayField: true,
       attributeKeyPattern: /^taxonomies\/(.*)$/,
     },
     taxonomyLevelNameCompletion: {
       type: 'completion',
+      isArrayField: true,
+      attributeKeyPattern: /^taxonomies\/(.*)$/,
     },
     feeStructure: {
       type: 'keyword',

--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -77,20 +77,17 @@ const stringFieldTypes = ['text', 'keyword'];
  * @param mappingFields
  * @param fieldName
  */
-export const getMappingField = (
+export const getMappingFields = (
   { mappingFields }: Pick<ResourceIndexDocumentMappings, 'mappingFields'>,
   fieldName: string,
-): FieldAndMapping | undefined => {
+): FieldAndMapping[] => {
   if (Object.keys(mappingFields).includes(fieldName)) {
-    return { field: fieldName, mapping: mappingFields[fieldName] };
+    return [{ field: fieldName, mapping: mappingFields[fieldName] }];
   }
 
-  const [field, mapping] =
-    Object.entries(mappingFields).find(
-      ([, { attributeKeyPattern }]) => attributeKeyPattern?.test(fieldName),
-    ) ?? [];
-
-  return mapping && field ? { field, mapping } : undefined;
+  return Object.entries(mappingFields)
+    .filter(([, { attributeKeyPattern }]) => attributeKeyPattern?.test(fieldName))
+    .map(([field, mapping]) => ({ field, mapping }));
 };
 
 export const isHighBoostGlobalField = (
@@ -98,8 +95,9 @@ export const isHighBoostGlobalField = (
   fieldName: string,
 ) => highBoostGlobalFields.includes(fieldName);
 
-export const isStringField = (fieldType: string): fieldType is 'keyword' | 'text' =>
-  stringFieldTypes.includes(fieldType);
+export const isStringField = (
+  fieldType: string,
+): fieldType is 'keyword' | 'text' | 'completion' => stringFieldTypes.includes(fieldType);
 
 export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
   // This is a list of attribute names that should be given higher priority in search results.
@@ -132,12 +130,12 @@ export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
     taxonomyLevelName: {
       type: 'keyword',
       isArrayField: true,
-      attributeKeyPattern: /^taxonomies\/(.*)$/,
+      attributeKeyPattern: /^taxonomies\/.*$/,
     },
     taxonomyLevelNameCompletion: {
       type: 'completion',
       isArrayField: true,
-      attributeKeyPattern: /^taxonomies\/(.*)$/,
+      attributeKeyPattern: /^taxonomies\/.*$/,
     },
     feeStructure: {
       type: 'keyword',

--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -66,7 +66,7 @@ export type FieldAndMapping = {
   mapping: MappingField;
 };
 
-const stringFieldTypes = ['text', 'keyword', 'completion'];
+const stringFieldTypes = ['text', 'keyword'];
 
 /**
  * Returns the mapping field for the given field name.
@@ -95,9 +95,8 @@ export const isHighBoostGlobalField = (
   fieldName: string,
 ) => highBoostGlobalFields.includes(fieldName);
 
-export const isStringField = (
-  fieldType: string,
-): fieldType is 'keyword' | 'text' | 'completion' => stringFieldTypes.includes(fieldType);
+export const isStringField = (fieldType: string): fieldType is 'keyword' | 'text' =>
+  stringFieldTypes.includes(fieldType);
 
 export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
   // This is a list of attribute names that should be given higher priority in search results.

--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -66,7 +66,7 @@ export type FieldAndMapping = {
   mapping: MappingField;
 };
 
-const stringFieldTypes = ['text', 'keyword'];
+const stringFieldTypes = ['text', 'keyword', 'completion'];
 
 /**
  * Returns the mapping field for the given field name.

--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -201,11 +201,26 @@ const KHP_MAPPING_NODE_TAXONOMIES: { children: MappingNode } = {
   children: {
     '{arrayIndex}': {
       children: {
-        '{taxonomyIndex}': referenceAttributeMapping(
-          'taxonomies/{arrayIndex}/{taxonomyIndex}',
-          'khp-taxonomy-codes',
-          { value: ctx => ctx.currentValue.code },
-        ),
+        '{taxonomyIndex}': {
+          children: {
+            nameEN: translatableAttributeMapping(
+              'taxonomies/{arrayIndex}/{taxonomyIndex}',
+              {
+                value: ctx => ctx.currentValue,
+                language: 'en',
+                info: ctx => ctx.parentValue,
+              },
+            ),
+            nameFR: translatableAttributeMapping(
+              'taxonomies/{arrayIndex}/{taxonomyIndex}',
+              {
+                value: ctx => ctx.currentValue,
+                language: 'fr',
+                info: ctx => ctx.parentValue,
+              },
+            ),
+          },
+        },
       },
     },
   },

--- a/resources-domain/resources-search-index/index.ts
+++ b/resources-domain/resources-search-index/index.ts
@@ -36,11 +36,18 @@ export const convertDocumentsToBulkRequest = (messages: ResourcesSearchIndexPayl
       acc[accountSid] = [];
     }
     if (document.deletedAt) {
+      console.debug('Delete Document for resource ID:', document.id);
       acc[accountSid].push({
         action: 'delete',
         id: document.id,
       });
     } else {
+      console.debug(
+        'Index Document for resource ID:',
+        document.id,
+        'Converted document:',
+        document,
+      );
       acc[accountSid].push({
         action: 'index',
         id: document.id,

--- a/resources-domain/resources-service/package.json
+++ b/resources-domain/resources-service/package.json
@@ -40,6 +40,8 @@
     "db:create:schema": "node ./create-db",
     "db:create-migration": "sequelize migration:generate --name ",
     "db:undo-last": "sequelize db:migrate:undo",
+    "es:create-index:development": "cross-env NODE_ENV=development tsx ./scripts/elasticsearch/create-index.ts",
+    "es:delete-index:development": "cross-env NODE_ENV=development tsx ./scripts/elasticsearch/delete-index.ts",
     "es:create-index:local": "cross-env AWS_REGION=us-east-1 SSM_ENDPOINT=http://localhost:4566 NODE_ENV=local ELASTICSEARCH_CONFIG_node=http://localhost:9200 tsx ./scripts/elasticsearch/create-index.ts",
     "es:delete-index:local": "cross-env AWS_REGION=us-east-1 SSM_ENDPOINT=http://localhost:4566 NODE_ENV=local ELASTICSEARCH_CONFIG_node=http://localhost:9200 tsx ./scripts/elasticsearch/delete-index.ts",
     "build-scripts": "tsc --project tsconfig.scripts.json",

--- a/resources-domain/resources-service/tests/service/resources.elasticsearch.test.ts
+++ b/resources-domain/resources-service/tests/service/resources.elasticsearch.test.ts
@@ -22,7 +22,6 @@ import { db } from '../../src/connection-pool';
 import each from 'jest-each';
 import { ReferrableResourceSearchResult } from '../../src/resource/resourceService';
 import { AssertionError } from 'assert';
-import addHours from 'date-fns/addHours';
 import { Client, getClient } from '@tech-matters/elasticsearch-client';
 import { getById } from '../../src/resource/resourceDataAccess';
 import {
@@ -38,7 +37,6 @@ const clients: Record<string, Client> = {};
 
 const server = getServer();
 const request = getRequest(server);
-let mockServer: Awaited<ReturnType<typeof mockingProxy.mockttpServer>>;
 
 const accountSids = ['ACCOUNT_1', 'ACCOUNT_2'];
 
@@ -62,7 +60,6 @@ afterAll(async () => {
 
 beforeAll(async () => {
   await mockingProxy.start();
-  mockServer = await mockingProxy.mockttpServer();
 
   const accountResourceIdTuples: [string, string[]][] = [
     ['1', range(5)],
@@ -79,7 +76,7 @@ beforeAll(async () => {
           ),
         );
         const suggestSql = [
-          `INSERT INTO resources."ResourceStringAttributes" ("resourceId", "accountSid", "key", "language", "value", "info") VALUES ('RESOURCE_${resourceIdx}', 'ACCOUNT_${accountIdx}', 'taxonomyLevelName', 'en-US', 'suggest_${resourceIdx}', '{ "some": "json" }')`,
+          `INSERT INTO resources."ResourceStringAttributes" ("resourceId", "accountSid", "key", "language", "value", "info") VALUES ('RESOURCE_${resourceIdx}', 'ACCOUNT_${accountIdx}', 'taxonomies/0/0', 'en-US', 'suggest_${resourceIdx}', '{ "some": "json" }')`,
         ];
 
         return [sql, ...attributeSql, ...suggestSql];
@@ -348,143 +345,6 @@ describe('GET /search', () => {
       });
     },
   );
-
-  // TODO: test in unit tests?
-  describe.skip('Inline attributes of non string types', () => {
-    const dateVal = new Date(2010, 15, 11, 13, 30, 15);
-    beforeEach(async () => {
-      await db.multi(`
-  INSERT INTO resources."ResourceBooleanAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'BOOLEAN_ATTRIBUTE', true, '{ "some": "json" }');
-  INSERT INTO resources."ResourceNumberAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'NUMBER_ATTRIBUTE', 1337.42, '{ "some": "json" }');
-  INSERT INTO resources."ResourceDateTimeAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_1', 'ACCOUNT_1', 'DATETIME_ATTRIBUTE', '${dateVal.toISOString()}', '{ "some": "json" }');
-  INSERT INTO resources."ResourceBooleanAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_2', 'ACCOUNT_1', 'BOOLEAN_ATTRIBUTE', false, '{ "some": "json" }');
-  INSERT INTO resources."ResourceNumberAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_2', 'ACCOUNT_1', 'NUMBER_ATTRIBUTE', 666, '{ "some": "json" }');
-  INSERT INTO resources."ResourceDateTimeAttributes" ("resourceId", "accountSid", "key", "value", "info") VALUES ('RESOURCE_2', 'ACCOUNT_1', 'DATETIME_ATTRIBUTE', '${addHours(
-    dateVal,
-    2,
-  ).toISOString()}', '{ "some": "json" }');
-         `);
-    });
-    test('should return the resource with the attributes', async () => {
-      // Arrange
-      await mockServer
-        .forGet(/https:\/\/resources\.mock-elasticsearch\.com\/2013-01-01\/search(.*)/)
-        .thenJson(200, {
-          hits: {
-            found: 2,
-            hit: [
-              {
-                id: 'RESOURCE_1',
-                name: 'Resource 1 (Account 1)',
-                attributes: expect.anything(),
-              },
-              {
-                id: 'RESOURCE_2',
-                name: 'Resource 2 (Account 1)',
-                attributes: expect.anything(),
-              },
-            ],
-          },
-        });
-      const url = `${basePath}?limit=5&start=0`;
-
-      // Act
-      const response = await request.post(url).set(headers).send({ q: 'something' });
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(response.body.totalCount).toBe(2);
-      expect(response.body.results).toHaveLength(2);
-
-      expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({
-        totalCount: 2,
-        results: [
-          {
-            id: 'RESOURCE_1',
-            name: 'Resource 1 (Account 1)',
-            attributes: {
-              BOOLEAN_ATTRIBUTE: [
-                {
-                  value: true,
-                  info: { some: 'json' },
-                },
-              ],
-              NUMBER_ATTRIBUTE: [
-                {
-                  value: 1337.42,
-                  info: { some: 'json' },
-                },
-              ],
-              DATETIME_ATTRIBUTE: [
-                {
-                  value: dateVal.toISOString(),
-                  info: { some: 'json' },
-                },
-              ],
-              ATTRIBUTE_0: [
-                {
-                  value: 'VALUE_0',
-                  language: 'en-US',
-                  info: { some: 'json' },
-                },
-              ],
-            },
-          },
-          {
-            id: 'RESOURCE_2',
-            name: 'Resource 2 (Account 1)',
-            attributes: {
-              BOOLEAN_ATTRIBUTE: [
-                {
-                  value: false,
-                  info: { some: 'json' },
-                },
-              ],
-              NUMBER_ATTRIBUTE: [
-                {
-                  value: 666,
-                  info: { some: 'json' },
-                },
-              ],
-              DATETIME_ATTRIBUTE: [
-                {
-                  value: addHours(dateVal, 2).toISOString(),
-                  info: { some: 'json' },
-                },
-              ],
-              ATTRIBUTE_0: [
-                {
-                  value: 'VALUE_0',
-                  language: 'en-US',
-                  info: { some: 'json' },
-                },
-              ],
-              ATTRIBUTE_1: [
-                {
-                  value: 'VALUE_0',
-                  language: 'en-US',
-                  info: { some: 'json' },
-                },
-                {
-                  value: 'VALUE_1',
-                  language: 'en-US',
-                  info: { some: 'json' },
-                },
-              ],
-            },
-          },
-        ],
-      });
-    });
-    afterEach(async () => {
-      await db.multi(`
-  DELETE FROM resources."ResourceBooleanAttributes";
-  DELETE FROM resources."ResourceNumberAttributes";
-  DELETE FROM resources."ResourceDateTimeAttributes";
-        `);
-    });
-  });
 });
 
 describe('GET /suggest', () => {


### PR DESCRIPTION
## Description

* A couple of adjustments to the mappings used to import and index resource taxonomies
* Debug logging in the reindex admin endpoint
* Using 'copyTo' didn't appear to populate the completion field, but this might be because the field wasn't created ahead of time. Also the taxonomy mapping fields are now given arrays, so I made them independent fields fed from the same data rather than using copyTo

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added


### Related Issues
CHI-2009

### Verification steps

* Deploy this build
* Delete the entry for Aselo Development in the "resources"."Accounts" database table (or reset the sequence to a lower value if you only want to partially reindex for testing)
* 'Test' the development resources-import-producer-as lambda from the AWS console to kick of a reimport from KHP.
* Once complete, test the /suggest endpoint to verify it is returning suggestions rather than throwing errors