### PR TITLE
CHI-2238: No longer force date filters in contact searches to beginning / end of day

### DIFF
--- a/hrm-domain/hrm-service/package.json
+++ b/hrm-domain/hrm-service/package.json
@@ -78,6 +78,7 @@
     "@types/supertest": "^2.0.12",
     "chalk": "^4.0.0",
     "cross-env": "^7.0.3",
+    "date-fns-tz": "^2.0.0",
     "global-agent": "^3.0.0",
     "jest-each": "^29.2.1",
     "mockttp": "^3.2.2",

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -15,7 +15,8 @@
  */
 
 import each from 'jest-each';
-import { subHours, subDays } from 'date-fns';
+import { subHours, subDays, parseISO, subSeconds, addSeconds } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 import { db } from '../src/connection-pool';
 import { ContactRawJson } from '../src/contact/contact-json';
@@ -881,8 +882,9 @@ describe('/contacts route', () => {
 
       let createdContacts: contactDb.Contact[] = [];
       let csamReports = new Array<csamReportApi.CSAMReport>();
+      const [currentUTCDateString] = new Date().toISOString().split('T');
 
-      const startTestsTimeStamp = new Date();
+      const startTestsTimeStamp = parseISO(`${currentUTCDateString}T06:00:00.000Z`);
 
       beforeAll(async () => {
         // Clean what's been created so far
@@ -1189,6 +1191,20 @@ describe('/contacts route', () => {
           },
         },
         {
+          changeDescription: 'Test date filters (should match oneWeekBefore only)',
+          body: {
+            dateFrom: subDays(startTestsTimeStamp, 8).toISOString(),
+            dateTo: subDays(startTestsTimeStamp, 5).toISOString(),
+          },
+          expectCallback: response => {
+            expect(response.status).toBe(200);
+            const { contacts } = response.body;
+
+            expect(contacts).toHaveLength(1);
+            expect(contacts[0].details).toMatchObject(noHelpline.form);
+          },
+        },
+        {
           changeDescription: 'Test date filters (should all but oneWeekBefore)',
           body: {
             dateFrom: subHours(startTestsTimeStamp, 1).toISOString(),
@@ -1199,6 +1215,34 @@ describe('/contacts route', () => {
 
             // Expect all but invalid and oneWeekBefore
             expect(contacts).toHaveLength(createdContacts.length - 2);
+            const createdContactsByTimeOfContact = createdContacts.sort(
+              compareTimeOfContactDesc,
+            );
+            createdContactsByTimeOfContact.forEach(c => {
+              const searchContact = contacts.find(results => results.contactId === c.id);
+              if (searchContact) {
+                // Check that all contacts contains the appropriate info
+                expect(c.rawJson).toMatchObject(searchContact.details);
+              }
+            });
+          },
+        },
+        {
+          changeDescription:
+            'with date filters as local times (should filter one hour before for a CST day, because an hour before is the previous day)',
+          body: {
+            dateFrom: formatInTimeZone(
+              startTestsTimeStamp,
+              '-06:00',
+              'yyyy-MM-dd HH:mm:ssXXX',
+            ),
+          },
+          expectCallback: response => {
+            expect(response.status).toBe(200);
+            const { contacts } = response.body;
+
+            // Expect all but invalid and oneWeekBefore
+            expect(contacts).toHaveLength(createdContacts.length - 3);
             const createdContactsByTimeOfContact = createdContacts.sort(
               compareTimeOfContactDesc,
             );
@@ -1299,11 +1343,14 @@ describe('/contacts route', () => {
           useOpenRules();
         }
 
-        const res = await request.post(`${route}/search`).set(headers).send({
-          dateFrom: createdContact.createdAt,
-          dateTo: createdContact.createdAt,
-          firstName: 'withTaskIdAndTranscript',
-        });
+        const res = await request
+          .post(`${route}/search`)
+          .set(headers)
+          .send({
+            dateFrom: subSeconds(createdContact.createdAt, 1).toISOString(),
+            dateTo: addSeconds(createdContact.createdAt, 1).toISOString(),
+            firstName: 'withTaskIdAndTranscript',
+          });
 
         expect(res.status).toBe(200);
         expect(res.body.count).toBe(1);

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -1229,7 +1229,7 @@ describe('/contacts route', () => {
         },
         {
           changeDescription:
-            'with date filters as local times (should filter one hour before for a CST day, because an hour before is the previous day)',
+            'with date filters as local times - should apply them correctly adjusted',
           body: {
             dateFrom: formatInTimeZone(
               startTestsTimeStamp,

--- a/hrm-domain/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-data-access.ts
@@ -17,7 +17,7 @@
 import { db } from '../connection-pool';
 import { UPDATE_CASEID_BY_ID, UPDATE_RAWJSON_BY_ID } from './sql/contact-update-sql';
 import { SELECT_CONTACT_SEARCH } from './sql/contact-search-sql';
-import { endOfDay, parseISO, startOfDay } from 'date-fns';
+import { parseISO } from 'date-fns';
 import {
   selectSingleContactByIdSql,
   selectSingleContactByTaskId,
@@ -128,8 +128,8 @@ const searchParametersToQueryParameters = (
     helpline: helpline || undefined, // ensure empty strings are replaced with nulls
     contactNumber: contactNumber || undefined, // ensure empty strings are replaced with nulls
     counselor: counselor || undefined, // ensure empty strings are replaced with nulls
-    dateFrom: dateFrom ? startOfDay(parseISO(dateFrom)).toISOString() : undefined,
-    dateTo: dateTo ? endOfDay(parseISO(dateTo)).toISOString() : undefined,
+    dateFrom: dateFrom ? parseISO(dateFrom).toISOString() : undefined,
+    dateTo: dateTo ? parseISO(dateTo).toISOString() : undefined,
     accountSid,
 
     dataCallTypes: Object.values(callTypes),

--- a/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
@@ -17,7 +17,6 @@
 import * as pgPromise from 'pg-promise';
 import { mockConnection, mockTask, mockTransaction } from '../mock-db';
 import { search, create } from '../../src/contact/contact-data-access';
-import { endOfDay, startOfDay } from 'date-fns';
 import { ContactBuilder } from './contact-builder';
 import {
   NewContactRecord,
@@ -137,23 +136,23 @@ describe('search', () => {
     });
   });
 
-  test('dateTo / dateFrom parameters - sets them to the start and end of day respectively', async () => {
+  test('dateTo / dateFrom parameters - converts them to UTC', async () => {
     jest.spyOn(conn, 'manyOrNone').mockResolvedValue([]);
     mockTask(conn);
     await search(
       ACCOUNT_SID,
       {
         onlyDataContacts: false,
-        dateFrom: new Date('2000-05-15T12:00:00Z').toISOString(),
-        dateTo: new Date('2000-05-25T12:00:00Z').toISOString(),
+        dateFrom: '2000-05-15T17:00:00+05:00',
+        dateTo: '2000-05-25T08:00:00-04:00',
       },
       42,
       1337,
     );
     expect(conn.manyOrNone).toHaveBeenCalledWith(expect.any(String), {
       ...emptySearch,
-      dateFrom: startOfDay(new Date('2000-05-15T12:00:00Z')).toISOString(),
-      dateTo: endOfDay(new Date('2000-05-25T12:00:00Z')).toISOString(),
+      dateFrom: new Date('2000-05-15T12:00:00Z').toISOString(),
+      dateTo: new Date('2000-05-25T12:00:00Z').toISOString(),
       limit: 42,
       offset: 1337,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "@types/supertest": "^2.0.12",
         "chalk": "^4.0.0",
         "cross-env": "^7.0.3",
+        "date-fns-tz": "^2.0.0",
         "global-agent": "^3.0.0",
         "jest-each": "^29.2.1",
         "mockttp": "^3.2.2",
@@ -5970,6 +5971,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "dev": true,
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -17304,6 +17314,7 @@
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
         "date-fns": "^2.28.0",
+        "date-fns-tz": "^2.0.0",
         "debug": "^4.1.1",
         "deep-diff": "^1.0.2",
         "dotenv": "^8.2.0",
@@ -19173,6 +19184,13 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "dev": true,
+      "requires": {}
     },
     "dayjs": {
       "version": "1.11.9",


### PR DESCRIPTION
## Description

The code in the contact layer that was adjusting any date filters specified in a contact search to be the beginning / end of the day was doing this based on the local time zone of the server, which when deployed to AWS will always be UTC - this meant filtering was incorrect from the perspective of clients doing searches in other time zones.

Determining the 'local day' is much more easily done on the client that's actually in that timezone.

This kind of adjusting should be carried out on the client anyway, clients should be able to specify any dates infilters and HRM should apply them as is, rather than being forced to request complete days.

In order to completely fix CHI-2238, this AND the flex PR to add date bounding on the client side should BOTH be deployed. Date filtering at the edges will be incorrect otherwise - but since it's broken in production already I don't think that's a compatibility issue that needs addressing

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
Fixes CHI-2238

### Verification steps

Deploy a version of HRM with this PR applied, and a version of Flex with this PR applied: https://github.com/techmatters/flex-plugins/pull/1662
Test that the date filters for Case Search, Contact Search and all 3 Case List date filters are returning all the correct records but no more for the date range specified
