### PR TITLE
[Bug Fix] Fixed isS3StoredConversationMedia helper function

### DIFF
--- a/hrm-domain/hrm-service/src/conversation-media/conversation-media-data-access.ts
+++ b/hrm-domain/hrm-service/src/conversation-media/conversation-media-data-access.ts
@@ -97,8 +97,7 @@ export const isS3StoredRecording = (m: ConversationMedia): m is S3StoredRecordin
   m.storeType === 'S3' && m.storeTypeSpecificData?.type === S3ContactMediaType.RECORDING;
 export const isS3StoredConversationMedia = (
   m: ConversationMedia,
-): m is S3StoredConversationMedia =>
-  isS3StoredTranscriptPending(m) || isS3StoredRecording(m);
+): m is S3StoredConversationMedia => isS3StoredTranscript(m) || isS3StoredRecording(m);
 
 export const create =
   (task?) =>


### PR DESCRIPTION
## Description
This PR fixes an issue in the `isS3StoredConversationMedia` function. In particular we noticed because of a failing permissions endpoint. The issue was that `isS3StoredConversationMedia` was only returning true for transcripts when this was "pending".