### PR TITLE
CHI-1989Correctly scope verifications and lat/long properties on resource sites

### DIFF
--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -435,20 +435,16 @@ export const KHP_MAPPING_NODE: MappingNode = {
   ),
   coverage: {
     children: {
-      '{coverageIndex}': {
-        children: {
-          '{language}': translatableAttributeMapping(
-            ({ parentValue, captures }) =>
-              `coverage/${parentValue._id ?? captures.coverageIndex}`,
-            {
-              language: ({ captures }) => captures.language,
-              info: ({ parentValue }) => parentValue,
-            },
-          ),
-          siteId: { children: {} },
-          _id: { children: {} },
+      '{coverageIndex}': translatableAttributeMapping(
+        ({ currentValue, captures }) =>
+          `coverage/${currentValue._id ?? captures.coverageIndex}`,
+        {
+          language: ({ captures }) => captures.language,
+          info: ({ currentValue }) => currentValue,
+          value: ({ currentValue, captures }) =>
+            `coverage/${currentValue._id ?? captures.coverageIndex}`,
         },
-      },
+      ),
     },
   },
   targetPopulations: {

--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -64,7 +64,7 @@ const KHP_MAPPING_NODE_SITES: { children: MappingNode } = {
           children: {
             '{verificationIndex}': attributeMapping(
               'stringAttributes',
-              'verifications/{verificationIndex}',
+              siteKey('verifications/{verificationIndex}'),
               {
                 value: ctx => ctx.currentValue.name,
                 info: ctx => ctx.currentValue,
@@ -120,8 +120,11 @@ const KHP_MAPPING_NODE_SITES: { children: MappingNode } = {
             }),
             postalCode: translatableAttributeMapping(siteKey('location/postalCode')),
             description: translatableAttributeMapping(siteKey('location/description')),
-            longitude: attributeMapping('numberAttributes', 'location/longitude'),
-            latitude: attributeMapping('numberAttributes', 'location/latitude'),
+            longitude: attributeMapping(
+              'numberAttributes',
+              siteKey('location/longitude'),
+            ),
+            latitude: attributeMapping('numberAttributes', siteKey('location/latitude')),
           },
         },
         operations: {

--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -445,6 +445,8 @@ export const KHP_MAPPING_NODE: MappingNode = {
               info: ({ parentValue }) => parentValue,
             },
           ),
+          siteId: { children: {} },
+          _id: { children: {} },
         },
       },
     },


### PR DESCRIPTION
## Description

Previously lat / longs on site locations were being mapped to a top level `location/latitude` or `location/longitude` property. These need scoping under their relevant site. 

The same fix was applied for verifications

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added

### Related Issues

CJI-1989

### Verification steps

Review the next (re)import of staging resources and ensure that the latlongs are imported correctly (not sure if verifications are in use right now?)
