### PR TITLE
[Client Profiles] HRM - support note storage/retrieval on backend

### DIFF
--- a/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
+++ b/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
@@ -36,7 +36,7 @@ module.exports = {
     await queryInterface.sequelize.query(`
       CREATE TABLE IF NOT EXISTS public."ProfileSections"
       (
-        "id" integer COLLATE pg_catalog."default" NOT NULL DEFAULT nextval('"ProfileSections_id_seq"'::regclass),
+        id integer NOT NULL DEFAULT nextval('"ProfileSections_id_seq"'::regclass),
         "sectionType" text COLLATE pg_catalog."default" NOT NULL,
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
         "profileId" integer NOT NULL,

--- a/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
+++ b/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    /// ProfileSections
+    await queryInterface.sequelize.query(`
+    CREATE SEQUENCE IF NOT EXISTS public."ProfileSections_id_seq"
+      INCREMENT 1
+      START 1
+      MINVALUE 1
+      MAXVALUE 9223372036854775807
+      CACHE 1;
+   `);
+    console.log('Sequence "ProfileSections_id_seq" created');
+    await queryInterface.sequelize.query(`
+      ALTER SEQUENCE public."ProfileSections_id_seq" OWNER TO hrm
+   `);
+    console.log("Sequence 'ProfileSections_id_seq' ownership altered.");
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS public."ProfileSections"
+      (
+        "id" text COLLATE pg_catalog."default" NOT NULL DEFAULT nextval('"ProfileSections_id_seq"'::regclass),
+        "sectionType" text COLLATE pg_catalog."default" NOT NULL,
+        "accountSid" text COLLATE pg_catalog."default" NOT NULL,
+        "profileId" integer NOT NULL,
+        "content" text COLLATE pg_catalog."default",
+        "createdBy" text COLLATE pg_catalog."default" NOT NULL,
+        "createdAt" timestamp with time zone NOT NULL,
+        "updatedBy" text COLLATE pg_catalog."default",
+        "updatedAt" timestamp with time zone NOT NULL,
+        CONSTRAINT "ProfileSections_pkey" PRIMARY KEY ("id", "accountSid"),
+        CONSTRAINT "ProfileSections_profileId_Profiles_id_fk" FOREIGN KEY ("profileId", "accountSid")
+          REFERENCES public."Profiles" (id, "accountSid") MATCH SIMPLE
+          ON UPDATE CASCADE
+          ON DELETE CASCADE
+      )
+    `);
+    console.log("Table 'ProfileSections' created.");
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS public."ProfileSections" OWNER to hrm;
+    `);
+    console.log("Table 'ProfileSections' ownership altered.");
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS "fki_ProfileSections_profileId_Profile_id_fk" ON public."ProfileSections" USING btree 
+        ("profileId" ASC NULLS LAST, "accountSid" COLLATE pg_catalog."default" ASC NULLS LAST)
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS "fki_ProfileSections_profileId_Profile_id_fk"
+    `);
+    await queryInterface.sequelize.query(`
+      DROP TABLE IF EXISTS public."ProfileSections"
+    `);
+    await queryInterface.sequelize.query(`
+      DROP SEQUENCE IF EXISTS public."ProfileSections_id_seq"
+    `);
+  },
+};

--- a/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
+++ b/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
@@ -20,7 +20,7 @@ module.exports = {
     await queryInterface.sequelize.query(`
       CREATE TABLE IF NOT EXISTS public."ProfileSections"
       (
-        "id" text COLLATE pg_catalog."default" NOT NULL DEFAULT nextval('"ProfileSections_id_seq"'::regclass),
+        "id" integer COLLATE pg_catalog."default" NOT NULL DEFAULT nextval('"ProfileSections_id_seq"'::regclass),
         "sectionType" text COLLATE pg_catalog."default" NOT NULL,
         "accountSid" text COLLATE pg_catalog."default" NOT NULL,
         "profileId" integer NOT NULL,

--- a/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
+++ b/hrm-domain/hrm-service/migrations/20231030183157-create-client-profile-notes.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 'use strict';
 
 /** @type {import('sequelize-cli').Migration} */

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -34,6 +34,7 @@ import { getProfileByIdSql, joinProfilesIdentifiersSql } from './sql/profile-get
 import { db } from '../connection-pool';
 import {
   NewProfileSectionRecord,
+  getProfileSectionByIdSql,
   insertProfileSectionSql,
   updateProfileSectionByIdSql,
 } from './sql/profile-sections-sql';
@@ -336,6 +337,23 @@ export const updateProfileSectionById = async (
         }),
       )
       .then(data => newOk({ data }));
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+export const getProfileSectionById = async (
+  accountSid: string,
+  { profileId, sectionId }: { profileId: Profile['id']; sectionId: ProfileSection['id'] },
+): Promise<TResult<ProfileSection>> => {
+  try {
+    const data = await db.task<ProfileSection>(async t =>
+      t.oneOrNone(getProfileSectionByIdSql, { accountSid, profileId, sectionId }),
+    );
+
+    return newOk({ data });
   } catch (err) {
     return newErr({
       message: err instanceof Error ? err.message : String(err),

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -167,6 +167,69 @@ profilesRouter.delete(
   },
 );
 
+// curl -X POST 'http://localhost:8080/v0/accounts/ACd8a2e89748318adf6ddff7df6948deaf/profiles/5/sections' -H 'Content-Type: application/json' -H "Authorization: Bearer " -d '{
+//     "content": "A note bla bla bla",
+//     "sectionType": "note"
+//   }'
+profilesRouter.post('/:profileId/sections', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid, user } = req;
+    const { profileId } = req.params;
+    const { content, sectionType } = req.body;
+
+    const result = await profileController.createProfileSection(
+      accountSid,
+      { content, profileId, sectionType },
+      { user },
+    );
+
+    if (isErr(result)) {
+      return next(createError(result.statusCode, result.message));
+    }
+
+    if (!result.data) {
+      return next(createError(404));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    return next(createError(500, err.message));
+  }
+});
+
+// curl -X POST 'http://localhost:8080/v0/accounts/ACd8a2e89748318adf6ddff7df6948deaf/profiles/5/sections/5' -H 'Content-Type: application/json' -H "Authorization: Bearer " -d '{
+//     "content": "A note bla bla bla",
+//   }'
+profilesRouter.patch(
+  '/:profileId/sections/:sectionId',
+  publicEndpoint,
+  async (req, res, next) => {
+    try {
+      const { accountSid, user } = req;
+      const { profileId, sectionId } = req.params;
+      const { content } = req.body;
+
+      const result = await profileController.updateProfileSectionById(
+        accountSid,
+        { profileId, sectionId, content },
+        { user },
+      );
+
+      if (isErr(result)) {
+        return next(createError(result.statusCode, result.message));
+      }
+
+      if (!result.data) {
+        return next(createError(404));
+      }
+
+      res.json(result.data);
+    } catch (err) {
+      return next(createError(500, err.message));
+    }
+  },
+);
+
 // WARNING: this endpoint MUST be the last one in this router, because it will be used if none of the above regex matches the path
 profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
   try {

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -230,6 +230,34 @@ profilesRouter.patch(
   },
 );
 
+profilesRouter.get(
+  '/:profileId/sections/:sectionId',
+  publicEndpoint,
+  async (req, res, next) => {
+    try {
+      const { accountSid } = req;
+      const { profileId, sectionId } = req.params;
+
+      const result = await profileController.getProfileSectionById(accountSid, {
+        profileId,
+        sectionId,
+      });
+
+      if (isErr(result)) {
+        return next(createError(result.statusCode, result.message));
+      }
+
+      if (!result.data) {
+        return next(createError(404));
+      }
+
+      res.json(result.data);
+    } catch (err) {
+      return next(createError(500, err.message));
+    }
+  },
+);
+
 // WARNING: this endpoint MUST be the last one in this router, because it will be used if none of the above regex matches the path
 profilesRouter.get('/:profileId', publicEndpoint, async (req, res, next) => {
   try {

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -194,3 +194,22 @@ export const updateProfileSectionById = async (
     });
   }
 };
+
+// While this is just a wrapper around profileDB.getProfileSectionById, we'll need more code to handle permissions soon
+export const getProfileSectionById = async (
+  accountSid: string,
+  payload: {
+    profileId: profileDB.Profile['id'];
+    sectionId: profileDB.ProfileSection['id'];
+  },
+): Promise<TResult<profileDB.ProfileSection>> => {
+  try {
+    const ps = await profileDB.getProfileSectionById(accountSid, payload);
+
+    return ps;
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -55,10 +55,10 @@ export const getProfileByIdSql = `
     FROM "ProfilesToProfileFlags" ppf
     WHERE ppf."profileId" = $<profileId>
     GROUP BY ppf."profileId"
-  )
+  ),
 
   RelatedProfileSections AS (
-    SELECT pps."profileId", JSON_AGG(pps.*) AS "profileSections"
+    SELECT pps."profileId", JSON_AGG(JSON_BUILD_OBJECT(pps.id, pps."sectionType")) AS "profileSections"
     FROM "ProfileSections" pps
     WHERE pps."profileId" = $<profileId> AND pps."accountSid" = $<accountSid>
     GROUP BY pps."profileId"

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -57,16 +57,25 @@ export const getProfileByIdSql = `
     GROUP BY ppf."profileId"
   )
 
+  RelatedProfileSections AS (
+    SELECT pps."profileId", JSON_AGG(pps.*) AS "profileSections"
+    FROM "ProfileSections" pps
+    WHERE pps."profileId" = $<profileId> AND pps."accountSid" = $<accountSid>
+    GROUP BY pps."profileId"
+  )
+
   SELECT
     profiles.*,
     COALESCE(ri.identifiers, '[]'::json) as identifiers,
     COALESCE(ccc."contactsCount"::int, 0) as "contactsCount",
     COALESCE(ccc."casesCount"::int, 0) as "casesCount",
-    COALESCE(rpf."profileFlags", '[]'::json) as "profileFlags"
+    COALESCE(rpf."profileFlags", '[]'::json) as "profileFlags",
+    COALESCE(rps."profileSections", '[]'::json) as "profileSections"
   FROM "Profiles" profiles
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
   LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"
   LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"
+  LEFT JOIN RelatedProfileSections rps ON profiles.id = rps."profileId"
   WHERE profiles."accountSid" = $<accountSid> AND profiles."id" = $<profileId>
 `;
 

--- a/hrm-domain/hrm-service/src/profile/sql/profile-sections-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-sections-sql.ts
@@ -50,11 +50,19 @@ export const insertProfileSectionSql = (
   RETURNING *
 `;
 
+const WHERE_ID_AND_PROFILE_CLAUSE =
+  'WHERE id = $<sectionId> AND "profileId" = $<profileId> AND "accountSid" = $<accountSid>';
+
 export const updateProfileSectionByIdSql = `
   UPDATE "ProfileSections" SET
     "content" = $<content>,
     "updatedBy" = $<updatedBy>,
     "updatedAt" = $<updatedAt>
-  WHERE id = $<sectionId> AND "profileId" = $<profileId> AND "accountSid" = $<accountSid>
+  ${WHERE_ID_AND_PROFILE_CLAUSE}
   RETURNING *;
+`;
+
+export const getProfileSectionByIdSql = `
+  SELECT * FROM "ProfileSections"
+  ${WHERE_ID_AND_PROFILE_CLAUSE}
 `;

--- a/hrm-domain/hrm-service/src/profile/sql/profile-sections-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-sections-sql.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { pgp } from '../../connection-pool';
+
+type NewRecordCommons = {
+  accountSid: string;
+  createdBy: string;
+  updatedBy?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type NewProfileSectionRecord = {
+  sectionType: string;
+  profileId: number;
+  content: string;
+};
+
+export const insertProfileSectionSql = (
+  profileSection: NewProfileSectionRecord & NewRecordCommons,
+) => `
+  ${pgp.helpers.insert(
+    profileSection,
+    [
+      'sectionType',
+      'profileId',
+      'content',
+      'accountSid',
+      'createdBy',
+      'updatedBy',
+      'createdAt',
+      'updatedAt',
+    ],
+    'ProfileSections',
+  )}
+  RETURNING *
+`;
+
+export const updateProfileSectionByIdSql = `
+  UPDATE "ProfileSections" SET
+    "content" = $<content>,
+    "updatedBy" = $<updatedBy>,
+    "updatedAt" = $<updatedAt>
+  WHERE id = $<sectionId> AND "profileId" = $<profileId> AND "accountSid" = $<accountSid>
+  RETURNING *;
+`;


### PR DESCRIPTION
## Description
This PR
- Adds a new table, `ProfileSections` which is intended to store different text based content associated to a profile.
- Adds three new endpoints:
  - `/profiles/:profileId/sections` which accepts a `POST` operation. This endpoint accepts a JSON body like `{ content, sectionType }` and will create a new section associated with profile of `:profileId`.
  - `/profiles/:profileId/sections/:sectionId` which accepts a `PATCH` operation. This endpoint accepts a JSON body like `{ content }` and will update the section of id `:sectionId`.
  - `/profiles/:profileId/sections/:id` which accepts a `GET` operation. This endpoint returns the section of id `:sectionId`.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
