### PR TITLE
feat: associate/disassociate profile flags

### DIFF
--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -14,6 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import each from 'jest-each';
 import './case-validation';
 import { db } from '../src/connection-pool';
 import * as caseApi from '../src/case/case';
@@ -23,7 +24,6 @@ import { getRequest, getServer, headers, useOpenRules } from './server';
 import * as mocks from './mocks';
 import { mockSuccessfulTwilioAuthentication, mockingProxy } from '@tech-matters/testing';
 import { getOrCreateProfileWithIdentifier } from '../src/profile/profile';
-import { isErr } from '@tech-matters/types';
 import { IdentifierWithProfiles } from '../src/profile/profile-data-access';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 
@@ -57,12 +57,10 @@ beforeEach(async () => {
 
 describe('/profiles route', () => {
   const baseRoute = `/v0/accounts/${accountSid}/profiles`;
-
   const identifier = 'identifier';
 
   describe('/identifier/:identifier', () => {
     const buildRoute = (id: string) => `${baseRoute}/identifier/${id}`;
-
     const accounts = [accountSid, 'ANOTHER_ACCOUNT'];
 
     let createdProfiles: { [acc: string]: IdentifierWithProfiles };
@@ -75,15 +73,8 @@ describe('/profiles route', () => {
           accounts.map(acc => getOrCreateProfileWithIdentifier()(identifier, acc)),
         )
       )
-        .map(result => {
-          if (isErr(result)) {
-            throw new Error('Creating profile returned an error');
-          } else {
-            return result.data;
-          }
-        })
+        .map(result => result.unwrap())
         .reduce((accum, curr) => ({ ...accum, [curr.accountSid]: curr }), {});
-
       // Create one case for each
       createdCases = (
         await Promise.all(accounts.map(acc => caseApi.createCase(case1, acc, workerSid)))
@@ -171,90 +162,16 @@ describe('/profiles route', () => {
   });
 
   describe('/:profileId', () => {
-    const buildRoute = (id: number, subroute: 'contacts' | 'cases') =>
-      `${baseRoute}/${id}/${subroute}`;
-
-    const sortById = (a: { id: number }, b: { id: number }) => a.id - b.id;
-
     let createdProfile: IdentifierWithProfiles;
-    let createdCases: caseApi.Case[];
-    let createdContacts: Awaited<ReturnType<typeof contactApi.createContact>>[];
     beforeAll(async () => {
       // Create an identifier
       createdProfile = await getOrCreateProfileWithIdentifier()(
         identifier,
         accountSid,
-      ).then(result => {
-        if (isErr(result)) {
-          throw new Error('Creating profile returned an error');
-        }
-        return result.data;
-      });
-
-      // Create two cases
-      createdCases = await Promise.all(
-        [1, 2].map(() => caseApi.createCase(case1, accountSid, workerSid)),
-      );
-
-      // Create two contacts for each
-      createdContacts = await Promise.all(
-        createdCases.flatMap(createdCase =>
-          [1, 2].map(n =>
-            contactApi
-              .createContact(
-                createdCase.accountSid,
-                workerSid,
-                true,
-                {
-                  ...contact1,
-                  number: identifier,
-                  taskId: contact1.taskId + createdCase.id + n,
-                  profileId: createdProfile.profiles[0].id,
-                  identifierId: createdProfile.id,
-                },
-                {
-                  user: twilioUser(workerSid, []),
-                  can: () => true,
-                },
-              )
-              .then(contact =>
-                // Associate contact to case
-                contactApi.connectContactToCase(
-                  contact.accountSid,
-                  workerSid,
-                  String(contact.id),
-                  String(createdCase.id),
-                  {
-                    user: twilioUser(workerSid, []),
-                    can: () => true,
-                  },
-                ),
-              ),
-          ),
-        ),
-      );
-
-      createdCases = await Promise.all(
-        createdCases.map(c =>
-          caseApi.getCase(c.id, c.accountSid, {
-            user: twilioUser(workerSid, []),
-            can: () => true,
-          }),
-        ) as any,
-      );
+      ).then(result => result.unwrap());
     });
 
     afterAll(async () => {
-      await Promise.all(
-        Object.entries(createdContacts).map(([, c]) =>
-          deleteFromTableById('Contacts')(c.id, c.accountSid),
-        ),
-      );
-      await Promise.all(
-        Object.entries(createdCases).map(([, c]) =>
-          deleteFromTableById('Cases')(c.id, c.accountSid),
-        ),
-      );
       await Promise.all([
         ...createdProfile.profiles.map(p =>
           deleteFromTableById('Profiles')(p.id, p.accountSid),
@@ -263,77 +180,317 @@ describe('/profiles route', () => {
       ]);
     });
 
-    const convertContactToExpect = (
-      contact: contactApi.WithLegacyCategories<contactApi.Contact>,
-    ) => ({
-      ...contact,
-      createdAt: expect.toParseAsDate(),
-      updatedAt: expect.toParseAsDate(),
-      finalizedAt: expect.toParseAsDate(),
-      timeOfContact: expect.toParseAsDate(),
-      totalCount: expect.anything(),
-      id: expect.anything(),
-    });
+    describe('GET', () => {
+      const buildRoute = (id: number) => `${baseRoute}/${id}`;
 
-    describe('/contacts', () => {
-      // test('when identifier not exists, return 404', async () => {
-      //   const response = await request.get(buildRoute('not-exists')).set(headers);
-      //   expect(response.statusCode).toBe(404);
-      // });
+      test('when profile not exists, return 404', async () => {
+        const response = await request.get(buildRoute(0)).set(headers);
 
-      test('when profile exists, return 200', async () => {
+        expect(response.statusCode).toBe(404);
+      });
+
+      test('when profile exists, return 200 with profile data', async () => {
         const response = await request
-          .get(buildRoute(createdProfile.profiles[0].id, 'contacts'))
+          .get(buildRoute(createdProfile.profiles[0].id))
           .set(headers);
+
         expect(response.statusCode).toBe(200);
-        expect(response.body.count).toBe(createdContacts.length);
-        expect(response.body.contacts.sort(sortById)).toEqual(
-          expect.objectContaining(
-            createdContacts.sort(sortById).map(convertContactToExpect),
-          ),
-        );
+        console.log(response.body);
+        expect(response.body).toMatchObject(createdProfile.profiles[0]);
       });
     });
 
-    describe('/cases', () => {
-      // test('when identifier not exists, return 404', async () => {
-      //   const response = await request.get(buildRoute('not-exists')).set(headers);
-      //   expect(response.statusCode).toBe(404);
-      // });
+    describe('', () => {
+      const buildRoute = (id: number, subroute: 'contacts' | 'cases') =>
+        `${baseRoute}/${id}/${subroute}`;
 
-      test('when profile exists, return 200', async () => {
-        const response = await request
-          .get(buildRoute(createdProfile.profiles[0].id, 'cases'))
-          .set(headers);
-        expect(response.statusCode).toBe(200);
-        expect(response.body.count).toBe(createdCases.length);
-        expect(
-          response.body.cases
-            .map(({ createdAt, updatedAt, childName, totalCount, ...rest }) => ({
-              ...rest,
-              connectedContacts: rest.connectedContacts?.sort(sortById),
-            }))
-            .sort(sortById),
-        ).toStrictEqual(
-          createdCases
-            .map(({ createdAt, updatedAt, childName, ...rest }) => ({
-              ...rest,
-              connectedContacts: rest.connectedContacts?.sort(sortById),
-            }))
-            .sort(sortById),
+      const sortById = (a: { id: number }, b: { id: number }) => a.id - b.id;
+
+      let createdCases: caseApi.Case[];
+      let createdContacts: Awaited<ReturnType<typeof contactApi.createContact>>[];
+      beforeAll(async () => {
+        // Create two cases
+        createdCases = await Promise.all(
+          [1, 2].map(() => caseApi.createCase(case1, accountSid, workerSid)),
+        );
+
+        // Create two contacts for each
+        createdContacts = await Promise.all(
+          createdCases.flatMap(createdCase =>
+            [1, 2].map(n =>
+              contactApi
+                .createContact(
+                  createdCase.accountSid,
+                  workerSid,
+                  true,
+                  {
+                    ...contact1,
+                    number: identifier,
+                    taskId: contact1.taskId + createdCase.id + n,
+                    profileId: createdProfile.profiles[0].id,
+                    identifierId: createdProfile.id,
+                  },
+                  {
+                    user: twilioUser(workerSid, []),
+                    can: () => true,
+                  },
+                )
+                .then(contact =>
+                  // Associate contact to case
+                  contactApi.connectContactToCase(
+                    contact.accountSid,
+                    workerSid,
+                    String(contact.id),
+                    String(createdCase.id),
+                    {
+                      user: twilioUser(workerSid, []),
+                      can: () => true,
+                    },
+                  ),
+                ),
+            ),
+          ),
+        );
+
+        createdCases = await Promise.all(
+          createdCases.map(c =>
+            caseApi.getCase(c.id, c.accountSid, {
+              user: twilioUser(workerSid, []),
+              can: () => true,
+            }),
+          ) as any,
+        );
+      });
+
+      afterAll(async () => {
+        await Promise.all(
+          Object.entries(createdContacts).map(([, c]) =>
+            deleteFromTableById('Contacts')(c.id, c.accountSid),
+          ),
+        );
+        await Promise.all(
+          Object.entries(createdCases).map(([, c]) =>
+            deleteFromTableById('Cases')(c.id, c.accountSid),
+          ),
+        );
+      });
+
+      const convertContactToExpect = (
+        contact: contactApi.WithLegacyCategories<contactApi.Contact>,
+      ) => ({
+        ...contact,
+        createdAt: expect.toParseAsDate(),
+        updatedAt: expect.toParseAsDate(),
+        finalizedAt: expect.toParseAsDate(),
+        timeOfContact: expect.toParseAsDate(),
+        totalCount: expect.anything(),
+        id: expect.anything(),
+      });
+
+      describe('/contacts', () => {
+        describe('GET', () => {
+          // test('when identifier not exists, return 404', async () => {
+          //   const response = await request.get(buildRoute('not-exists')).set(headers);
+          //   expect(response.statusCode).toBe(404);
+          // });
+
+          test('when profile exists, return 200 with associated contacts', async () => {
+            const response = await request
+              .get(buildRoute(createdProfile.profiles[0].id, 'contacts'))
+              .set(headers);
+
+            expect(response.statusCode).toBe(200);
+            expect(response.body.count).toBe(createdContacts.length);
+            expect(response.body.contacts.sort(sortById)).toEqual(
+              expect.objectContaining(
+                createdContacts.sort(sortById).map(convertContactToExpect),
+              ),
+            );
+          });
+        });
+      });
+
+      describe('/cases', () => {
+        describe('GET', () => {
+          // test('when identifier not exists, return 404', async () => {
+          //   const response = await request.get(buildRoute('not-exists')).set(headers);
+          //   expect(response.statusCode).toBe(404);
+          // });
+
+          test('when profile exists, return 200 with associated cases', async () => {
+            const response = await request
+              .get(buildRoute(createdProfile.profiles[0].id, 'cases'))
+              .set(headers);
+
+            expect(response.statusCode).toBe(200);
+            expect(response.body.count).toBe(createdCases.length);
+            expect(
+              response.body.cases
+                .map(({ createdAt, updatedAt, childName, totalCount, ...rest }) => ({
+                  ...rest,
+                  connectedContacts: rest.connectedContacts?.sort(sortById),
+                }))
+                .sort(sortById),
+            ).toStrictEqual(
+              createdCases
+                .map(({ createdAt, updatedAt, childName, ...rest }) => ({
+                  ...rest,
+                  connectedContacts: rest.connectedContacts?.sort(sortById),
+                }))
+                .sort(sortById),
+            );
+          });
+        });
+      });
+    });
+
+    describe('/:profileFlagId', () => {
+      const buildRoute = (profileId: number, profileFlagId: number) =>
+        `${baseRoute}/${profileId}/flags/${profileFlagId}`;
+
+      let defaultFlags: profilesDB.ProfileFlag[];
+      beforeAll(async () => {
+        defaultFlags = await profilesDB
+          .getProfileFlagsForAccount(accountSid)
+          .then(result => result.unwrap());
+      });
+
+      describe('POST', () => {
+        each([
+          {
+            description: 'auth is missing',
+            expectStatus: 401,
+            customHeaders: {},
+          },
+          {
+            description: 'profile does not exists',
+            profileId: 0,
+            expectStatus: 500,
+          },
+          {
+            description: 'flag does not exists',
+            profileFlagId: 0,
+            expectStatus: 500,
+          },
+          {
+            description: 'profile and flag exist',
+            expectStatus: 200,
+            expectFunction: (response, profileId, profileFlagId) => {
+              expect(response.body.id).toBe(profileId);
+              expect(response.body.profileFlags).toContain(profileFlagId);
+            },
+          },
+        ]).test(
+          'when $description, returns $expectStatus',
+          async ({
+            profileId = createdProfile.profiles[0].id,
+            profileFlagId = defaultFlags[0].id,
+            expectStatus,
+            customHeaders,
+            expectFunction,
+          }) => {
+            const response = await request
+              .post(buildRoute(profileId, profileFlagId))
+              .set(customHeaders || headers);
+            expect(response.statusCode).toBe(expectStatus);
+            console.log(response.body);
+            if (expectFunction) {
+              expectFunction(response, profileId, profileFlagId);
+            }
+
+            // Dissasociate
+            db.task(t =>
+              t.none(
+                `DELETE FROM "ProfilesToProfileFlags" WHERE "profileId" = ${profileId}`,
+              ),
+            );
+          },
+        );
+      });
+
+      describe('DELETE', () => {
+        beforeAll(async () => {
+          (
+            await profilesDB.associateProfileToProfileFlag()(
+              accountSid,
+              createdProfile.profiles[0].id,
+              defaultFlags[0].id,
+            )
+          ).unwrap();
+
+          const pfs = (
+            await profilesDB.getProfileById()(accountSid, createdProfile.profiles[0].id)
+          ).profileFlags;
+          if (!pfs.includes(defaultFlags[0].id)) {
+            throw new Error('Missing expected association');
+          }
+        });
+
+        afterAll(async () => {
+          // Dissasociate
+          await db.task(t =>
+            t.none(
+              `DELETE FROM "ProfilesToProfileFlags" WHERE "profileId" = ${createdProfile.profiles[0].id}`,
+            ),
+          );
+        });
+
+        each([
+          {
+            description: 'auth is missing',
+            expectStatus: 401,
+            customHeaders: {},
+          },
+          {
+            description: 'profile does not exists',
+            profileId: 0,
+            expectStatus: 404,
+          },
+          {
+            description: 'flag does not exists (no-op)',
+            profileFlagId: 0,
+            expectStatus: 200,
+          },
+          {
+            description: 'profile and flag exist',
+            expectStatus: 200,
+            expectFunction: (response, profileId, profileFlagId) => {
+              expect(response.body.id).toBe(profileId);
+              expect(response.body.profileFlags).not.toContain(profileFlagId);
+            },
+          },
+        ]).test(
+          'when $description, returns $expectStatus',
+          async ({
+            profileId = createdProfile.profiles[0].id,
+            profileFlagId = defaultFlags[0].id,
+            expectStatus,
+            customHeaders,
+            expectFunction,
+          }) => {
+            const response = await request
+              .delete(buildRoute(profileId, profileFlagId))
+              .set(customHeaders || headers);
+            expect(response.statusCode).toBe(expectStatus);
+            console.log(response.body);
+            if (expectFunction) {
+              expectFunction(response, profileId, profileFlagId);
+            }
+          },
         );
       });
     });
   });
 
-  describe('/profileFlags', () => {
-    const defaultFlags = ['abusive', 'blocked'];
-
+  describe('/flags', () => {
     describe('GET', () => {
-      const route = `${baseRoute}/profileFlags`;
+      const defaultFlags = ['abusive', 'blocked'];
+
+      const route = `${baseRoute}/flags`;
 
       test('when no custom flags are added, return default flags', async () => {
         const response = await request.get(route).set(headers);
+
         expect(response.statusCode).toBe(200);
         // We know that there are two "default" flags that every account has: "abusive" and "blocked"
         expect(response.body).toHaveLength(defaultFlags.length);
@@ -356,6 +513,7 @@ describe('/profiles route', () => {
         ).unwrap();
 
         const response = await request.get(route).set(headers);
+
         expect(response.statusCode).toBe(200);
         // We know that there are two "default" flags that every account has: "abusive" and "blocked"
         expect(response.body).toHaveLength(defaultFlags.length + 1);

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -356,6 +356,15 @@ describe('/profiles route', () => {
       });
 
       describe('POST', () => {
+        afterAll(async () => {
+          // Dissasociate
+          db.task(t =>
+            t.none(
+              `DELETE FROM "ProfilesToProfileFlags" WHERE "profileId" = ${createdProfile.profiles[0].id}`,
+            ),
+          );
+        });
+
         each([
           {
             description: 'auth is missing',
@@ -380,6 +389,10 @@ describe('/profiles route', () => {
               expect(response.body.profileFlags).toContain(profileFlagId);
             },
           },
+          {
+            description: 'association already exists',
+            expectStatus: 500,
+          },
         ]).test(
           'when $description, returns $expectStatus',
           async ({
@@ -397,13 +410,6 @@ describe('/profiles route', () => {
             if (expectFunction) {
               expectFunction(response, profileId, profileFlagId);
             }
-
-            // Dissasociate
-            db.task(t =>
-              t.none(
-                `DELETE FROM "ProfilesToProfileFlags" WHERE "profileId" = ${profileId}`,
-              ),
-            );
           },
         );
       });

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -54,6 +54,7 @@ export type IdentifierWithProfiles = Identifier & { profiles: ProfileWithCounts[
 export type ProfileWithRelationships = Profile &
   ProfileCounts & {
     identifiers: Identifier[];
+    profileFlags: ProfileFlag['id'][];
   };
 
 type IdentifierParams =
@@ -190,12 +191,15 @@ export const associateProfileToProfileFlag =
     profileFlagId: number,
   ): Promise<TResult<null>> => {
     try {
+      const now = new Date();
       return await txIfNotInOne<TResult<null>>(task, async t => {
         await t.none(
           associateProfileToProfileFlagSql({
             accountSid,
             profileId,
             profileFlagId,
+            createdAt: now,
+            updatedAt: now,
           }),
         );
 

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -195,7 +195,7 @@ export const associateProfileToProfileFlag =
           }),
         );
 
-        return null;
+        return newOk({ data: null });
       });
     } catch (err) {
       return newErr({
@@ -219,7 +219,7 @@ export const disassociateProfileFromProfileFlag =
           profileFlagId,
         });
 
-        return null;
+        return newOk({ data: null });
       });
     } catch (err) {
       return newErr({

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -22,6 +22,10 @@ import {
   insertProfileSql,
   associateProfileToIdentifierSql,
 } from './sql/profile-insert-sql';
+import {
+  associateProfileToProfileFlagSql,
+  disassociateProfileFromProfileFlagSql,
+} from './sql/profile-flags-sql';
 import { txIfNotInOne } from '../sql';
 import { getProfileByIdSql, joinProfilesIdentifiersSql } from './sql/profile-get-sql';
 
@@ -166,11 +170,60 @@ export const createIdentifierAndProfile =
     }
   };
 
-export const getProfileById = async (
-  accountSid: string,
-  profileId: number,
-): Promise<ProfileWithRelationships> => {
-  return txIfNotInOne<ProfileWithRelationships>(undefined, async t => {
-    return t.oneOrNone(getProfileByIdSql, { accountSid, profileId });
-  });
-};
+export const getProfileById =
+  (task?) =>
+  async (accountSid: string, profileId: number): Promise<ProfileWithRelationships> => {
+    return txIfNotInOne<ProfileWithRelationships>(task, async t => {
+      return t.oneOrNone(getProfileByIdSql, { accountSid, profileId });
+    });
+  };
+
+export const associateProfileToProfileFlag =
+  (task?) =>
+  async (
+    accountSid: string,
+    profileId: number,
+    profileFlagId: number,
+  ): Promise<TResult<null>> => {
+    try {
+      return await txIfNotInOne<TResult<null>>(task, async t => {
+        await t.none(
+          associateProfileToProfileFlagSql({
+            accountSid,
+            profileId,
+            profileFlagId,
+          }),
+        );
+
+        return null;
+      });
+    } catch (err) {
+      return newErr({
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+export const disassociateProfileFromProfileFlag =
+  (task?) =>
+  async (
+    accountSid: string,
+    profileId: number,
+    profileFlagId: number,
+  ): Promise<TResult<null>> => {
+    try {
+      return await txIfNotInOne<TResult<null>>(task, async t => {
+        await t.none(disassociateProfileFromProfileFlagSql, {
+          accountSid,
+          profileId,
+          profileFlagId,
+        });
+
+        return null;
+      });
+    } catch (err) {
+      return newErr({
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -90,7 +90,7 @@ profilesRouter.get('/:profileId/cases', publicEndpoint, async (req, res, next) =
   }
 });
 
-profilesRouter.get('/profileFlags', publicEndpoint, async (req, res, next) => {
+profilesRouter.get('/flags', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;
 
@@ -105,28 +105,6 @@ profilesRouter.get('/profileFlags', publicEndpoint, async (req, res, next) => {
     res.json(result.data);
   } catch (err) {
     console.error(err);
-    return next(createError(500, err.message));
-  }
-});
-
-// WARNING: this endpoint must be the last one in this router, because it will be used if none of the above regex matches the path
-profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
-  try {
-    const { accountSid } = req;
-    const { profileId } = req.params;
-
-    const result = await profileController.getProfile()(accountSid, profileId);
-
-    if (isErr(result)) {
-      return next(createError(result.statusCode, result.message));
-    }
-
-    if (!result.data) {
-      return next(createError(404));
-    }
-
-    res.json(result.data);
-  } catch (err) {
     return next(createError(500, err.message));
   }
 });
@@ -188,5 +166,27 @@ profilesRouter.delete(
     }
   },
 );
+
+// WARNING: this endpoint MUST be the last one in this router, because it will be used if none of the above regex matches the path
+profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { profileId } = req.params;
+
+    const result = await profileController.getProfile()(accountSid, profileId);
+
+    if (isErr(result)) {
+      return next(createError(result.statusCode, result.message));
+    }
+
+    if (!result.data) {
+      return next(createError(404));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    return next(createError(500, err.message));
+  }
+});
 
 export default profilesRouter.expressRouter;

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -119,7 +119,7 @@ profilesRouter.post(
       const { accountSid } = req;
       const { profileId, profileFlagId } = req.params;
 
-      const result = await profileController.associateProfileToProfileFlag()(
+      const result = await profileController.associateProfileToProfileFlag(
         accountSid,
         profileId,
         profileFlagId,
@@ -148,7 +148,7 @@ profilesRouter.delete(
       const { accountSid } = req;
       const { profileId, profileFlagId } = req.params;
 
-      const result = await profileController.disassociateProfileFromProfileFlag()(
+      const result = await profileController.disassociateProfileFromProfileFlag(
         accountSid,
         profileId,
         profileFlagId,

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -109,7 +109,9 @@ export const associateProfileToProfileFlag = async (
 ): Promise<TResult<ProfileWithRelationships>> => {
   try {
     return await db.task<TResult<ProfileWithRelationships>>(async t => {
-      await associateProfileToProfileFlagDAL(t)(accountSid, profileId, profileFlagId);
+      (
+        await associateProfileToProfileFlagDAL(t)(accountSid, profileId, profileFlagId)
+      ).unwrap(); // unwrap the result to bubble error up (if any)
       const profile = await getProfileById(t)(accountSid, profileId);
 
       return newOk({ data: profile });
@@ -128,11 +130,13 @@ export const disassociateProfileFromProfileFlag = async (
 ): Promise<TResult<ProfileWithRelationships>> => {
   try {
     return await db.task<TResult<ProfileWithRelationships>>(async t => {
-      await disassociateProfileFromProfileFlagDAL(t)(
-        accountSid,
-        profileId,
-        profileFlagId,
-      );
+      (
+        await disassociateProfileFromProfileFlagDAL(t)(
+          accountSid,
+          profileId,
+          profileFlagId,
+        )
+      ).unwrap(); // unwrap the result to bubble error up (if any);
       const profile = await getProfileById(t)(accountSid, profileId);
 
       return newOk({ data: profile });

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -22,12 +22,13 @@ import {
   Profile,
   ProfileWithRelationships,
   associateProfileToProfileFlag as associateProfileToProfileFlagDAL,
-  createIdentifierAndProfile,
   disassociateProfileFromProfileFlag as disassociateProfileFromProfileFlagDAL,
+  createIdentifierAndProfile,
   getIdentifierWithProfiles,
   getProfileById,
 } from './profile-data-access';
 import { txIfNotInOne } from '../sql';
+import { db } from '../connection-pool';
 
 export { Identifier, Profile, getIdentifierWithProfiles };
 
@@ -101,48 +102,44 @@ export const getIdentifierByIdentifier = async (
   }
 };
 
-export const associateProfileToProfileFlag =
-  (task?) =>
-  async (
-    accountSid: string,
-    profileId: Profile['id'],
-    profileFlagId: number,
-  ): Promise<TResult<ProfileWithRelationships>> => {
-    try {
-      return await txIfNotInOne<TResult<ProfileWithRelationships>>(task, async t => {
-        await associateProfileToProfileFlagDAL(t)(accountSid, profileId, profileFlagId);
-        const profile = await getProfileById(task)(accountSid, profileId);
+export const associateProfileToProfileFlag = async (
+  accountSid: string,
+  profileId: Profile['id'],
+  profileFlagId: number,
+): Promise<TResult<ProfileWithRelationships>> => {
+  try {
+    return await db.task<TResult<ProfileWithRelationships>>(async t => {
+      await associateProfileToProfileFlagDAL(t)(accountSid, profileId, profileFlagId);
+      const profile = await getProfileById(t)(accountSid, profileId);
 
-        return newOk({ data: profile });
-      });
-    } catch (err) {
-      return newErr({
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  };
+      return newOk({ data: profile });
+    });
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
 
-export const disassociateProfileFromProfileFlag =
-  (task?) =>
-  async (
-    accountSid: string,
-    profileId: Profile['id'],
-    profileFlagId: number,
-  ): Promise<TResult<ProfileWithRelationships>> => {
-    try {
-      return await txIfNotInOne<TResult<ProfileWithRelationships>>(task, async t => {
-        await disassociateProfileFromProfileFlagDAL(t)(
-          accountSid,
-          profileId,
-          profileFlagId,
-        );
-        const profile = await getProfileById(task)(accountSid, profileId);
+export const disassociateProfileFromProfileFlag = async (
+  accountSid: string,
+  profileId: Profile['id'],
+  profileFlagId: number,
+): Promise<TResult<ProfileWithRelationships>> => {
+  try {
+    return await db.task<TResult<ProfileWithRelationships>>(async t => {
+      await disassociateProfileFromProfileFlagDAL(t)(
+        accountSid,
+        profileId,
+        profileFlagId,
+      );
+      const profile = await getProfileById(t)(accountSid, profileId);
 
-        return newOk({ data: profile });
-      });
-    } catch (err) {
-      return newErr({
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  };
+      return newOk({ data: profile });
+    });
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};

--- a/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
@@ -16,16 +16,18 @@
 
 import { pgp } from '../../connection-pool';
 
+type NewRecordCommons = {
+  accountSid: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 export type NewProfileFlagRecord = {
   name: string;
 };
 
 export const insertProfileFlagSql = (
-  profileFlag: NewProfileFlagRecord & {
-    accountSid: string;
-    createdAt: Date;
-    updatedAt: Date;
-  },
+  profileFlag: NewProfileFlagRecord & NewRecordCommons,
 ) => `
   ${pgp.helpers.insert(
     profileFlag,
@@ -41,18 +43,15 @@ export const getProfileFlagsByAccountSql = `
 `;
 
 type AssociateProfileToProfileFlagParams = {
-  accountSid: string;
   profileId: number;
   profileFlagId: number;
 };
-export const associateProfileToProfileFlagSql = ({
-  accountSid,
-  profileId,
-  profileFlagId,
-}: AssociateProfileToProfileFlagParams) => `
+export const associateProfileToProfileFlagSql = (
+  association: AssociateProfileToProfileFlagParams & NewRecordCommons,
+) => `
   ${pgp.helpers.insert(
-    { accountSid, profileId, profileFlagId },
-    ['accountSid', 'profileId', 'profileFlagId'],
+    association,
+    ['accountSid', 'profileId', 'profileFlagId', 'createdAt', 'updatedAt'],
     'ProfilesToProfileFlags',
   )}
 `;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { pgp } from '../../connection-pool';
+
+type AssociateProfileToProfileFlagParams = {
+  accountSid: string;
+  profileId: number;
+  profileFlagId: number;
+};
+export const associateProfileToProfileFlagSql = ({
+  accountSid,
+  profileId,
+  profileFlagId,
+}: AssociateProfileToProfileFlagParams) => `
+  ${pgp.helpers.insert(
+    { accountSid, profileId, profileFlagId },
+    ['accountSid', 'profileId', 'profileFlagId'],
+    'ProfilesToProfileFlags',
+  )}
+`;
+
+export const disassociateProfileFromProfileFlagSql = `
+  DELETE FROM "ProfilesToProfileFlags"
+  WHERE "profileId" = $<profileId> AND "profileFlagId" = $<profileFlagId> AND "accountSid" = $<accountSid>
+`;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -51,7 +51,7 @@ export const getProfileByIdSql = `
   RelatedProfileFlags AS (
     SELECT
         ppf."profileId",
-        JSON_AGG(ppf."profileFlagId") AS profileFlags
+        JSON_AGG(ppf."profileFlagId") AS "profileFlags"
     FROM "ProfilesToProfileFlags" ppf
     WHERE ppf."profileId" = $<profileId>
     GROUP BY ppf."profileId"
@@ -60,9 +60,9 @@ export const getProfileByIdSql = `
   SELECT
     profiles.*,
     COALESCE(ri.identifiers, '[]'::json) as identifiers,
-    COALESCE(ccc."contactsCount", 0) as "contactsCount",
-    COALESCE(ccc."casesCount", 0) as "casesCount",
-    COALESCE(rpf.profileFlags, '[]'::json) as profileFlags
+    COALESCE(ccc."contactsCount"::int, 0) as "contactsCount",
+    COALESCE(ccc."casesCount"::int, 0) as "casesCount",
+    COALESCE(rpf."profileFlags", '[]'::json) as "profileFlags"
   FROM "Profiles" profiles
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
   LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -51,16 +51,27 @@ export const getProfileByIdSql = `
     FROM "Contacts"
     WHERE "Contacts"."profileId" = $<profileId>
     GROUP BY "Contacts"."profileId"
+  ),
+
+  RelatedProfileFlags AS (
+    SELECT
+        ppf."profileId",
+        JSON_AGG(ppf."profileFlagId") AS profileFlags
+    FROM "ProfilesToProfileFlags" ppf
+    WHERE ppf."profileId" = $<profileId>
+    GROUP BY ppf."profileId"
   )
 
   SELECT
     profiles.*,
     COALESCE(ri.identifiers, '[]'::json) as identifiers,
     COALESCE(ccc."contactsCount", 0) as "contactsCount",
-    COALESCE(ccc."casesCount", 0) as "casesCount"
+    COALESCE(ccc."casesCount", 0) as "casesCount",
+    COALESCE(rpf.profileFlags, '[]'::json) as profileFlags
   FROM "Profiles" profiles
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
   LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"
+  LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"
   WHERE profiles."accountSid" = $<accountSid> AND profiles."id" = $<profileId>
 `;
 


### PR DESCRIPTION
## Description
This PR adds a new endpoint, `/:profileId/flags/:profileFlagId`, which accepts two methods:
- `POST`, creates a new association between the profile of id `profileId` and the flag of id `profileFlagId` (if it does not exists).
- `DELETE`, deletes the association between the profile of id `profileId` and the flag of id `profileFlagId` (if it exists).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2290)
- [x] New tests added

### Verification steps
Trust service tests or
- Start local server.
- Create a new profile. At least one flag will exist when the migration is executed (default flags).
- Hit `/:profileId/flags/:profileFlagId` with a `POST` method, where `profileId` value is the above profile and `profileFlagId` value is one of the default flags.
- Confirm a new association has been created and that the profile payload contains it under `profileFlags` proerty.
- Hit `/:profileId/flags/:profileFlagId` with a `DELETE` method, where `profileId` value is the above profile and `profileFlagId` value is one of the default flags.
- Confirm that the association has been removed and that the profile payload does not contains the flag anymore.