### PR TITLE
CHI-1989: Fix coverage, documentsRequired & language resource import mappings

### DIFF
--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -434,22 +434,14 @@ export const KHP_MAPPING_NODE: MappingNode = {
     children: {
       '{coverageIndex}': {
         children: {
-          '{language}': translatableAttributeMapping('coverage/{coverageIndex}', {
-            value: ctx => ctx.parentValue._id,
-            language: ctx => ctx.captures.language,
-            info: ctx => {
-              try {
-                return {
-                  siteId: ctx.parentValue.siteId,
-                  ...JSON.parse(ctx.currentValue),
-                };
-              } catch (e) {
-                return {
-                  siteId: ctx.parentValue.siteId,
-                };
-              }
+          '{language}': translatableAttributeMapping(
+            ({ parentValue, captures }) =>
+              `coverage/${parentValue._id ?? captures.coverageIndex}`,
+            {
+              language: ({ captures }) => captures.language,
+              info: ({ parentValue }) => parentValue,
             },
-          }),
+          ),
         },
       },
     },
@@ -507,11 +499,13 @@ export const KHP_MAPPING_NODE: MappingNode = {
       '{documentIndex}': {
         children: {
           objectId: { children: {} },
-          '{language}': referenceAttributeMapping(
-            'documentsRequired/{documentIndex}',
-            'documentsRequired',
+          '{language}': translatableAttributeMapping(
+            ctx =>
+              `documentsRequired/${
+                ctx.parentValue.objectId ?? ctx.captures.documentIndex
+              }`,
             {
-              value: ctx => ctx.parentValue.en,
+              value: ctx => ctx.parentValue[ctx.captures.language],
               language: ctx => ctx.captures.language,
             },
           ),
@@ -545,11 +539,12 @@ export const KHP_MAPPING_NODE: MappingNode = {
   },
   languages: {
     children: {
-      '{languageIndex}': referenceAttributeMapping(
-        'languages/{languageIndex}',
-        'khp-languages',
+      '{languageIndex}': translatableAttributeMapping(
+        context =>
+          `languages/${context.currentValue._id ?? context.captures.languageIndex}`,
         {
-          value: context => context.currentValue.language,
+          value: context => context.currentValue.code,
+          info: context => context.currentValue,
         },
       ),
     },


### PR DESCRIPTION
## Description

* Redesignates language and documents required properties as inline strings, not referenced values
* Rejigs some key strings to use external IDs where available rather than arbitrary indexes, to make updates more stable

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added

### Related Issues
CHI-1989

### Verification steps

Unit tests show mapping working as expected
