### PR TITLE
CHI-1434 fix task id idempotence

### DIFF
--- a/hrm-domain/hrm-service/migrations/20231006194800-contact_taskId_unique.sql.js
+++ b/hrm-domain/hrm-service/migrations/20231006194800-contact_taskId_unique.sql.js
@@ -35,7 +35,7 @@ module.exports = {
     );
     console.log('Cleared out contacts with duplicate taskIds');
     await queryInterface.sequelize
-      .query(`CREATE UNIQUE INDEX IF NOT EXISTS "Contacts_taskId_idx"
+      .query(`CREATE UNIQUE INDEX IF NOT EXISTS "Contacts_taskId_accountSid_idx"
                   ON public."Contacts" USING btree
                   ("taskId" COLLATE pg_catalog."default" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
                   TABLESPACE pg_default`);

--- a/hrm-domain/hrm-service/migrations/20231006194800-contact_taskId_unique.sql.js
+++ b/hrm-domain/hrm-service/migrations/20231006194800-contact_taskId_unique.sql.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DELETE FROM "ContactJobs" WHERE "contactId" IN (SELECT id FROM "Contacts" WHERE "taskId" IN (SELECT "taskId" FROM public."Contacts" GROUP BY "taskId" HAVING COUNT(*) > 1));`,
+    );
+    await queryInterface.sequelize.query(
+      `DELETE FROM "CSAMReports" WHERE "contactId" IN (SELECT id FROM "Contacts" WHERE "taskId" IN (SELECT "taskId" FROM public."Contacts" GROUP BY "taskId" HAVING COUNT(*) > 1));`,
+    );
+    await queryInterface.sequelize.query(
+      `DELETE FROM "Referrals" WHERE "contactId" IN (SELECT id FROM "Contacts" WHERE "taskId" IN (SELECT "taskId" FROM public."Contacts" GROUP BY "taskId" HAVING COUNT(*) > 1));`,
+    );
+    await queryInterface.sequelize.query(
+      `DELETE FROM "ConversationMedias" WHERE "contactId" IN (SELECT id FROM "Contacts" WHERE "taskId" IN (SELECT "taskId" FROM public."Contacts" GROUP BY "taskId" HAVING COUNT(*) > 1));`,
+    );
+    await queryInterface.sequelize.query(
+      `DELETE FROM "Contacts" WHERE "taskId" IN (SELECT "taskId" FROM public."Contacts" GROUP BY "taskId" HAVING COUNT(*) > 1);`,
+    );
+    console.log('Cleared out contacts with duplicate taskIds');
+    await queryInterface.sequelize
+      .query(`CREATE UNIQUE INDEX IF NOT EXISTS "Contacts_taskId_idx"
+                  ON public."Contacts" USING btree
+                  ("taskId" COLLATE pg_catalog."default" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+                  TABLESPACE pg_default`);
+    console.log('TaskId unique index created');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DROP INDEX IF EXISTS public."Contacts_taskId_idx"`,
+    );
+    console.log('TaskId unique index dropped');
+  },
+};

--- a/hrm-domain/hrm-service/service-tests/contact-job/contact-job-cleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/contact-job-cleanup.test.ts
@@ -69,6 +69,11 @@ beforeAll(async () => {
   await mockSuccessfulTwilioAuthentication(workerSid);
 });
 
+afterEach(async () => {
+  await db.none(`DELETE FROM "ContactJobs"`);
+  await db.none(`DELETE FROM "Contacts"`);
+});
+
 afterAll(async () => {
   delete process.env.TWILIO_AUTH_TOKEN;
   await mockingProxy.stop();

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -241,6 +241,7 @@ describe('/contacts route', () => {
       {
         contact: {
           ...contact1,
+          taskId: 'contact-1-task-sid-2',
           referrals: [
             {
               resourceId: 'TEST_RESOURCE',
@@ -295,7 +296,7 @@ describe('/contacts route', () => {
           conversationDuration: null,
           accountSid: null,
           timeOfContact: null,
-          taskId: null,
+          taskId: 'empty-contact-tasksid',
           channelSid: null,
           serviceSid: null,
         },
@@ -308,7 +309,7 @@ describe('/contacts route', () => {
           channel: '',
           conversationDuration: null,
           accountSid: '',
-          taskId: '',
+          taskId: 'empty-contact-tasksid',
           channelSid: '',
           serviceSid: '',
         },
@@ -354,6 +355,24 @@ describe('/contacts route', () => {
 
       // but should both return the same entity (i.e. the second call didn't create one)
       expect(subsequentResponse.body.id).toBe(response.body.id);
+    });
+
+    test('Concurrent idempotence on create contact', async () => {
+      const responses = await Promise.all([
+        request.post(route).set(headers).send(withTaskId),
+        request.post(route).set(headers).send(withTaskId),
+        request.post(route).set(headers).send(withTaskId),
+        request.post(route).set(headers).send(withTaskId),
+        request.post(route).set(headers).send(withTaskId),
+        request.post(route).set(headers).send(withTaskId),
+      ]);
+
+      // all should succeed
+      responses.forEach(response => expect(response.status).toBe(200));
+      const expectedId = responses[0].body.id;
+      // but should both return the same entity (i.e. only one call created one)
+
+      responses.forEach(response => expect(response.body.id).toBe(expectedId));
     });
 
     test('Connects to CSAM reports (not existing csam report id, do nothing)', async () => {
@@ -919,11 +938,13 @@ describe('/contacts route', () => {
         // Create some contacts to work with
         const oneHourBefore = {
           ...another2,
+          taskId: 'oneHourBefore-tasksid-2',
           timeOfContact: subHours(startTestsTimeStamp, 1).toISOString(), // one hour before
         };
 
         const oneWeekBefore = {
           ...noHelpline,
+          taskId: 'oneWeekBefore-tasksid-2',
           timeOfContact: subDays(startTestsTimeStamp, 7).toISOString(), // one hour before
         };
 
@@ -931,14 +952,15 @@ describe('/contacts route', () => {
 
         const withCSAMReports = {
           ...noHelpline,
+          taskId: 'withCSAMReports-tasksid-2',
           queueName: 'withCSAMReports',
           number: '123412341234',
           csamReports: [newReport1, newReport2],
         };
         const responses = await resolveSequentially(
           [
-            { ...contact1, taskId: 'contact-1-task' },
-            { ...contact2, taskId: 'contact-2-task' },
+            { ...contact1, taskId: 'contact1-tasksid-2' },
+            { ...contact2, taskId: 'contact2-tasksid-2' },
             broken1,
             broken2,
             nonData1,
@@ -992,8 +1014,8 @@ describe('/contacts route', () => {
             expect(c1.csamReports).toHaveLength(0);
             expect(c2.csamReports).toHaveLength(0);
             // Test the association
-            expect(c1.overview.taskId).toBe('contact-1-task');
-            expect(c2.overview.taskId).toBe('contact-2-task');
+            expect(c1.overview.taskId).toBe('contact1-tasksid-2');
+            expect(c2.overview.taskId).toBe('contact2-tasksid-2');
             expect(count).toBe(2);
             expect(contacts.length).toBe(2);
           },
@@ -1013,8 +1035,8 @@ describe('/contacts route', () => {
             expect(c1.csamReports).toHaveLength(0);
             expect(c2.csamReports).toHaveLength(0);
             // Test the association
-            expect(c1.overview.taskId).toBe('contact-1-task');
-            expect(c2.overview.taskId).toBe('contact-2-task');
+            expect(c1.overview.taskId).toBe('contact1-tasksid-2');
+            expect(c2.overview.taskId).toBe('contact2-tasksid-2');
             expect(count).toBe(2);
           },
         },
@@ -1890,7 +1912,7 @@ describe('/contacts route', () => {
       const contactToBeDeleted = await contactApi.createContact(
         accountSid,
         workerSid,
-        <any>contact1,
+        <any>contact2,
         { user: twilioUser(workerSid, []), can: () => true },
       );
       const caseToBeDeleted = await caseApi.createCase(case1, accountSid, workerSid);

--- a/hrm-domain/hrm-service/service-tests/mocks.ts
+++ b/hrm-domain/hrm-service/service-tests/mocks.ts
@@ -70,6 +70,7 @@ export const contact1: CreateContactPayloadWithFormProperty = {
       streetAddress: '',
     },
   },
+  taskId: 'contact1-task-sid',
   twilioWorkerId: 'WK-worker-sid',
   createdBy: 'WK-worker-sid',
   helpline: '',
@@ -128,6 +129,7 @@ export const contact2: CreateContactPayloadWithFormProperty = {
     },
   },
   twilioWorkerId: 'WK-worker-sid',
+  taskId: 'contact2-task-sid',
   createdBy: 'WK-worker-sid',
   helpline: '',
   queueName: '',
@@ -138,6 +140,7 @@ export const contact2: CreateContactPayloadWithFormProperty = {
 
 export const nonData1: CreateContactPayloadWithFormProperty = {
   ...contact1,
+  taskId: 'nonData1-task-sid',
   form: {
     callType: 'Joke',
     childInformation: {},
@@ -147,6 +150,7 @@ export const nonData1: CreateContactPayloadWithFormProperty = {
 };
 export const nonData2: CreateContactPayloadWithFormProperty = {
   ...contact2,
+  taskId: 'nonData2-task-sid',
   form: {
     callType: 'Blank',
     childInformation: {},
@@ -157,10 +161,12 @@ export const nonData2: CreateContactPayloadWithFormProperty = {
 // Non data contacts with actual information
 export const broken1: CreateContactPayloadWithFormProperty = {
   ...contact1,
+  taskId: 'broken1-task-sid',
   form: { ...contact1.form, callType: 'Joke' },
 };
 export const broken2: CreateContactPayloadWithFormProperty = {
   ...contact2,
+  taskId: 'broken2-task-sid',
   form: { ...contact2.form, callType: 'Blank' },
 };
 
@@ -178,12 +184,14 @@ export const anotherCaller: Contact['rawJson']['callerInformation'] = {
 
 export const another1: CreateContactPayloadWithFormProperty = {
   ...contact1,
+  taskId: 'another1-task-sid',
   form: { ...contact1.form, childInformation: anotherChild },
   helpline: 'Helpline 1',
 };
 
 export const another2: CreateContactPayloadWithFormProperty = {
   ...contact2,
+  taskId: 'another2-task-sid',
   form: {
     ...contact2.form,
     callerInformation: {
@@ -203,6 +211,7 @@ export const another2: CreateContactPayloadWithFormProperty = {
 
 export const noHelpline: CreateContactPayloadWithFormProperty = {
   ...another1,
+  taskId: 'noHelpline-task-sid',
   helpline: '',
 };
 

--- a/hrm-domain/hrm-service/service-tests/referrals.test.ts
+++ b/hrm-domain/hrm-service/service-tests/referrals.test.ts
@@ -72,7 +72,11 @@ beforeEach(async () => {
   console.log('Contact IDs for test:', existingContactId, otherExistingContactId);
 });
 
-afterAll(async () => Promise.all([mockingProxy.stop(), clearDownDb(), server.close()]));
+afterEach(async () => {
+  await clearDownDb();
+});
+
+afterAll(async () => Promise.all([mockingProxy.stop(), server.close()]));
 
 const route = `/v0/accounts/${accountSid}/referrals`;
 

--- a/hrm-domain/hrm-service/src/contact/contact-data-access.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-data-access.ts
@@ -18,10 +18,7 @@ import { db } from '../connection-pool';
 import { UPDATE_CASEID_BY_ID, UPDATE_RAWJSON_BY_ID } from './sql/contact-update-sql';
 import { SELECT_CONTACT_SEARCH } from './sql/contact-search-sql';
 import { parseISO } from 'date-fns';
-import {
-  selectSingleContactByIdSql,
-  selectSingleContactByTaskId,
-} from './sql/contact-get-sql';
+import { selectSingleContactByIdSql } from './sql/contact-get-sql';
 import { insertContactSql, NewContactRecord } from './sql/contact-insert-sql';
 import { PersonInformation, ReferralWithoutContactId } from './contact-json';
 import type { ITask } from 'pg-promise';
@@ -148,44 +145,29 @@ const searchParametersToQueryParameters = (
   return queryParams;
 };
 
+type CreateResultRecord = Contact & { isNewRecord: boolean };
+type CreateResult = { contact: Contact; isNewRecord: boolean };
+
 export const create =
   (task?) =>
-  async (
-    accountSid: string,
-    newContact: NewContactRecord,
-  ): Promise<{ contact: Contact; isNewRecord: boolean }> => {
-    // Inner query that will be executed in a pgp.ITask
-    const executeQuery = async (
-      conn: ITask<{ contact: Contact; isNewRecord: boolean }>,
-    ) => {
-      if (newContact.taskId) {
-        const existingContact: Contact = await conn.oneOrNone<Contact>(
-          selectSingleContactByTaskId('Contacts'),
-          {
-            accountSid,
-            taskId: newContact.taskId,
-          },
-        );
-        if (existingContact) {
-          // A contact with the same task ID already exists, return it
-          return { contact: existingContact, isNewRecord: false };
-        }
-      }
+  async (accountSid: string, newContact: NewContactRecord): Promise<CreateResult> => {
+    return txIfNotInOne(
+      task,
+      async (conn: ITask<{ contact: Contact; isNewRecord: boolean }>) => {
+        const now = new Date();
+        const { isNewRecord, ...created }: CreateResultRecord =
+          await conn.one<CreateResultRecord>(
+            insertContactSql({
+              ...newContact,
+              accountSid,
+              createdAt: now,
+              updatedAt: now,
+            }),
+          );
 
-      const now = new Date();
-      const created: Contact = await conn.one<Contact>(
-        insertContactSql({
-          ...newContact,
-          accountSid,
-          createdAt: now,
-          updatedAt: now,
-        }),
-      );
-
-      return { contact: created, isNewRecord: true };
-    };
-
-    return txIfNotInOne(task, executeQuery);
+        return { contact: created, isNewRecord };
+      },
+    );
   };
 
 export const patch = async (

--- a/hrm-domain/hrm-service/src/contact/contact.ts
+++ b/hrm-domain/hrm-service/src/contact/contact.ts
@@ -270,24 +270,25 @@ export const createContact = async (
           conversationMediaPayload,
         } = getNewContactPayload(newContact);
 
-    const completeNewContact: NewContactRecord = {
-      ...newContactPayload,
-      helpline: newContactPayload.helpline ?? '',
-      number: newContactPayload.number ?? '',
-      channel: newContactPayload.channel ?? '',
-      timeOfContact: newContactPayload.timeOfContact
-        ? new Date(newContactPayload.timeOfContact)
-        : new Date(),
-      channelSid: newContactPayload.channelSid ?? '',
-      serviceSid: newContactPayload.serviceSid ?? '',
-      taskId: newContactPayload.taskId ?? '',
-      twilioWorkerId: newContactPayload.twilioWorkerId ?? '',
-      rawJson: newContactPayload.rawJson,
-      queueName:
-        // Checking in rawJson might be redundant, copied from Sequelize logic in contact-controller.js
-        newContactPayload.queueName || (<any>(newContactPayload.rawJson ?? {})).queueName,
-      createdBy,
-    };
+        const completeNewContact: NewContactRecord = {
+          ...newContactPayload,
+          helpline: newContactPayload.helpline ?? '',
+          number: newContactPayload.number ?? '',
+          channel: newContactPayload.channel ?? '',
+          timeOfContact: newContactPayload.timeOfContact
+            ? new Date(newContactPayload.timeOfContact)
+            : new Date(),
+          channelSid: newContactPayload.channelSid ?? '',
+          serviceSid: newContactPayload.serviceSid ?? '',
+          taskId: newContactPayload.taskId ?? '',
+          twilioWorkerId: newContactPayload.twilioWorkerId ?? '',
+          rawJson: newContactPayload.rawJson,
+          queueName:
+            // Checking in rawJson might be redundant, copied from Sequelize logic in contact-controller.js
+            newContactPayload.queueName ||
+            (<any>(newContactPayload.rawJson ?? {})).queueName,
+          createdBy,
+        };
 
         // create contact record (may return an exiting one cause idempotence)
         const { contact, isNewRecord } = await create(conn)(
@@ -316,19 +317,19 @@ export const createContact = async (
           const referrals = referralsPayload ?? [];
           const createdReferrals = [];
 
-      if (referrals && referrals.length) {
-        // Do this sequentially, it's on a single connection in a transaction anyway.
-        for (const referral of referrals) {
-          const { contactId, ...withoutContactId } = await createReferral(conn)(
-            accountSid,
-            {
-              ...referral,
-              contactId: contact.id.toString(),
-            },
-          );
-          createdReferrals.push(withoutContactId);
-        }
-      }
+          if (referrals && referrals.length) {
+            // Do this sequentially, it's on a single connection in a transaction anyway.
+            for (const referral of referrals) {
+              const { contactId, ...withoutContactId } = await createReferral(conn)(
+                accountSid,
+                {
+                  ...referral,
+                  contactId: contact.id.toString(),
+                },
+              );
+              createdReferrals.push(withoutContactId);
+            }
+          }
 
           const createdConversationMedia: ConversationMedia[] = [];
           if (conversationMediaPayload && conversationMediaPayload.length) {

--- a/hrm-domain/hrm-service/src/contact/sql/contact-get-sql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contact-get-sql.ts
@@ -40,6 +40,4 @@ export const selectSingleContactByIdSql = (table: string) => `
 
 export const selectSingleContactByTaskId = (table: string) => ` 
       ${selectContactsWithRelations(table)}
-      ${TASKID_WHERE_CLAUSE}
-      -- only take the latest, this ORDER / LIMIT clause would be redundant 
-      ORDER BY c."createdAt" DESC LIMIT 1`;
+      ${TASKID_WHERE_CLAUSE}`;

--- a/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
@@ -36,37 +36,61 @@ export type NewContactRecord = {
 export const insertContactSql = (
   contact: NewContactRecord & { accountSid: string; createdAt: Date; updatedAt: Date },
 ) => `
-WITH inserted AS (
-  ${pgp.helpers.insert(
-    contact,
-    [
-      'accountSid',
-      'rawJson',
-      'queueName',
-      'twilioWorkerId',
-      'createdBy',
-      'createdAt',
-      'updatedAt',
-      'helpline',
-      'channel',
-      'number',
-      'conversationDuration',
-      'timeOfContact',
-      'taskId',
-      'channelSid',
-      'serviceSid',
-    ],
-    'Contacts',
-  )}
-  ON CONFLICT ("taskId", "accountSid") DO NOTHING
-  RETURNING *
-)
-SELECT "inserted".*, NULL AS "csamReports", NULL AS "referrals", NULL AS "conversationMedia", true AS "isNewRecord" FROM inserted
-UNION
-SELECT "existing".*, false AS "isNewRecord" FROM 
-(
-    ${pgp.as.format(selectSingleContactByTaskId('Contacts'), {
-      taskId: contact.taskId,
-      accountSid: contact.accountSid,
-    })}
-) AS existing WHERE existing.id NOT IN (SELECT id FROM inserted)`;
+  WITH existing AS (
+      ${pgp.as.format(selectSingleContactByTaskId('Contacts'), {
+        taskId: contact.taskId,
+        accountSid: contact.accountSid,
+      })}
+  ), inserted AS (
+    ${pgp.as.format(
+      `INSERT INTO "Contacts" (
+      "accountSid",
+      "rawJson",
+      "queueName",
+      "twilioWorkerId",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+      "helpline",
+      "channel",
+      "number",
+      "conversationDuration",
+      "timeOfContact",
+      "taskId",
+      "channelSid",
+      "serviceSid"
+    ) (SELECT 
+        $<accountSid>, 
+        $<rawJson>, 
+        $<queueName>, 
+        $<twilioWorkerId>, 
+        $<createdBy>, 
+        $<createdAt>, 
+        $<updatedAt>, 
+        $<helpline>, 
+        $<channel>, 
+        $<number>, 
+        $<conversationDuration>, 
+        $<timeOfContact>, 
+        $<taskId>, 
+        $<channelSid>, 
+        $<serviceSid>
+      WHERE NOT EXISTS (
+        ${pgp.as.format(selectSingleContactByTaskId('Contacts'), {
+          taskId: contact.taskId,
+          accountSid: contact.accountSid,
+        })}
+      )
+    )
+    RETURNING *`,
+      {
+        ...contact,
+        taskId: contact.taskId,
+        accountSid: contact.accountSid,
+      },
+    )}
+  )
+  SELECT "existing".*, false AS "isNewRecord" FROM "existing"
+  UNION
+  SELECT "inserted".*, NULL AS "csamReports", NULL AS "referrals", NULL AS "conversationMedia", true AS "isNewRecord" FROM "inserted"
+`;

--- a/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
@@ -16,6 +16,7 @@
 
 import { pgp } from '../../connection-pool';
 import { ContactRawJson } from '../contact-json';
+import { selectSingleContactByTaskId } from './contact-get-sql';
 
 export type NewContactRecord = {
   rawJson: ContactRawJson;
@@ -27,7 +28,7 @@ export type NewContactRecord = {
   channel?: string;
   conversationDuration: number;
   timeOfContact?: Date;
-  taskId?: string;
+  taskId: string;
   channelSid?: string;
   serviceSid?: string;
 };
@@ -35,6 +36,7 @@ export type NewContactRecord = {
 export const insertContactSql = (
   contact: NewContactRecord & { accountSid: string; createdAt: Date; updatedAt: Date },
 ) => `
+WITH inserted AS (
   ${pgp.helpers.insert(
     contact,
     [
@@ -56,5 +58,15 @@ export const insertContactSql = (
     ],
     'Contacts',
   )}
+  ON CONFLICT ("taskId", "accountSid") DO NOTHING
   RETURNING *
-`;
+)
+SELECT "inserted".*, NULL AS "csamReports", NULL AS "referrals", NULL AS "conversationMedia", true AS "isNewRecord" FROM inserted
+UNION
+SELECT "existing".*, false AS "isNewRecord" FROM 
+(
+    ${pgp.as.format(selectSingleContactByTaskId('Contacts'), {
+      taskId: contact.taskId,
+      accountSid: contact.accountSid,
+    })}
+) AS existing WHERE existing.id NOT IN (SELECT id FROM inserted)`;

--- a/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
@@ -174,7 +174,6 @@ describe('createContact', () => {
       'channel',
       'channelSid',
       'serviceSid',
-      'taskId',
       'twilioWorkerId',
     );
     const returnValue = await createContact(
@@ -607,6 +606,7 @@ describe('searchContacts', () => {
       .build();
     const sarahPark = new ContactBuilder()
       .withId(1234)
+      .withTaskId('sarah-park-task')
       .withChildFirstName('Sarah')
       .withChildLastName('Park')
       .withCallSummary('Young pregnant woman')

--- a/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
@@ -193,7 +193,7 @@ describe('createContact', () => {
       channel: '',
       channelSid: '',
       serviceSid: '',
-      taskId: '',
+      taskId: 'a task',
       twilioWorkerId: '',
     });
 
@@ -645,7 +645,7 @@ describe('searchContacts', () => {
           contactId: '1234',
           overview: {
             helpline: undefined,
-            taskId: undefined,
+            taskId: 'sarah-park-task',
             dateTime: '2020-03-15T00:00:00.000Z',
             name: '', // Legacy property, not used in Flex v2.1+
             customerNumber: 'Anonymous',


### PR DESCRIPTION
## Description

* Locks the enforcement of 'one contact per task' into the DB layer with a unique index - now subsequent edits cannot break the rule
* Changes the 'insert or return existing' logic to be run in a single SQL statement
* Fixes issue where if the contact already existed, it was returned without its relations
* Script to delete any existing contacts with duplicate tasks

It is HIGHLY recommended that all production DBs are manually checked for contacts with duplicate tasks and fixed prior to deploying this migration

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
Discovered implementing CHI-1434

### Verification steps

Automated tests
