### PR TITLE
[Client Profiles]  endpoints to get available profile flags for an account

### DIFF
--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -106,7 +106,8 @@ profilesRouter.get('/profileFlags', publicEndpoint, async (req, res, next) => {
   }
 });
 
-profilesRouter.get('/profile/:profileId', publicEndpoint, async (req, res, next) => {
+// WARNING: this endpoint must be the last one in this router, because it will be used if none of the above regex matches the path
+profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;
     const { profileId } = req.params;

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -18,7 +18,7 @@ import { isErr } from '@tech-matters/types';
 import createError from 'http-errors';
 
 import { SafeRouter, publicEndpoint } from '../permissions';
-import { getProfilesByIdentifier, getProfile } from './profile';
+import { getProfilesByIdentifier, getProfile, getProfileFlags } from './profile';
 import { getContactsByProfileId } from '../contact/contact';
 import { getCasesByProfileId } from '../case/case';
 
@@ -87,7 +87,26 @@ profilesRouter.get('/:profileId/cases', publicEndpoint, async (req, res, next) =
   }
 });
 
-profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
+profilesRouter.get('/profileFlags', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+
+    console.log('accountSid', accountSid);
+
+    const result = await getProfileFlags(accountSid);
+
+    if (isErr(result)) {
+      return next(createError(result.statusCode, result.message));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    console.error(err);
+    return next(createError(500, err.message));
+  }
+});
+
+profilesRouter.get('/profile/:profileId', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;
     const { profileId } = req.params;

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -23,6 +23,7 @@ import {
   createIdentifierAndProfile,
   getIdentifierWithProfiles,
   getProfileById,
+  getProfileFlagsForAccount,
 } from './profile-data-access';
 
 export { Identifier, Profile, getIdentifierWithProfiles };
@@ -94,3 +95,5 @@ export const getProfilesByIdentifier = async (
     });
   }
 };
+
+export const getProfileFlags = getProfileFlagsForAccount;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-flags-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-flags-get-sql.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const getProfileFlagsByAccountSql = `
+  SELECT * FROM "ProfileFlags"
+  WHERE "accountSid" = $<accountSid> OR "accountSid" IS NULL
+`;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-flags-insert-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-flags-insert-sql.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { pgp } from '../../connection-pool';
+
+export type NewProfileFlagRecord = {
+  name: string;
+};
+
+export const insertProfileFlagSql = (
+  profileFlag: NewProfileFlagRecord & {
+    accountSid: string;
+    createdAt: Date;
+    updatedAt: Date;
+  },
+) => `
+  ${pgp.helpers.insert(
+    profileFlag,
+    ['accountSid', 'name', 'createdAt', 'updatedAt'],
+    'ProfileFlags',
+  )}
+  RETURNING *
+`;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -22,11 +22,6 @@ const WHERE_IDENTIFIER_CLAUSE = `
   )
 `;
 
-// export const lookupIdentifierSql = `
-//   SELECT * FROM "Identifiers"
-//   ${WHERE_IDENTIFIER_CLAUSE}
-// `;
-
 export const getProfileByIdSql = `
   WITH RelatedIdentifiers AS (
     SELECT

--- a/hrm-domain/lambdas/files-urls/tests/unit/getSignedS3Url.test.ts
+++ b/hrm-domain/lambdas/files-urls/tests/unit/getSignedS3Url.test.ts
@@ -40,6 +40,6 @@ describe('getSignedS3Url', () => {
     });
 
     const result = await getSignedS3Url(event);
-    expect(result).toEqual(newOk({ data: { media_url: mockSignedUrl } }));
+    expect(result.unwrap()).toEqual({ media_url: mockSignedUrl });
   });
 });

--- a/hrm-domain/lambdas/files-urls/tests/unit/parseParameters.test.ts
+++ b/hrm-domain/lambdas/files-urls/tests/unit/parseParameters.test.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import type { ALBEvent } from 'aws-lambda';
-import { newOk, newErr, isErr } from '@tech-matters/types';
+import { isErr } from '@tech-matters/types';
 import { parseParameters, ERROR_MESSAGES } from '../../parseParameters';
 import { mockPathParameters, mockQueryStringParameters, newAlbEvent } from '../__mocks__';
 

--- a/hrm-domain/lambdas/files-urls/tests/unit/parseParameters.test.ts
+++ b/hrm-domain/lambdas/files-urls/tests/unit/parseParameters.test.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import type { ALBEvent } from 'aws-lambda';
-import { newOk, newErr } from '@tech-matters/types';
+import { newOk, newErr, isErr } from '@tech-matters/types';
 import { parseParameters, ERROR_MESSAGES } from '../../parseParameters';
 import { mockPathParameters, mockQueryStringParameters, newAlbEvent } from '../__mocks__';
 
@@ -24,10 +24,9 @@ describe('parseParameters', () => {
       queryStringParameters: {},
     } as ALBEvent;
     const result = await parseParameters(event);
-    expect(result).toEqual(
-      newErr({
-        message: ERROR_MESSAGES.MISSING_REQUIRED_QUERY_STRING_PARAMETERS,
-      }),
+    expect(isErr(result)).toBeTruthy();
+    expect((result as any).message).toEqual(
+      ERROR_MESSAGES.MISSING_REQUIRED_QUERY_STRING_PARAMETERS,
     );
   });
 
@@ -39,11 +38,8 @@ describe('parseParameters', () => {
       },
     });
     const result = await parseParameters(event);
-    expect(result).toEqual(
-      newErr({
-        message: ERROR_MESSAGES.INVALID_METHOD,
-      }),
-    );
+    expect(isErr(result)).toBeTruthy();
+    expect((result as any).message).toEqual(ERROR_MESSAGES.INVALID_METHOD);
   });
 
   it('should return a 500 error for invalid fileType', async () => {
@@ -54,11 +50,8 @@ describe('parseParameters', () => {
       },
     });
     const result = await parseParameters(event);
-    expect(result).toEqual(
-      newErr({
-        message: ERROR_MESSAGES.INVALID_FILE_TYPE,
-      }),
-    );
+    expect(isErr(result)).toBeTruthy();
+    expect((result as any).message).toEqual(ERROR_MESSAGES.INVALID_FILE_TYPE);
   });
 
   it('should return a 500 error for missing required parameters for fileType', async () => {
@@ -71,10 +64,9 @@ describe('parseParameters', () => {
       },
     });
     const result = await parseParameters(event);
-    expect(result).toEqual(
-      newErr({
-        message: ERROR_MESSAGES.MISSING_REQUIRED_PARAMETERS_FOR_FILE_TYPE,
-      }),
+    expect(isErr(result)).toBeTruthy();
+    expect((result as any).message).toEqual(
+      ERROR_MESSAGES.MISSING_REQUIRED_PARAMETERS_FOR_FILE_TYPE,
     );
   });
 
@@ -83,13 +75,10 @@ describe('parseParameters', () => {
       queryStringParameters: mockQueryStringParameters,
     });
     const result = await parseParameters(event);
-    expect(result).toEqual(
-      newOk({
-        data: {
-          ...mockQueryStringParameters,
-          ...mockPathParameters,
-        },
-      }),
-    );
+    expect(isErr(result)).toBeFalsy();
+    expect(result.unwrap()).toEqual({
+      ...mockQueryStringParameters,
+      ...mockPathParameters,
+    });
   });
 });

--- a/packages/types/Result.ts
+++ b/packages/types/Result.ts
@@ -29,6 +29,7 @@ type ErrorResult = ResultBase & {
   message: string;
   statusCode: number;
   name: string;
+  readonly unwrap: () => never;
 };
 
 export const newErr = ({
@@ -41,12 +42,18 @@ export const newErr = ({
   message,
   statusCode,
   name,
+  unwrap: () => {
+    throw new Error(
+      `TResult Error: Attempted to unwrap Err variant with message: ${message}`,
+    );
+  },
 });
 
 type SuccessResult<TData> = ResultBase & {
   status: 'success';
   data: TData;
   statusCode: number;
+  readonly unwrap: () => TData;
 };
 
 type NewSuccessResultParms<TData> = {
@@ -62,6 +69,7 @@ export const newOk = <TData>({
   status: 'success',
   data,
   statusCode,
+  unwrap: () => data,
 });
 
 export type TResult<TData> = SuccessResult<TData> | ErrorResult;


### PR DESCRIPTION
## Description
This PR
- Exposes a new endpoint, `/profiles/profileFlags`, which accepots a `GET` method. This endpoint will return the list of profile flags for the account corresponding to the current request, plus the two default flags (that have a `null` value in the `accountSid` column) `blocked` and `abusive`.
- Moves the `/profiles/:profileId` endpoint to retrieve a single profile by id to `/profiles/profile/:profileId` to avoid regex collisions. This can be reverted but we must remember to serve this endpoint last in the router, since otherwise any endpoint served after this one that matches `/profiles/<something>` will try to be evaluated against the "get profile by id" one.
- Adds a new method to the Result type, `unwrap` which will:
  - Return the `data` value for the success variant.
  - Throw a new error for the Error variant.
This function is not safe to use in production code, but comes handy to avoid repeating code in test suites. I can rename it to something like `dangerousUnwrap` if needed, but it felt like adding training weels :P

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2122)
- [x] New tests added

### Verification steps
Trust service tests or
- Start local server (`npm run build && npm run start`).
- Hit the `/profiles/profileFlags` endpoint and confirm that the two default flags are returned from the endpoint.
- If desired, add one or more custom flags and confirm that this are also returned from the endpoint when queried again.