### PR TITLE
CHI-1434: Fix the case search query to properly include referrals

### DIFF
--- a/hrm-domain/hrm-service/src/conversation-media/sql/conversation-media-get-sql.ts
+++ b/hrm-domain/hrm-service/src/conversation-media/sql/conversation-media-get-sql.ts
@@ -40,7 +40,3 @@ export const selectCoalesceConversationMediasByContactId = (contactAlias: string
   FROM "ConversationMedias" cm
   WHERE ${onFkFilteredClause(contactAlias)}
 `;
-
-export const leftJoinConversationMediasOnFK = (contactAlias: string) => `
-  LEFT JOIN "ConversationMedias" cm ON ${onFkFilteredClause(contactAlias)}
-`;

--- a/hrm-domain/hrm-service/src/csam-report/sql/csam-report-get-sql.ts
+++ b/hrm-domain/hrm-service/src/csam-report/sql/csam-report-get-sql.ts
@@ -40,7 +40,3 @@ export const selectCoalesceCsamReportsByContactId = (contactAlias: string) => `
   FROM "CSAMReports" r
   WHERE ${onFkFilteredClause(contactAlias)}
 `;
-
-export const leftJoinCsamReportsOnFK = (contactAlias: string) => `
-  LEFT JOIN "CSAMReports" r ON ${onFkFilteredClause(contactAlias)}
-`;

--- a/hrm-domain/hrm-service/src/referral/sql/referral-get-sql.ts
+++ b/hrm-domain/hrm-service/src/referral/sql/referral-get-sql.ts
@@ -25,7 +25,3 @@ export const selectCoalesceReferralsByContactId = (contactAlias: string) => `
   FROM "Referrals" referral
   WHERE ${onFkFilteredClause(contactAlias)}
 `;
-
-export const leftJoinReferralsOnFK = (contactAlias: string) => `
-  LEFT JOIN "Referrals" referral ON ${onFkFilteredClause(contactAlias)}
-`;


### PR DESCRIPTION
## Description

The existing case search query wasn't correctly returning referrals correctly -  this reworks it to be closer to the contact search query.

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added


### Related Issues
CHI-1434

### Verification steps

* Confirm contacts attached to searched cases
* Ensure CSAM reports & media are still correctly returned
