### PR TITLE
CHI-1989: Correctly namespaced the eligibility details in KHP resources

### DIFF
--- a/resources-domain/resources-import-producer/src/khpMappings.ts
+++ b/resources-domain/resources-import-producer/src/khpMappings.ts
@@ -272,16 +272,16 @@ export const KHP_MAPPING_NODE: MappingNode = {
     children: {
       phrase: {
         children: {
-          '{language}': translatableAttributeMapping('phrase', {
+          '{language}': translatableAttributeMapping('eligibility/phrase', {
             language: ctx => ctx.captures.language,
           }),
         },
       },
-      adult: attributeMapping('booleanAttributes', 'adult'),
-      child: attributeMapping('booleanAttributes', 'child'),
-      family: attributeMapping('booleanAttributes', 'family'),
-      teen: attributeMapping('booleanAttributes', 'teen'),
-      gender: attributeMapping('stringAttributes', 'gender'),
+      adult: attributeMapping('booleanAttributes', 'eligibility/adult'),
+      child: attributeMapping('booleanAttributes', 'eligibility/child'),
+      family: attributeMapping('booleanAttributes', 'eligibility/family'),
+      teen: attributeMapping('booleanAttributes', 'eligibility/teen'),
+      gender: attributeMapping('stringAttributes', 'eligibility/gender'),
     },
   },
   website: {


### PR DESCRIPTION
## Description

Fixed the mappings so all the eligibility related details in imported resources are put under attributes with a an `eligibility/` root path in the database
