### PR TITLE
CHI-1989: Remove retrieve recording URL lambda build from release flow

### DIFF
--- a/.github/workflows/hrm-qa-release.yml
+++ b/.github/workflows/hrm-qa-release.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         lambda_name:
-          - contact-retrieve-recording-url
           - contact-retrieve-transcript
           - job-complete
           - resources-import-consumer


### PR DESCRIPTION
Simple change, not waiting for approvals