### PR TITLE
CHI-1989: Up default configured limits on resource importer config

### DIFF
--- a/resources-domain/resources-import-producer/src/config.ts
+++ b/resources-domain/resources-import-producer/src/config.ts
@@ -65,8 +65,8 @@ const getConfig = async () => {
     importApiBaseUrl: new URL(importApiBaseUrl ?? ''),
     importApiKey,
     importApiAuthHeader,
-    maxBatchSize: Number(process.env.RESOURCE_IMPORT_MAX_BATCH_SIZE ?? 5000),
-    maxApiSize: Number(process.env.RESOURCE_IMPORT_MAX_API_SIZE ?? 100),
+    maxBatchSize: Number(process.env.RESOURCE_IMPORT_MAX_BATCH_SIZE ?? 20000),
+    maxApiSize: Number(process.env.RESOURCE_IMPORT_MAX_API_SIZE ?? 500),
     maxRequests: Number(process.env.RESOURCE_IMPORT_MAX_REQUESTS ?? 200),
   } as const;
 };


### PR DESCRIPTION
## Description

We will probably be doing a few 'clear down and reimport' sweeps over the coming weeks, so upping the limits on how much we pull from KHP and how much we process in a single run on our end to speed up that process