### PR TITLE
CHI-1434: Contact finalized date

### DIFF
--- a/hrm-domain/hrm-service/migrations/20231010145200-contact_finalizedAt.js
+++ b/hrm-domain/hrm-service/migrations/20231010145200-contact_finalizedAt.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS public."Contacts"
+      ADD COLUMN "finalizedAt" timestamp with time zone;
+    `);
+    console.log('"finalizedAt" column added to table "Contacts"');
+    await queryInterface.sequelize.query(`
+      UPDATE public."Contacts" SET "finalizedAt" = COALESCE("createdAt", current_timestamp);
+    `);
+    console.log('"finalizedAt" column added to table "Contacts"');
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Contacts" 
+      DROP COLUMN IF EXISTS "finalizedAt";
+    `);
+    console.log('"finalizedAt" column dropped to table "Contacts"');
+  },
+};

--- a/hrm-domain/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case-search.test.ts
@@ -142,6 +142,7 @@ const insertSampleCases = async ({
       const { contact: savedContact } = await contactDb.create()(
         accounts[i % accounts.length],
         contactToCreate,
+        true,
       );
       connectedContact = await contactDb.connectToCase(
         savedContact.accountSid,
@@ -225,7 +226,8 @@ describe('/cases route', () => {
         contactToCreate.taskId = `TASK_SID`;
         contactToCreate.channelSid = `CHANNEL_SID`;
         contactToCreate.serviceSid = 'SERVICE_SID';
-        createdContact = (await contactDb.create()(accountSid, contactToCreate)).contact;
+        createdContact = (await contactDb.create()(accountSid, contactToCreate, true))
+          .contact;
         createdContact = await contactDb.connectToCase(
           accountSid,
           createdContact.id.toString(),
@@ -376,6 +378,7 @@ describe('/cases route', () => {
       const createdContact = await createContact(
         accountSid,
         workerSid,
+        true,
         mocks.withTaskIdAndTranscript,
         { user: twilioUser(workerSid, []), can: () => true },
       );
@@ -526,7 +529,7 @@ describe('/cases route', () => {
           toCreate.channelSid = `CHANNEL_SID`;
           toCreate.serviceSid = 'SERVICE_SID';
           // Connects createdContact with createdCase2
-          createdContact = (await contactDb.create()(accountSid, toCreate)).contact;
+          createdContact = (await contactDb.create()(accountSid, toCreate, true)).contact;
           createdContact = await contactDb.connectToCase(
             accountSid,
             createdContact.id.toString(),
@@ -1267,6 +1270,7 @@ describe('/cases route', () => {
         const createdContact = await createContact(
           accountSid,
           workerSid,
+          true,
           mocks.withTaskIdAndTranscript,
           { user: twilioUser(workerSid, []), can: () => true },
         );

--- a/hrm-domain/hrm-service/service-tests/case-validation.ts
+++ b/hrm-domain/hrm-service/service-tests/case-validation.ts
@@ -158,6 +158,7 @@ export const validateCaseListResponse = (actual, expectedCaseAndContactModels, c
           referrals: [],
           timeOfContact: expect.toParseAsDate(expectedContactModel.timeOfContact),
           createdAt: expect.toParseAsDate(expectedContactModel.createdAt),
+          finalizedAt: expect.toParseAsDate(expectedContactModel.finalizedAt),
           updatedAt: expect.toParseAsDate(expectedContactModel.updatedAt),
         }),
       ]);

--- a/hrm-domain/hrm-service/service-tests/case.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case.test.ts
@@ -291,6 +291,7 @@ describe('/cases route', () => {
         const createdContact = await createContact(
           accountSid,
           workerSid,
+          true,
           mocks.withTaskIdAndTranscript,
           { user: twilioUser(workerSid, []), can: () => true },
         );
@@ -680,6 +681,7 @@ describe('/cases route', () => {
         const createdContact = await createContact(
           accountSid,
           workerSid,
+          true,
           mocks.withTaskIdAndTranscript,
           { user: twilioUser(workerSid, []), can: () => true },
         );

--- a/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
@@ -115,6 +115,7 @@ const createChatContact = async (channel: string, startedTimestamp: number) => {
   const contact = await contactApi.createContact(
     accountSid,
     workerSid,
+    true,
     contactTobeCreated,
     {
       can: () => true,
@@ -204,7 +205,7 @@ describe('publish retrieve-transcript job type', () => {
     expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(1);
     expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledWith({
       ...retrieveContactTranscriptJob,
-      lastAttempt: expect.toParseAsDate(),
+      lastAttempt: expect.any(Date),
       numberOfAttempts: 1,
       resource: {
         ...contactWithoutLegacyCompatibility,
@@ -213,6 +214,7 @@ describe('publish retrieve-transcript job type', () => {
           createdAt: expect.toParseAsDate(cm.createdAt),
           updatedAt: expect.toParseAsDate(cm.updatedAt),
         })),
+        finalizedAt: expect.toParseAsDate(contact.finalizedAt),
         createdAt: expect.toParseAsDate(contact.createdAt),
         updatedAt: expect.toParseAsDate(contact.updatedAt),
         timeOfContact: expect.toParseAsDate(contact.timeOfContact),
@@ -271,7 +273,7 @@ describe('publish retrieve-transcript job type', () => {
       expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(1);
       expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledWith({
         ...retrieveContactTranscriptJob,
-        lastAttempt: expect.toParseAsDate(),
+        lastAttempt: expect.any(Date),
         numberOfAttempts: 1,
         resource: {
           ...contact,
@@ -281,6 +283,7 @@ describe('publish retrieve-transcript job type', () => {
             updatedAt: expect.toParseAsDate(cm.updatedAt),
           })),
           createdAt: expect.toParseAsDate(contact.createdAt),
+          finalizedAt: expect.toParseAsDate(contact.finalizedAt),
           updatedAt: expect.toParseAsDate(contact.updatedAt),
           timeOfContact: expect.toParseAsDate(contact.timeOfContact),
         },

--- a/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
@@ -59,8 +59,7 @@ const cleanup = async () => {
 };
 
 beforeAll(() => {
-  process.env.TWILIO_AUTH_TOKEN = 'mockAuthToken';
-  process.env.TWILIO_CLIENT_USE_ENV_AUTH_TOKEN = 'true';
+  process.env[`TWILIO_AUTH_TOKEN_${accountSid}`] = 'mockAuthToken';
 });
 
 beforeEach(cleanup);

--- a/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
@@ -1,0 +1,686 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ContactRawJson,
+  CreateContactPayload,
+  PatchPayload,
+  WithLegacyCategories,
+} from '../../src/contact/contact';
+import '../case-validation';
+import * as contactApi from '../../src/contact/contact';
+import { accountSid, contact1, withTaskIdAndTranscript, workerSid } from '../mocks';
+import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
+import each from 'jest-each';
+import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
+import * as contactDb from '../../src/contact/contact-data-access';
+import { ruleFileWithOneActionOverride } from '../permissions-overrides';
+import { isS3StoredTranscript } from '../../src/conversation-media/conversation-media-data-access';
+import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
+import {
+  cleanupCases,
+  cleanupContacts,
+  cleanupContactsJobs,
+  cleanupCsamReports,
+  cleanupReferrals,
+  deleteContactById,
+  deleteJobsByContactId,
+} from './db-cleanup';
+
+type ContactRawJsonWithLegacyCategories =
+  WithLegacyCategories<contactDb.Contact>['rawJson'];
+
+useOpenRules();
+const server = getServer();
+const request = getRequest(server);
+const route = `/v0/accounts/${accountSid}/contacts`;
+
+const cleanup = async () => {
+  await mockingProxy.start();
+  await mockSuccessfulTwilioAuthentication(workerSid);
+  await cleanupCsamReports();
+  await cleanupReferrals();
+  await cleanupContactsJobs();
+  await cleanupContacts();
+  await cleanupCases();
+};
+
+beforeAll(cleanup);
+
+afterAll(cleanup);
+
+describe('/contacts/:contactId route', () => {
+  describe('PATCH', () => {
+    type TestOptions = {
+      patch: PatchPayload['rawJson'];
+      description: string;
+      original?: ContactRawJson;
+      expected: ContactRawJsonWithLegacyCategories;
+    };
+    const subRoute = contactId => `${route}/${contactId}`;
+
+    test('should return 401', async () => {
+      const createdContact = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        true,
+        {
+          ...contact1,
+          rawJson: <ContactRawJson>{},
+          csamReports: [],
+        },
+        { user: twilioUser(workerSid, []), can: () => true },
+      );
+      try {
+        const response = await request.patch(subRoute(createdContact.id)).send({});
+
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe('Authorization failed');
+      } finally {
+        await deleteContactById(createdContact.id, createdContact.accountSid);
+      }
+    });
+    describe('rawJson changes', () => {
+      const sampleRawJson: ContactRawJson = {
+        ...(contact1.rawJson as ContactRawJson),
+        categories: {
+          a: ['a2'],
+          b: ['b1'],
+        },
+      };
+      const sampleRawJsonWithLegacyCategories = {
+        ...sampleRawJson,
+        caseInformation: {
+          ...sampleRawJson.caseInformation,
+          categories: {
+            a: { a2: true },
+            b: { b1: true },
+          },
+        },
+      };
+      const tests: TestOptions[] = [
+        {
+          description: 'set callType to data call type',
+          patch: {
+            callType: 'Child calling about self',
+          },
+          expected: {
+            callType: 'Child calling about self',
+            caseInformation: {
+              categories: {},
+            },
+          },
+        },
+        {
+          description: 'set callType to non data call type',
+          patch: {
+            callType: 'Hang up',
+          },
+          expected: {
+            callType: 'Hang up',
+            caseInformation: {
+              categories: {},
+            },
+          },
+        },
+        {
+          description: 'add child information',
+          patch: {
+            childInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'property',
+            },
+          },
+          expected: {
+            childInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'property',
+            },
+            caseInformation: {
+              categories: {},
+            },
+          },
+        },
+        {
+          description: 'add caller information',
+          patch: {
+            callerInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'other property',
+            },
+          },
+          expected: {
+            callerInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'other property',
+            },
+            caseInformation: {
+              categories: {},
+            },
+          },
+        },
+        {
+          description: 'add case information and categories',
+          patch: {
+            caseInformation: {
+              other: 'case property',
+            },
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+          expected: {
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+            caseInformation: {
+              other: 'case property',
+              categories: {
+                category1: { subcategory1: true, subcategory2: true },
+              },
+            },
+          },
+        },
+        {
+          description: 'add case information',
+          patch: {
+            caseInformation: {
+              other: 'case property',
+            },
+          },
+          expected: {
+            caseInformation: {
+              other: 'case property',
+              categories: {},
+            },
+          },
+        },
+        {
+          description: 'add categories',
+          patch: {
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+            caseInformation: {},
+          },
+          expected: {
+            caseInformation: {
+              categories: {
+                category1: { subcategory1: true, subcategory2: true },
+              },
+            },
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+        },
+
+        {
+          description: 'overwrite callType as data call type',
+          original: sampleRawJson,
+          patch: {
+            callType: 'Child calling about self',
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            callType: 'Child calling about self',
+          },
+        },
+        {
+          description: 'overwrite callType as non data call type',
+          original: sampleRawJson,
+          patch: {
+            callType: 'Hang up',
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            callType: 'Hang up',
+          },
+        },
+        {
+          description: 'overwrite child information',
+          original: sampleRawJson,
+          patch: {
+            childInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'property',
+            },
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            childInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'property',
+            },
+          },
+        },
+        {
+          original: sampleRawJson,
+          description: 'overwrite caller information',
+          patch: {
+            callerInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'other property',
+            },
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            callerInformation: {
+              firstName: 'Lorna',
+              lastName: 'Ballantyne',
+              some: 'other property',
+            },
+          },
+        },
+        {
+          original: sampleRawJson,
+          description: 'overwrite case information and categories',
+          patch: {
+            caseInformation: {
+              other: 'overwrite case property',
+            },
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            caseInformation: {
+              other: 'overwrite case property',
+              categories: {
+                category1: { subcategory1: true, subcategory2: true },
+              },
+            },
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+        },
+        {
+          original: sampleRawJson,
+          description: 'overwrite case information',
+          patch: {
+            caseInformation: {
+              other: 'case property',
+            },
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            caseInformation: {
+              other: 'case property',
+              categories: sampleRawJsonWithLegacyCategories.caseInformation.categories,
+            },
+          },
+        },
+        {
+          original: sampleRawJson,
+          description: 'overwrite categories',
+          patch: {
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+          expected: {
+            ...sampleRawJsonWithLegacyCategories,
+            caseInformation: {
+              ...sampleRawJsonWithLegacyCategories.caseInformation,
+              categories: {
+                category1: {
+                  subcategory1: true,
+                  subcategory2: true,
+                },
+              },
+            },
+
+            categories: {
+              category1: ['subcategory1', 'subcategory2'],
+            },
+          },
+        },
+      ];
+      each(tests).test(
+        'should $description if that is specified in the payload',
+        async ({ patch, expected, original }: TestOptions) => {
+          const createdContact = await contactApi.createContact(
+            accountSid,
+            workerSid,
+            true,
+            {
+              ...contact1,
+              rawJson: original || <ContactRawJson>{},
+              csamReports: [],
+            },
+            { user: twilioUser(workerSid, []), can: () => true },
+          );
+          try {
+            const existingContactId = createdContact.id;
+            const response = await request
+              .patch(subRoute(existingContactId))
+              .set(headers)
+              .send({ rawJson: patch });
+
+            expect(response.status).toBe(200);
+            const { categories, ...caseInformationWithoutLegacyCategories } =
+              expected?.caseInformation ?? {};
+            const expectedInDb: Partial<ContactRawJson> = expected?.caseInformation
+              ? {
+                  ...expected,
+                  caseInformation: caseInformationWithoutLegacyCategories as Record<
+                    string,
+                    string | boolean
+                  >,
+                }
+              : (expected as Partial<ContactRawJson>);
+            // Bodge a corner case where an absent caseInformation is untouched by the patch operation
+            if (
+              !original?.caseInformation &&
+              !patch?.caseInformation &&
+              !patch?.categories
+            ) {
+              delete expectedInDb.caseInformation;
+            }
+            expect(response.body).toStrictEqual({
+              ...createdContact,
+              timeOfContact: expect.toParseAsDate(createdContact.timeOfContact),
+              createdAt: expect.toParseAsDate(createdContact.createdAt),
+              finalizedAt: expect.toParseAsDate(createdContact.finalizedAt),
+              updatedAt: expect.toParseAsDate(),
+              updatedBy: workerSid,
+              rawJson: expected,
+              csamReports: [],
+              referrals: [],
+            });
+            // Test the association
+            expect(response.body.csamReports).toHaveLength(0);
+            const savedContact = await contactDb.getById(accountSid, existingContactId);
+
+            expect(savedContact).toStrictEqual({
+              ...createdContact,
+              createdAt: expect.toParseAsDate(createdContact.createdAt),
+              updatedAt: expect.toParseAsDate(),
+              updatedBy: workerSid,
+              rawJson: expectedInDb,
+              csamReports: [],
+              referrals: [],
+            });
+          } finally {
+            await deleteContactById(createdContact.id, createdContact.accountSid);
+          }
+        },
+      );
+    });
+
+    describe('Changes outside rawJson', () => {
+      beforeEach(async () => {
+        // Clean what's been created so far
+        await cleanupCsamReports();
+        await cleanupReferrals();
+        await cleanupContactsJobs();
+        await cleanupContacts();
+        await cleanupCases();
+      });
+
+      test('Not permitted on finalized contact', async () => {
+        const createdContact = await contactApi.createContact(
+          accountSid,
+          workerSid,
+          true,
+          contact1,
+          { user: twilioUser(workerSid, []), can: () => true },
+        );
+        const response = await request
+          .patch(subRoute(createdContact.id))
+          .set(headers)
+          .send({ conversationDuration: 1337 });
+
+        expect(response.status).toBe(401);
+      });
+
+      type FullPatchTestOptions = {
+        patch: PatchPayload;
+        description: string;
+        originalDifferences?: PatchPayload;
+        expectedDifferences?: PatchPayload;
+      };
+
+      const testCases: FullPatchTestOptions[] = [
+        {
+          description: 'patches conversationDuration',
+          patch: {
+            conversationDuration: 1337,
+          },
+          expectedDifferences: {
+            conversationDuration: 1337,
+          },
+          originalDifferences: {
+            conversationDuration: 42,
+          },
+        },
+      ];
+      each(testCases).test(
+        'should $description if that is specified in the payload for a draft contact',
+        async ({
+          patch,
+          expectedDifferences,
+          originalDifferences,
+        }: FullPatchTestOptions) => {
+          const original: CreateContactPayload = {
+            ...contact1,
+            ...originalDifferences,
+            rawJson: {
+              ...contact1.rawJson,
+              ...originalDifferences?.rawJson,
+            },
+          };
+          const createdContact = await contactApi.createContact(
+            accountSid,
+            workerSid,
+            false,
+            original,
+            { user: twilioUser(workerSid, []), can: () => true },
+          );
+          const expected: WithLegacyCategories<contactDb.Contact> = {
+            ...createdContact,
+            ...expectedDifferences,
+            rawJson: {
+              ...createdContact.rawJson,
+              ...expectedDifferences?.rawJson,
+              caseInformation: {
+                ...createdContact.rawJson!.caseInformation,
+                ...expectedDifferences?.rawJson?.caseInformation,
+                categories: {},
+              },
+            },
+          };
+          try {
+            const existingContactId = createdContact.id;
+            const response = await request
+              .patch(subRoute(existingContactId))
+              .set(headers)
+              .send(patch);
+
+            expect(response.status).toBe(200);
+            const { categories, ...caseInformationWithoutLegacyCategories } =
+              expected.rawJson?.caseInformation ?? {};
+            const expectedInDb: contactApi.Contact = expected.rawJson?.caseInformation
+              ? ({
+                  ...expected,
+                  rawJson: {
+                    ...expected.rawJson,
+                    caseInformation: caseInformationWithoutLegacyCategories as Record<
+                      string,
+                      string | boolean
+                    >,
+                  },
+                } as contactApi.Contact)
+              : (expected as contactApi.Contact);
+            // Bodge a corner case where an absent caseInformation is untouched by the patch operation
+            if (
+              !original.rawJson?.caseInformation &&
+              !patch.rawJson?.caseInformation &&
+              !patch.rawJson?.categories
+            ) {
+              delete (expectedInDb.rawJson as any).caseInformation;
+            }
+            expect(response.body).toStrictEqual({
+              ...expected,
+              timeOfContact: expect.toParseAsDate(expected.timeOfContact),
+              createdAt: expect.toParseAsDate(expected.createdAt),
+              updatedAt: expect.toParseAsDate(),
+              updatedBy: workerSid,
+              referrals: [],
+            });
+            // Test the association
+            expect(response.body.csamReports).toHaveLength(0);
+            const savedContact = await contactDb.getById(accountSid, existingContactId);
+
+            expect(savedContact).toStrictEqual({
+              ...expectedInDb,
+              createdAt: expect.toParseAsDate(createdContact.createdAt),
+              updatedAt: expect.toParseAsDate(),
+              updatedBy: workerSid,
+              csamReports: [],
+              referrals: [],
+            });
+          } finally {
+            await deleteContactById(createdContact.id, createdContact.accountSid);
+          }
+        },
+      );
+    });
+
+    test('use non-existent contactId should return 404', async () => {
+      const contactToBeDeleted = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        true,
+        <any>contact1,
+        { user: twilioUser(workerSid, []), can: () => true },
+      );
+      const nonExistingContactId = contactToBeDeleted.id;
+      await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
+      const response = await request
+        .patch(subRoute(nonExistingContactId))
+        .set(headers)
+        .send({
+          rawJson: {
+            name: { firstName: 'Lorna', lastName: 'Ballantyne' },
+            some: 'property',
+          },
+        });
+
+      expect(response.status).toBe(404);
+    });
+
+    test('malformed payload should return 400', async () => {
+      const contact = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        true,
+        <any>{ ...contact1, taskId: 'malformed-task-id' },
+        { user: twilioUser(workerSid, []), can: () => true },
+      );
+      const response = await request.patch(subRoute(contact.id)).set(headers).send([]);
+
+      expect(response.status).toBe(400);
+    });
+
+    test('no body should be a noop', async () => {
+      const createdContact = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        true,
+        <any>contact1,
+        { user: twilioUser(workerSid, []), can: () => true },
+      );
+      const response = await request
+        .patch(subRoute(createdContact.id))
+        .set(headers)
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({
+        ...createdContact,
+        timeOfContact: expect.toParseAsDate(createdContact.timeOfContact),
+        createdAt: expect.toParseAsDate(createdContact.createdAt),
+        finalizedAt: expect.toParseAsDate(createdContact.finalizedAt),
+        updatedAt: expect.toParseAsDate(),
+        updatedBy: workerSid,
+      });
+    });
+
+    each([
+      {
+        expectTranscripts: true,
+        description: `with viewExternalTranscript includes transcripts`,
+      },
+      {
+        expectTranscripts: false,
+        description: `without viewExternalTranscript excludes transcripts`,
+      },
+    ]).test(`$description`, async ({ expectTranscripts }) => {
+      const createdContact = await contactApi.createContact(
+        accountSid,
+        workerSid,
+        true,
+        withTaskIdAndTranscript,
+        { user: twilioUser(workerSid, []), can: () => true },
+      );
+      if (!expectTranscripts) {
+        setRules(ruleFileWithOneActionOverride('viewExternalTranscript', false));
+      } else {
+        useOpenRules();
+      }
+
+      const res = await request
+        .patch(`${route}/${createdContact.id}`)
+        .set(headers)
+        .send({ rawJson: createdContact.rawJson });
+      expect(res.status).toBe(200);
+
+      if (expectTranscripts) {
+        expect(
+          (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
+        ).toBeTruthy();
+        expect(
+          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
+            cm => cm.store === 'S3',
+          ),
+        ).toBeTruthy();
+      } else {
+        expect(
+          (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
+        ).toBeFalsy();
+        expect(
+          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
+            cm => cm.store === 'S3',
+          ),
+        ).toBeFalsy();
+      }
+
+      await deleteJobsByContactId(createdContact.id, createdContact.accountSid);
+      await deleteContactById(createdContact.id, createdContact.accountSid);
+      useOpenRules();
+    });
+  });
+});

--- a/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
@@ -461,6 +461,7 @@ describe('/contacts/:contactId route', () => {
         description: string;
         originalDifferences?: PatchPayload;
         expectedDifferences?: PatchPayload;
+        finalize?: boolean;
       };
 
       const testCases: FullPatchTestOptions[] = [
@@ -476,6 +477,20 @@ describe('/contacts/:contactId route', () => {
             conversationDuration: 42,
           },
         },
+        {
+          description: 'finalize contact',
+          finalize: true,
+          patch: {
+            conversationDuration: 1337,
+          },
+          expectedDifferences: {
+            conversationDuration: 1337,
+            finalizedAt: expect.toParseAsDate(),
+          },
+          originalDifferences: {
+            conversationDuration: 42,
+          },
+        },
       ];
       each(testCases).test(
         'should $description if that is specified in the payload for a draft contact',
@@ -483,6 +498,7 @@ describe('/contacts/:contactId route', () => {
           patch,
           expectedDifferences,
           originalDifferences,
+          finalize = false,
         }: FullPatchTestOptions) => {
           const original: CreateContactPayload = {
             ...contact1,
@@ -515,7 +531,7 @@ describe('/contacts/:contactId route', () => {
           try {
             const existingContactId = createdContact.id;
             const response = await request
-              .patch(subRoute(existingContactId))
+              .patch(`${subRoute(existingContactId)}?finalize=${finalize}`)
               .set(headers)
               .send(patch);
 

--- a/hrm-domain/hrm-service/service-tests/contact/db-cleanup.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/db-cleanup.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 import { db } from '../../src/connection-pool';
 import { accountSid, workerSid } from '../mocks';
 

--- a/hrm-domain/hrm-service/service-tests/contact/db-cleanup.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/db-cleanup.ts
@@ -1,0 +1,55 @@
+import { db } from '../../src/connection-pool';
+import { accountSid, workerSid } from '../mocks';
+
+const cleanupWhereClause = `
+  WHERE "twilioWorkerId" IN ('fake-worker-123', 'fake-worker-129', 'fake-worker-987', '${workerSid}') OR "accountSid" IN ('', '${accountSid}');
+`;
+export const cleanupCases = () =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "Cases"
+      ${cleanupWhereClause}
+  `),
+  );
+export const cleanupContacts = () =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "Contacts"
+      ${cleanupWhereClause}
+  `),
+  );
+export const cleanupContactsJobs = () =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "ContactJobs"
+      WHERE "accountSid" IN ('', '${accountSid}')
+  `),
+  );
+export const cleanupCsamReports = () =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "CSAMReports"
+      ${cleanupWhereClause}
+    `),
+  );
+export const cleanupReferrals = () =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "CSAMReports"
+      ${cleanupWhereClause}
+    `),
+  ); // eslint-disable-next-line @typescript-eslint/no-shadow
+export const deleteContactById = (id: number, accountSid: string) =>
+  db.task(t =>
+    t.none(`
+      DELETE FROM "Contacts"
+      WHERE "id" = ${id} AND "accountSid" = '${accountSid}';
+  `),
+  ); // eslint-disable-next-line @typescript-eslint/no-shadow
+export const deleteJobsByContactId = (contactId: number, accountSid: string) =>
+  db.task(t =>
+    t.manyOrNone(`
+      DELETE FROM "ContactJobs"
+      WHERE "contactId" = ${contactId} AND "accountSid" = '${accountSid}';
+    `),
+  );

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -15,42 +15,38 @@
  */
 
 import each from 'jest-each';
-import { subHours, subDays, parseISO, subSeconds, addSeconds } from 'date-fns';
+import { addSeconds, parseISO, subDays, subHours, subSeconds } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 
 import { db } from '../src/connection-pool';
 import { ContactRawJson } from '../src/contact/contact-json';
 import {
+  isS3StoredTranscript,
   NewConversationMedia,
   S3ContactMediaType,
-  isS3StoredTranscript,
 } from '../src/conversation-media/conversation-media';
 import {
   accountSid,
-  contact1,
-  contact2,
-  broken1,
-  broken2,
   another1,
   another2,
-  noHelpline,
-  withTaskId,
+  broken1,
+  broken2,
   case1,
   case2,
-  workerSid,
-  nonData2,
+  contact1,
+  contact2,
+  noHelpline,
   nonData1,
+  nonData2,
+  withTaskId,
   withTaskIdAndTranscript,
+  workerSid,
 } from './mocks';
 import './case-validation';
 import * as caseApi from '../src/case/case';
 import * as caseDb from '../src/case/case-data-access';
-import {
-  CreateContactPayload,
-  PatchPayload,
-  WithLegacyCategories,
-} from '../src/contact/contact';
 import * as contactApi from '../src/contact/contact';
+import { CreateContactPayload, WithLegacyCategories } from '../src/contact/contact';
 import * as contactDb from '../src/contact/contact-data-access';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import * as contactJobDataAccess from '../src/contact-job/contact-job-data-access';
@@ -60,13 +56,19 @@ import { ruleFileWithOneActionOverride } from './permissions-overrides';
 import * as csamReportApi from '../src/csam-report/csam-report';
 import * as referralDB from '../src/referral/referral-data-access';
 import * as conversationMediaDB from '../src/conversation-media/conversation-media-data-access';
-import { headers, getRequest, getServer, setRules, useOpenRules } from './server';
+import { getRequest, getServer, headers, setRules, useOpenRules } from './server';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 
 import { ContactJobType } from '@tech-matters/types';
-
-type ContactRawJsonWithLegacyCategories =
-  WithLegacyCategories<contactDb.Contact>['rawJson'];
+import {
+  cleanupCases,
+  cleanupContacts,
+  cleanupContactsJobs,
+  cleanupCsamReports,
+  cleanupReferrals,
+  deleteContactById,
+  deleteJobsByContactId,
+} from './contact/db-cleanup';
 
 useOpenRules();
 const server = getServer();
@@ -80,62 +82,9 @@ const request = getRequest(server);
 const resolveSequentially = ps =>
   ps.reduce((p, v) => p.then(a => v().then(r => a.concat([r]))), Promise.resolve([]));
 
-const cleanupWhereClause = `
-  WHERE "twilioWorkerId" IN ('fake-worker-123', 'fake-worker-129', 'fake-worker-987', '${workerSid}') OR "accountSid" IN ('', '${accountSid}');
-`;
-
-const cleanupCases = () =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "Cases"
-      ${cleanupWhereClause}
-  `),
-  );
-
-const cleanupContacts = () =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "Contacts"
-      ${cleanupWhereClause}
-  `),
-  );
-
-const cleanupContactsJobs = () =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "ContactJobs"
-      WHERE "accountSid" IN ('', '${accountSid}')
-  `),
-  );
-
-const cleanupCsamReports = () =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "CSAMReports"
-      ${cleanupWhereClause}
-    `),
-  );
-
-const cleanupReferrals = () =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "CSAMReports"
-      ${cleanupWhereClause}
-    `),
-  );
-
 // eslint-disable-next-line @typescript-eslint/no-shadow
 const getContactByTaskId = (taskId: string, accountSid: string) =>
   db.oneOrNone(selectSingleContactByTaskId('Contacts'), { accountSid, taskId });
-
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const deleteContactById = (id: number, accountSid: string) =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "Contacts"
-      WHERE "id" = ${id} AND "accountSid" = '${accountSid}';
-  `),
-  );
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
 const deleteContactJobById = (id: number, accountSid: string) =>
@@ -151,15 +100,6 @@ const selectJobsByContactId = (contactId: number, accountSid: string) =>
   db.task(t =>
     t.manyOrNone(`
       SELECT * FROM "ContactJobs"
-      WHERE "contactId" = ${contactId} AND "accountSid" = '${accountSid}';
-    `),
-  );
-
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const deleteJobsByContactId = (contactId: number, accountSid: string) =>
-  db.task(t =>
-    t.manyOrNone(`
-      DELETE FROM "ContactJobs"
       WHERE "contactId" = ${contactId} AND "accountSid" = '${accountSid}';
     `),
   );
@@ -233,7 +173,14 @@ describe('/contacts route', () => {
       expect(response.body.error).toBe('Authorization failed');
     });
 
-    each([
+    type CreateContactTestCase = {
+      contact: CreateContactPayload;
+      changeDescription?: string;
+      expectedGetContact?: Partial<contactDb.Contact>;
+      finalize?: boolean;
+    };
+
+    const createContactTestCases: CreateContactTestCase[] = [
       {
         contact: contact1,
         changeDescription: 'callType is Child calling about self',
@@ -294,35 +241,50 @@ describe('/contacts route', () => {
           number: null,
           channel: null,
           conversationDuration: null,
-          accountSid: null,
           timeOfContact: null,
           taskId: 'empty-contact-tasksid',
           channelSid: null,
           serviceSid: null,
         },
         expectedGetContact: {
-          rawJson: {},
+          rawJson: {} as ContactRawJson,
           twilioWorkerId: '',
           helpline: '',
           queueName: null,
           number: '',
           channel: '',
           conversationDuration: null,
-          accountSid: '',
           taskId: 'empty-contact-tasksid',
           channelSid: '',
           serviceSid: '',
         },
         changeDescription: 'missing fields (filled with defaults)',
       },
-    ]).test(
+      {
+        contact: contact1,
+        changeDescription: 'callType is Child calling about self',
+        finalize: false,
+        expectedGetContact: {
+          ...contact1,
+          rawJson: {
+            ...contact1.rawJson,
+          } as ContactRawJson,
+          finalizedAt: undefined,
+        } as Partial<contactDb.Contact>,
+      },
+    ];
+
+    each(createContactTestCases).test(
       'should return 200 when $changeDescription',
-      async ({ contact, expectedGetContact = null }) => {
+      async ({ contact, expectedGetContact = null, finalize = true }) => {
         // const updateSpy = jest.spyOn(CSAMReport, 'update');
 
         const expected = expectedGetContact || contact;
 
-        const res = await request.post(route).set(headers).send(contact);
+        const res = await request
+          .post(`${route}?finalize=${finalize}`)
+          .set(headers)
+          .send(contact);
 
         expect(res.status).toBe(200);
         expect(res.body.referrals).toStrictEqual(contact.referrals || []);
@@ -1492,629 +1454,6 @@ describe('/contacts route', () => {
         // // Remove records to not interfere with following tests
         await deleteCsamReportsByContactId(createdContact.id, createdContact.accountSid);
         await deleteContactById(createdContact.id, createdContact.accountSid);
-      });
-    });
-  });
-
-  describe('/contacts/:contactId route', () => {
-    describe('PATCH', () => {
-      type TestOptions = {
-        patch: PatchPayload['rawJson'];
-        description: string;
-        original?: ContactRawJson;
-        expected: ContactRawJsonWithLegacyCategories;
-      };
-      const subRoute = contactId => `${route}/${contactId}`;
-
-      test('should return 401', async () => {
-        const createdContact = await contactApi.createContact(
-          accountSid,
-          workerSid,
-          true,
-          {
-            ...contact1,
-            rawJson: <ContactRawJson>{},
-            csamReports: [],
-          },
-          { user: twilioUser(workerSid, []), can: () => true },
-        );
-        try {
-          const response = await request.patch(subRoute(createdContact.id)).send({});
-
-          expect(response.status).toBe(401);
-          expect(response.body.error).toBe('Authorization failed');
-        } finally {
-          await deleteContactById(createdContact.id, createdContact.accountSid);
-        }
-      });
-      describe('rawJson changes', () => {
-        const sampleRawJson: ContactRawJson = {
-          ...(contact1.rawJson as ContactRawJson),
-          categories: {
-            a: ['a2'],
-            b: ['b1'],
-          },
-        };
-        const sampleRawJsonWithLegacyCategories = {
-          ...sampleRawJson,
-          caseInformation: {
-            ...sampleRawJson.caseInformation,
-            categories: {
-              a: { a2: true },
-              b: { b1: true },
-            },
-          },
-        };
-        const tests: TestOptions[] = [
-          {
-            description: 'set callType to data call type',
-            patch: {
-              callType: 'Child calling about self',
-            },
-            expected: {
-              callType: 'Child calling about self',
-              caseInformation: {
-                categories: {},
-              },
-            },
-          },
-          {
-            description: 'set callType to non data call type',
-            patch: {
-              callType: 'Hang up',
-            },
-            expected: {
-              callType: 'Hang up',
-              caseInformation: {
-                categories: {},
-              },
-            },
-          },
-          {
-            description: 'add child information',
-            patch: {
-              childInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'property',
-              },
-            },
-            expected: {
-              childInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'property',
-              },
-              caseInformation: {
-                categories: {},
-              },
-            },
-          },
-          {
-            description: 'add caller information',
-            patch: {
-              callerInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'other property',
-              },
-            },
-            expected: {
-              callerInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'other property',
-              },
-              caseInformation: {
-                categories: {},
-              },
-            },
-          },
-          {
-            description: 'add case information and categories',
-            patch: {
-              caseInformation: {
-                other: 'case property',
-              },
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-            expected: {
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-              caseInformation: {
-                other: 'case property',
-                categories: {
-                  category1: { subcategory1: true, subcategory2: true },
-                },
-              },
-            },
-          },
-          {
-            description: 'add case information',
-            patch: {
-              caseInformation: {
-                other: 'case property',
-              },
-            },
-            expected: {
-              caseInformation: {
-                other: 'case property',
-                categories: {},
-              },
-            },
-          },
-          {
-            description: 'add categories',
-            patch: {
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-              caseInformation: {},
-            },
-            expected: {
-              caseInformation: {
-                categories: {
-                  category1: { subcategory1: true, subcategory2: true },
-                },
-              },
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-          },
-
-          {
-            description: 'overwrite callType as data call type',
-            original: sampleRawJson,
-            patch: {
-              callType: 'Child calling about self',
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              callType: 'Child calling about self',
-            },
-          },
-          {
-            description: 'overwrite callType as non data call type',
-            original: sampleRawJson,
-            patch: {
-              callType: 'Hang up',
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              callType: 'Hang up',
-            },
-          },
-          {
-            description: 'overwrite child information',
-            original: sampleRawJson,
-            patch: {
-              childInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'property',
-              },
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              childInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'property',
-              },
-            },
-          },
-          {
-            original: sampleRawJson,
-            description: 'overwrite caller information',
-            patch: {
-              callerInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'other property',
-              },
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              callerInformation: {
-                firstName: 'Lorna',
-                lastName: 'Ballantyne',
-                some: 'other property',
-              },
-            },
-          },
-          {
-            original: sampleRawJson,
-            description: 'overwrite case information and categories',
-            patch: {
-              caseInformation: {
-                other: 'overwrite case property',
-              },
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              caseInformation: {
-                other: 'overwrite case property',
-                categories: {
-                  category1: { subcategory1: true, subcategory2: true },
-                },
-              },
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-          },
-          {
-            original: sampleRawJson,
-            description: 'overwrite case information',
-            patch: {
-              caseInformation: {
-                other: 'case property',
-              },
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              caseInformation: {
-                other: 'case property',
-                categories: sampleRawJsonWithLegacyCategories.caseInformation.categories,
-              },
-            },
-          },
-          {
-            original: sampleRawJson,
-            description: 'overwrite categories',
-            patch: {
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-            expected: {
-              ...sampleRawJsonWithLegacyCategories,
-              caseInformation: {
-                ...sampleRawJsonWithLegacyCategories.caseInformation,
-                categories: {
-                  category1: {
-                    subcategory1: true,
-                    subcategory2: true,
-                  },
-                },
-              },
-
-              categories: {
-                category1: ['subcategory1', 'subcategory2'],
-              },
-            },
-          },
-        ];
-        each(tests).test(
-          'should $description if that is specified in the payload',
-          async ({ patch, expected, original }: TestOptions) => {
-            const createdContact = await contactApi.createContact(
-              accountSid,
-              workerSid,
-              true,
-              {
-                ...contact1,
-                rawJson: original || <ContactRawJson>{},
-                csamReports: [],
-              },
-              { user: twilioUser(workerSid, []), can: () => true },
-            );
-            try {
-              const existingContactId = createdContact.id;
-              const response = await request
-                .patch(subRoute(existingContactId))
-                .set(headers)
-                .send({ rawJson: patch });
-
-              expect(response.status).toBe(200);
-              const { categories, ...caseInformationWithoutLegacyCategories } =
-                expected?.caseInformation ?? {};
-              const expectedInDb: Partial<ContactRawJson> = expected?.caseInformation
-                ? {
-                    ...expected,
-                    caseInformation: caseInformationWithoutLegacyCategories as Record<
-                      string,
-                      string | boolean
-                    >,
-                  }
-                : (expected as Partial<ContactRawJson>);
-              // Bodge a corner case where an absent caseInformation is untouched by the patch operation
-              if (
-                !original?.caseInformation &&
-                !patch?.caseInformation &&
-                !patch?.categories
-              ) {
-                delete expectedInDb.caseInformation;
-              }
-              expect(response.body).toStrictEqual({
-                ...createdContact,
-                timeOfContact: expect.toParseAsDate(createdContact.timeOfContact),
-                createdAt: expect.toParseAsDate(createdContact.createdAt),
-                finalizedAt: expect.toParseAsDate(createdContact.finalizedAt),
-                updatedAt: expect.toParseAsDate(),
-                updatedBy: workerSid,
-                rawJson: expected,
-                csamReports: [],
-                referrals: [],
-              });
-              // Test the association
-              expect(response.body.csamReports).toHaveLength(0);
-              const savedContact = await contactDb.getById(accountSid, existingContactId);
-
-              expect(savedContact).toStrictEqual({
-                ...createdContact,
-                createdAt: expect.toParseAsDate(createdContact.createdAt),
-                updatedAt: expect.toParseAsDate(),
-                updatedBy: workerSid,
-                rawJson: expectedInDb,
-                csamReports: [],
-                referrals: [],
-              });
-            } finally {
-              await deleteContactById(createdContact.id, createdContact.accountSid);
-            }
-          },
-        );
-      });
-
-      describe('Changes outside rawJson', () => {
-        beforeEach(async () => {
-          // Clean what's been created so far
-          await cleanupCsamReports();
-          await cleanupReferrals();
-          await cleanupContactsJobs();
-          await cleanupContacts();
-          await cleanupCases();
-        });
-
-        test('Not permitted on finalized contact', async () => {
-          const createdContact = await contactApi.createContact(
-            accountSid,
-            workerSid,
-            true,
-            contact1,
-            { user: twilioUser(workerSid, []), can: () => true },
-          );
-          const response = await request
-            .patch(subRoute(createdContact.id))
-            .set(headers)
-            .send({ conversationDuration: 1337 });
-
-          expect(response.status).toBe(401);
-        });
-
-        type FullPatchTestOptions = {
-          patch: PatchPayload;
-          description: string;
-          originalDifferences?: PatchPayload;
-          expectedDifferences?: PatchPayload;
-        };
-
-        const testCases: FullPatchTestOptions[] = [
-          {
-            description: 'patches conversationDuration',
-            patch: {
-              conversationDuration: 1337,
-            },
-            expectedDifferences: {
-              conversationDuration: 1337,
-            },
-            originalDifferences: {
-              conversationDuration: 42,
-            },
-          },
-        ];
-        each(testCases).test(
-          'should $description if that is specified in the payload for a draft contact',
-          async ({
-            patch,
-            expectedDifferences,
-            originalDifferences,
-          }: FullPatchTestOptions) => {
-            const original: CreateContactPayload = {
-              ...contact1,
-              ...originalDifferences,
-              rawJson: {
-                ...contact1.rawJson,
-                ...originalDifferences?.rawJson,
-              },
-            };
-            const createdContact = await contactApi.createContact(
-              accountSid,
-              workerSid,
-              false,
-              original,
-              { user: twilioUser(workerSid, []), can: () => true },
-            );
-            const expected: WithLegacyCategories<contactDb.Contact> = {
-              ...createdContact,
-              ...expectedDifferences,
-              rawJson: {
-                ...createdContact.rawJson,
-                ...expectedDifferences?.rawJson,
-                caseInformation: {
-                  ...createdContact.rawJson!.caseInformation,
-                  ...expectedDifferences?.rawJson?.caseInformation,
-                  categories: {},
-                },
-              },
-            };
-            try {
-              const existingContactId = createdContact.id;
-              const response = await request
-                .patch(subRoute(existingContactId))
-                .set(headers)
-                .send(patch);
-
-              expect(response.status).toBe(200);
-              const { categories, ...caseInformationWithoutLegacyCategories } =
-                expected.rawJson?.caseInformation ?? {};
-              const expectedInDb: contactApi.Contact = expected.rawJson?.caseInformation
-                ? ({
-                    ...expected,
-                    rawJson: {
-                      ...expected.rawJson,
-                      caseInformation: caseInformationWithoutLegacyCategories as Record<
-                        string,
-                        string | boolean
-                      >,
-                    },
-                  } as contactApi.Contact)
-                : (expected as contactApi.Contact);
-              // Bodge a corner case where an absent caseInformation is untouched by the patch operation
-              if (
-                !original.rawJson?.caseInformation &&
-                !patch.rawJson?.caseInformation &&
-                !patch.rawJson?.categories
-              ) {
-                delete (expectedInDb.rawJson as any).caseInformation;
-              }
-              expect(response.body).toStrictEqual({
-                ...expected,
-                timeOfContact: expect.toParseAsDate(expected.timeOfContact),
-                createdAt: expect.toParseAsDate(expected.createdAt),
-                updatedAt: expect.toParseAsDate(),
-                updatedBy: workerSid,
-                referrals: [],
-              });
-              // Test the association
-              expect(response.body.csamReports).toHaveLength(0);
-              const savedContact = await contactDb.getById(accountSid, existingContactId);
-
-              expect(savedContact).toStrictEqual({
-                ...expectedInDb,
-                createdAt: expect.toParseAsDate(createdContact.createdAt),
-                updatedAt: expect.toParseAsDate(),
-                updatedBy: workerSid,
-                csamReports: [],
-                referrals: [],
-              });
-            } finally {
-              await deleteContactById(createdContact.id, createdContact.accountSid);
-            }
-          },
-        );
-      });
-
-      test('use non-existent contactId should return 404', async () => {
-        const contactToBeDeleted = await contactApi.createContact(
-          accountSid,
-          workerSid,
-          true,
-          <any>contact1,
-          { user: twilioUser(workerSid, []), can: () => true },
-        );
-        const nonExistingContactId = contactToBeDeleted.id;
-        await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
-        const response = await request
-          .patch(subRoute(nonExistingContactId))
-          .set(headers)
-          .send({
-            rawJson: {
-              name: { firstName: 'Lorna', lastName: 'Ballantyne' },
-              some: 'property',
-            },
-          });
-
-        expect(response.status).toBe(404);
-      });
-
-      test('malformed payload should return 400', async () => {
-        const contact = await contactApi.createContact(
-          accountSid,
-          workerSid,
-          true,
-          <any>{ ...contact1, taskId: 'malformed-task-id' },
-          { user: twilioUser(workerSid, []), can: () => true },
-        );
-        const response = await request.patch(subRoute(contact.id)).set(headers).send([]);
-
-        expect(response.status).toBe(400);
-      });
-
-      test('no body should be a noop', async () => {
-        const createdContact = await contactApi.createContact(
-          accountSid,
-          workerSid,
-          true,
-          <any>contact1,
-          { user: twilioUser(workerSid, []), can: () => true },
-        );
-        const response = await request
-          .patch(subRoute(createdContact.id))
-          .set(headers)
-          .send();
-
-        expect(response.status).toBe(200);
-        expect(response.body).toStrictEqual({
-          ...createdContact,
-          timeOfContact: expect.toParseAsDate(createdContact.timeOfContact),
-          createdAt: expect.toParseAsDate(createdContact.createdAt),
-          finalizedAt: expect.toParseAsDate(createdContact.finalizedAt),
-          updatedAt: expect.toParseAsDate(),
-          updatedBy: workerSid,
-        });
-      });
-
-      each([
-        {
-          expectTranscripts: true,
-          description: `with viewExternalTranscript includes transcripts`,
-        },
-        {
-          expectTranscripts: false,
-          description: `without viewExternalTranscript excludes transcripts`,
-        },
-      ]).test(`$description`, async ({ expectTranscripts }) => {
-        const createdContact = await contactApi.createContact(
-          accountSid,
-          workerSid,
-          true,
-          withTaskIdAndTranscript,
-          { user: twilioUser(workerSid, []), can: () => true },
-        );
-        if (!expectTranscripts) {
-          setRules(ruleFileWithOneActionOverride('viewExternalTranscript', false));
-        } else {
-          useOpenRules();
-        }
-
-        const res = await request
-          .patch(`${route}/${createdContact.id}`)
-          .set(headers)
-          .send({ rawJson: createdContact.rawJson });
-        expect(res.status).toBe(200);
-
-        if (expectTranscripts) {
-          expect(
-            (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
-          ).toBeTruthy();
-          expect(
-            (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-              cm => cm.store === 'S3',
-            ),
-          ).toBeTruthy();
-        } else {
-          expect(
-            (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
-          ).toBeFalsy();
-          expect(
-            (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-              cm => cm.store === 'S3',
-            ),
-          ).toBeFalsy();
-        }
-
-        await deleteJobsByContactId(createdContact.id, createdContact.accountSid);
-        await deleteContactById(createdContact.id, createdContact.accountSid);
-        useOpenRules();
       });
     });
   });

--- a/hrm-domain/hrm-service/service-tests/permissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/permissions.test.ts
@@ -155,7 +155,11 @@ describe('/permissions/:action route with contact objectType', () => {
           serviceSid: 'serviceSid',
         } as NewContactRecord;
 
-        const { contact: createdContact } = await contactDB.create()(accountSid, contact);
+        const { contact: createdContact } = await contactDB.create()(
+          accountSid,
+          contact,
+          true,
+        );
         createdContacts[accountSid] = createdContact;
 
         await Promise.all(

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -183,7 +183,7 @@ contactsRouter.patch(
   async (req, res) => {
     const { accountSid, user } = req;
     const { contactId } = req.params;
-    const finalize = req.query.finalize === 'false'; // Default to false for backwards compatibility
+    const finalize = req.query.finalize === 'true'; // Default to false for backwards compatibility
     try {
       const contact = await patchContact(
         accountSid,

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -115,13 +115,13 @@ const validatePatchPayload = ({ body }: Request, res: Response, next: NextFuncti
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const canEditContact = asyncHandler(async (req, res, next) => {
   if (!req.isAuthorized()) {
-    const { accountSid, user, can } = req;
+    const { accountSid, user, can, body } = req;
     const { contactId } = req.params;
 
     try {
       const contactObj = await getContactById(accountSid, contactId);
       if (contactObj.finalizedAt) {
-        const updatedProps = Object.keys(req.body ?? {}) as (keyof PatchPayload)[];
+        const updatedProps = Object.keys(body ?? {}) as (keyof PatchPayload)[];
         const isOnlyEditingForm = updatedProps.every(
           prop => prop === 'rawJson' || prop === 'referrals',
         );
@@ -153,7 +153,7 @@ const canEditContact = asyncHandler(async (req, res, next) => {
           if (
             await isTwilioTaskTransferTarget(
               twilioClient,
-              res.body?.taskSid,
+              body?.taskId,
               contactObj.taskId,
               user.workerSid,
             )

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -146,7 +146,10 @@ const canEditContact = asyncHandler(async (req, res, next) => {
           // It the contact record doesn't show this user as the contact owner, but Twilio shows that they are having the associated task transferred to them, permit the edit
           // Long term it's wrong for HRM to be verifying this itself - we should probably initiate updates for the contact record from the backend transfer logic rather than Flex in future.
           // Then HRM just needs to validate the request is coming from a valid backend service with permission to make the edit.
-          const twilioClient = await getClient({ accountSid });
+          const twilioClient = await getClient({
+            accountSid,
+            authToken: process.env[`TWILIO_AUTH_TOKEN_${accountSid}`],
+          });
           if (
             await isTwilioTaskTransferTarget(
               twilioClient,

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -171,6 +171,7 @@ const canEditContact = asyncHandler(async (req, res, next) => {
       ) {
         throw createError(404);
       } else {
+        console.error('Failed to authorize contact editing', err);
         throw createError(500);
       }
     }

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -24,6 +24,7 @@ import {
   getContactById,
   addConversationMediaToContact,
   getContactByTaskId,
+  PatchPayload,
 } from './contact';
 import asyncHandler from '../async-handler';
 import type { Request, Response, NextFunction } from 'express';
@@ -121,7 +122,14 @@ const canEditContact = asyncHandler(async (req, res, next) => {
     try {
       const contactObj = await getContactById(accountSid, contactId);
       if (contactObj.finalizedAt) {
-        if (can(user, actionsMaps.contact.EDIT_CONTACT, contactObj)) {
+        const updatedProps = Object.keys(req.body ?? {}) as (keyof PatchPayload)[];
+        const isOnlyEditingForm = updatedProps.every(
+          prop => prop === 'rawJson' || prop === 'referrals',
+        );
+        if (
+          isOnlyEditingForm &&
+          can(user, actionsMaps.contact.EDIT_CONTACT, contactObj)
+        ) {
           req.authorize();
         } else {
           req.unauthorize();

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -28,8 +28,7 @@ import {
 } from './contact';
 import asyncHandler from '../async-handler';
 import type { Request, Response, NextFunction } from 'express';
-import isTwilioTaskTransferTarget from '@tech-matters/twilio-client/isTwilioTaskTransferTarget';
-import { getClient } from '@tech-matters/twilio-client/dist';
+import { getClient, isTwilioTaskTransferTarget } from '@tech-matters/twilio-client';
 
 const contactsRouter = SafeRouter();
 

--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -127,8 +127,13 @@ const canEditContact = asyncHandler(async (req, res, next) => {
           req.unauthorize();
         }
       } else {
-        // If there is no finalized date, then the contact is a draft and can only be edited by the worker who created it
-        if (contactObj.createdBy === user.workerSid) {
+        // If there is no finalized date, then the contact is a draft and can only be edited by the worker who created it or the one who owns it.
+        // Offline contacts potentially need to be edited by a creator that won't own them.
+        // Transferred tasks need to be edited by an owner that didn't create them.
+        if (
+          contactObj.createdBy === user.workerSid ||
+          contactObj.twilioWorkerId === user.workerSid
+        ) {
           req.authorize();
         } else {
           // It the contact record doesn't show this user as the contact owner, but Twilio shows that they are having the associated task transferred to them, permit the edit

--- a/hrm-domain/hrm-service/src/contact/contact.ts
+++ b/hrm-domain/hrm-service/src/contact/contact.ts
@@ -284,6 +284,7 @@ const findS3StoredTranscriptPending = (
 export const createContact = async (
   accountSid: string,
   createdBy: string,
+  finalize: boolean,
   newContact: CreateContactPayload,
   { can, user }: { can: ReturnType<typeof setupCanForRules>; user: TwilioUser },
 ): Promise<WithLegacyCategories<Contact>> => {
@@ -318,6 +319,7 @@ export const createContact = async (
         const { contact, isNewRecord } = await create(conn)(
           accountSid,
           completeNewContact,
+          finalize,
         );
 
         let contactResult: Contact;
@@ -420,6 +422,7 @@ export const createContact = async (
 export const patchContact = async (
   accountSid: string,
   updatedBy: string,
+  finalize: boolean,
   contactId: string,
   contactPatch: PatchPayload,
   { can, user }: { can: ReturnType<typeof setupCanForRules>; user: TwilioUser },
@@ -439,7 +442,7 @@ export const patchContact = async (
         });
       }
     }
-    const updated = await patch(conn)(accountSid, contactId, {
+    const updated = await patch(conn)(accountSid, contactId, finalize, {
       updatedBy,
       ...restOfPatch,
       ...rawJson,

--- a/hrm-domain/hrm-service/src/contact/sql/contact-update-sql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contact-update-sql.ts
@@ -40,7 +40,8 @@ SET "rawJson" = COALESCE("rawJson", '{}'::JSONB)
   "channelSid" =   COALESCE($<channelSid>, "channelSid"),
   "serviceSid" =   COALESCE($<serviceSid>, "serviceSid"),
   "updatedAt" = CURRENT_TIMESTAMP,
-  "caseId" =   COALESCE($<caseId>, "caseId")
+  "caseId" =   COALESCE($<caseId>, "caseId"),
+  "finalizedAt" = COALESCE("finalizedAt", (CASE WHEN $<finalize> = true THEN CURRENT_TIMESTAMP ELSE NULL END))
 ${ID_WHERE_CLAUSE}
 RETURNING *
 )

--- a/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
@@ -18,14 +18,7 @@ import * as pgPromise from 'pg-promise';
 import { mockConnection, mockTask, mockTransaction } from '../mock-db';
 import { search, create } from '../../src/contact/contact-data-access';
 import { ContactBuilder } from './contact-builder';
-import {
-  NewContactRecord,
-  insertContactSql,
-} from '../../src/contact/sql/contact-insert-sql';
-
-jest.mock('../../src/contact/sql/contact-insert-sql', () => ({
-  insertContactSql: jest.fn().mockReturnValue('MOCKED INSERT STATEMENT'),
-}));
+import { NewContactRecord } from '../../src/contact/sql/contact-insert-sql';
 
 let conn: pgPromise.ITask<unknown>;
 
@@ -64,16 +57,14 @@ describe('create', () => {
 
     jest.spyOn(conn, 'one').mockResolvedValue(returnValue);
 
-    const created = await create()('parameter account-sid', sampleNewContact);
-    expect(insertContactSql).toHaveBeenCalledWith({
+    const created = await create()('parameter account-sid', sampleNewContact, true);
+    expect(conn.one).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), {
       ...sampleNewContact,
       updatedAt: expect.anything(),
       createdAt: expect.anything(),
       accountSid: 'parameter account-sid',
+      finalize: true,
     });
-    expect(conn.one).toHaveBeenCalledWith(
-      expect.stringContaining('MOCKED INSERT STATEMENT'),
-    );
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({
       contact: returnedContact,
@@ -87,16 +78,14 @@ describe('create', () => {
 
     jest.spyOn(conn, 'one').mockResolvedValue(returnValue);
 
-    const created = await create()('parameter account-sid', sampleNewContact);
-    expect(insertContactSql).toHaveBeenCalledWith({
+    const created = await create()('parameter account-sid', sampleNewContact, true);
+    expect(conn.one).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), {
       ...sampleNewContact,
       updatedAt: expect.anything(),
       createdAt: expect.anything(),
       accountSid: 'parameter account-sid',
+      finalize: true,
     });
-    expect(conn.one).toHaveBeenCalledWith(
-      expect.stringContaining('MOCKED INSERT STATEMENT'),
-    );
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({
       contact: returnedContact,

--- a/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
@@ -178,16 +178,21 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       sampleLegacyCreateContactPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...sampleCreateContactPayload,
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...sampleCreateContactPayload,
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createReferralMock).not.toHaveBeenCalled();
@@ -226,23 +231,28 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       minimalLegacyPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...minimalPayload,
-      createdBy: 'contact-creator',
-      helpline: '',
-      number: '',
-      channel: '',
-      channelSid: '',
-      serviceSid: '',
-      taskId: 'a task',
-      twilioWorkerId: '',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...minimalPayload,
+        createdBy: 'contact-creator',
+        helpline: '',
+        number: '',
+        channel: '',
+        channelSid: '',
+        serviceSid: '',
+        taskId: 'a task',
+        twilioWorkerId: '',
+      },
+      true,
+    );
 
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createReferralMock).not.toHaveBeenCalled();
@@ -264,17 +274,22 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       legacyPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...payload,
-      timeOfContact: expect.any(Date),
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...payload,
+        timeOfContact: expect.any(Date),
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createReferralMock).not.toHaveBeenCalled();
@@ -296,16 +311,21 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       legacyPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...payload,
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...payload,
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createReferralMock).not.toHaveBeenCalled();
@@ -341,14 +361,24 @@ describe('createContact', () => {
       ...sampleLegacyCreateContactPayload,
       csamReports,
     };
-    const returnValue = await createContact(accountSid, 'contact-creator', payload, {
-      can: () => true,
-      user: twilioUser(workerSid, []),
-    });
-    expect(createContactMock).toHaveBeenCalledWith(accountSid, {
-      ...sampleCreateContactPayload,
-      createdBy: 'contact-creator',
-    });
+    const returnValue = await createContact(
+      accountSid,
+      'contact-creator',
+      true,
+      payload,
+      {
+        can: () => true,
+        user: twilioUser(workerSid, []),
+      },
+    );
+    expect(createContactMock).toHaveBeenCalledWith(
+      accountSid,
+      {
+        ...sampleCreateContactPayload,
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(connectCsamMock).toHaveBeenCalledTimes(1);
     expect(connectCsamMock).toHaveBeenCalledWith(
@@ -388,16 +418,21 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       payload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...sampleCreateContactPayload,
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...sampleCreateContactPayload,
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(createReferralMock).toHaveBeenCalledTimes(2);
     referrals.forEach(referral =>
@@ -425,17 +460,22 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       legacyPayload as any,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
       },
     );
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...payload,
-      queueName: '',
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...payload,
+        queueName: '',
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createReferralMock).not.toHaveBeenCalled();
@@ -478,6 +518,7 @@ describe('createContact', () => {
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
+      true,
       payload,
       {
         can: () => true,
@@ -485,10 +526,14 @@ describe('createContact', () => {
       },
     );
 
-    expect(createContactMock).toHaveBeenCalledWith('parameter account-sid', {
-      ...sampleCreateContactPayload,
-      createdBy: 'contact-creator',
-    });
+    expect(createContactMock).toHaveBeenCalledWith(
+      'parameter account-sid',
+      {
+        ...sampleCreateContactPayload,
+        createdBy: 'contact-creator',
+      },
+      true,
+    );
 
     expect(createReferralMock).toHaveBeenCalledTimes(2);
     referrals.forEach(referral =>
@@ -562,6 +607,7 @@ describe('patchContact', () => {
     const result = await patchContact(
       'accountSid',
       'contact-patcher',
+      true,
       '1234',
       samplePatch,
       {
@@ -570,7 +616,7 @@ describe('patchContact', () => {
       },
     );
     expect(result).toStrictEqual(mockReturnContact);
-    expect(patchSpy).toHaveBeenCalledWith('accountSid', '1234', {
+    expect(patchSpy).toHaveBeenCalledWith('accountSid', '1234', true, {
       updatedBy: 'contact-patcher',
       childInformation: {
         firstName: 'Charlotte',
@@ -593,7 +639,7 @@ describe('patchContact', () => {
     jest.spyOn(contactDb, 'patch').mockReturnValue(patchSpy);
     patchSpy.mockResolvedValue(undefined);
     expect(
-      patchContact('accountSid', 'contact-patcher', '1234', samplePatch, {
+      patchContact('accountSid', 'contact-patcher', true, '1234', samplePatch, {
         can: () => true,
         user: twilioUser(workerSid, []),
       }),

--- a/packages/twilio-client/index.ts
+++ b/packages/twilio-client/index.ts
@@ -19,6 +19,8 @@ import { getSsmParameter } from '@tech-matters/ssm-cache';
 
 import { getMockClient } from './mockClient';
 
+export { default } from './isTwilioTaskTransferTarget';
+
 type ClientCache = {
   [accountSid: string]: Twilio;
 };
@@ -35,8 +37,7 @@ const getClientOrMock = ({
   authToken: string;
 }): Twilio => {
   if (authToken === 'mockAuthToken') {
-    const mock = getMockClient({ accountSid }) as unknown as Twilio;
-    return mock;
+    return getMockClient({ accountSid }) as unknown as Twilio;
   }
 
   return new Twilio(accountSid, authToken);

--- a/packages/twilio-client/index.ts
+++ b/packages/twilio-client/index.ts
@@ -19,7 +19,8 @@ import { getSsmParameter } from '@tech-matters/ssm-cache';
 
 import { getMockClient } from './mockClient';
 
-export { default } from './isTwilioTaskTransferTarget';
+export { isTwilioTaskTransferTarget } from './isTwilioTaskTransferTarget';
+export { setMockTaskRouterWorkspaces } from './mockClient/taskRouterWorkspaces';
 
 type ClientCache = {
   [accountSid: string]: Twilio;

--- a/packages/twilio-client/isTwilioTaskTransferTarget.ts
+++ b/packages/twilio-client/isTwilioTaskTransferTarget.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Twilio } from 'twilio';
+import { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
+
+const isTwilioTaskTransferTarget = async (
+  twilioClient: Twilio,
+  taskSid: string,
+  originalTaskSid: string,
+  workerSid: string,
+) => {
+  // Search each workspace for the task - we could pass the workspace into HRM, but twilio sids are globally unique anyway
+  const workspaces = await twilioClient.taskrouter.workspaces.list();
+  let task: TaskInstance | undefined = undefined;
+  for (const workspace of workspaces) {
+    task = await workspace.tasks().get(taskSid).fetch();
+    if (task) {
+      break;
+    }
+  }
+  if (!task) {
+    console.warn(`Task ${taskSid} not found in any workspace`);
+    return false;
+  }
+
+  // Check that the task ID currently in the DB matches the original task ID
+  const taskAttributes = JSON.parse(task.attributes ?? '{}');
+  if (taskAttributes.transferMeta?.originalTask !== originalTaskSid) {
+    return false;
+  }
+
+  // Check that the worker attempting the edit is currently reserved on the task
+  const reservations = await task.reservations().list();
+  return Boolean(reservations.find(r => r.workerSid === workerSid));
+};
+
+export default isTwilioTaskTransferTarget;

--- a/packages/twilio-client/isTwilioTaskTransferTarget.ts
+++ b/packages/twilio-client/isTwilioTaskTransferTarget.ts
@@ -27,7 +27,12 @@ export const isTwilioTaskTransferTarget = async (
   const workspaces = await twilioClient.taskrouter.workspaces.list();
   let task: TaskInstance | undefined = undefined;
   for (const workspace of workspaces) {
-    task = await workspace.tasks().get(taskSid).fetch();
+    try {
+      task = await workspace.tasks().get(taskSid).fetch();
+    } catch (e) {
+      // Task not found in this workspace
+      console.log(`Task ${taskSid} not found in workspace ${workspace.sid}`);
+    }
     if (task) {
       break;
     }

--- a/packages/twilio-client/isTwilioTaskTransferTarget.ts
+++ b/packages/twilio-client/isTwilioTaskTransferTarget.ts
@@ -17,7 +17,7 @@
 import { Twilio } from 'twilio';
 import { TaskInstance } from 'twilio/lib/rest/taskrouter/v1/workspace/task';
 
-const isTwilioTaskTransferTarget = async (
+export const isTwilioTaskTransferTarget = async (
   twilioClient: Twilio,
   taskSid: string,
   originalTaskSid: string,
@@ -47,5 +47,3 @@ const isTwilioTaskTransferTarget = async (
   const reservations = await task.reservations().list();
   return Boolean(reservations.find(r => r.workerSid === workerSid));
 };
-
-export default isTwilioTaskTransferTarget;

--- a/packages/twilio-client/mockClient/getMockClient.ts
+++ b/packages/twilio-client/mockClient/getMockClient.ts
@@ -16,6 +16,7 @@
 
 import RestException from 'twilio/lib/base/RestException';
 import { chatMessageList } from './chatMessageList';
+import { taskRouterWorkspaces } from './taskRouterWorkspaces';
 
 export const getMockClient = ({ accountSid }: { accountSid: string }) => {
   return {
@@ -187,7 +188,7 @@ export const getMockClient = ({ accountSid }: { accountSid: string }) => {
     },
     taskrouter: {
       workspaces: {
-        list: () => Promise.resolve([]),
+        list: () => Promise.resolve(taskRouterWorkspaces),
       },
     },
   };

--- a/packages/twilio-client/mockClient/getMockClient.ts
+++ b/packages/twilio-client/mockClient/getMockClient.ts
@@ -185,5 +185,10 @@ export const getMockClient = ({ accountSid }: { accountSid: string }) => {
         }),
       },
     },
+    taskrouter: {
+      workspaces: {
+        list: () => Promise.resolve([]),
+      },
+    },
   };
 };

--- a/packages/twilio-client/mockClient/taskRouterWorkspaces.ts
+++ b/packages/twilio-client/mockClient/taskRouterWorkspaces.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 export let taskRouterWorkspaces: any[] = [];
 
 export const setMockTaskRouterWorkspaces = (workspaces: any[]) => {

--- a/packages/twilio-client/mockClient/taskRouterWorkspaces.ts
+++ b/packages/twilio-client/mockClient/taskRouterWorkspaces.ts
@@ -1,0 +1,5 @@
+export let taskRouterWorkspaces: any[] = [];
+
+export const setMockTaskRouterWorkspaces = (workspaces: any[]) => {
+  taskRouterWorkspaces = workspaces;
+};


### PR DESCRIPTION
## Description

* Adds a 'finalized date' to contacts in the HRM DB
* Sets all existing records with a finalized date equal to the created date
* Adds a flag to the PATCH and POST contact endpoints to finalize a contact
* Updates permissions for editing to always only allow the contact creator or owner to edit a draft contact, regardless of edit contact permissions 
OR
If the user is a valid transfer recipient for the task
* Limits editing of finalized contacts to form & referral changes, to realign with what is currently permitted
* Small HRM service refactor to break up contacts.test.ts a little

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
CHI-1434

### Verification steps

Automated tests (TODO)
