### PR TITLE
CHI-1989: Increase POST body max size to 50mb

### DIFF
--- a/packages/http/webServerConfiguration.ts
+++ b/packages/http/webServerConfiguration.ts
@@ -22,7 +22,7 @@ import { ErrorRequestHandler } from 'express-serve-static-core';
 
 export const configureDefaultPreMiddlewares = (webServer: Express): Express => {
   webServer.use(httpLogger);
-  webServer.use(express.json());
+  webServer.use(express.json({ limit: '50mb' }));
   webServer.use(express.urlencoded({ extended: false }));
   webServer.use(cors());
   return webServer;


### PR DESCRIPTION
## Description

Our last KHP resource import run started hitting a max limit on the size of JSON POST body payloads in Express, so increasing it

### Checklist
- [X] Corresponding issue has been opened


### Related Issues
CHI-1989

### Verification steps

Deploy and see if the 'request.too.large'
