### PR TITLE
CHI-1989 - Added an explicit language mapping to resource index documents

### DIFF
--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings.ts
@@ -105,6 +105,7 @@ export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
     'province',
     'city',
     'targetPopulation',
+    'languages',
     'feeStructure',
   ],
 
@@ -147,6 +148,12 @@ export const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
     },
     interpretationTranslationServicesAvailable: {
       type: 'boolean',
+    },
+    languages: {
+      type: 'keyword',
+      isArrayField: true,
+      indexValueGenerator: ({ value, info }: ReferrableResourceAttribute<string>) =>
+        `${info?.language ?? ''} ${value}`,
     },
     province: {
       type: 'keyword',

--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -439,7 +439,6 @@ export const KHP_MAPPING_NODE: MappingNode = {
         ({ currentValue, captures }) =>
           `coverage/${currentValue._id ?? captures.coverageIndex}`,
         {
-          language: ({ captures }) => captures.language,
           info: ({ currentValue }) => currentValue,
           value: ({ currentValue, captures }) =>
             `coverage/${currentValue._id ?? captures.coverageIndex}`,

--- a/resources-domain/resources-service/scripts/database/clear-down.sql
+++ b/resources-domain/resources-service/scripts/database/clear-down.sql
@@ -1,0 +1,3 @@
+-- Remember, you need to remove all the documents from the related ElasticSearch indexes to fully clear down as well
+TRUNCATE resources."Resources" CASCADE;
+TRUNCATE resources."Accounts";


### PR DESCRIPTION
## Description

Searches based on language were not finding resources as expected, probably because only the codes were being explicitly indexed

* Added an explicit language mapping to resource index documents
* Added cleardown script for resources.
* Removed language from resource language attribute import mapping.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes CHI-1989

### Verification steps

1. Search for 'Russian' prior to reindexing - no results should be returned
2. Reindex the target environment using the scripts provided in HRM /resources-domain/resources-service/scripts
3. Search for 'Russian', some results should be returned
4. Open the returned resources, they should have 'Russian' listed under languages