### PR TITLE
[POC] Blocked profiles: expose profiles/identifier/:identifier/flags endpoint

### DIFF
--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -27,6 +27,7 @@ import {
   associateProfileToProfileFlagSql,
   disassociateProfileFromProfileFlagSql,
   getProfileFlagsByAccountSql,
+  getProfileFlagsByIdentifierSql,
   insertProfileFlagSql,
 } from './sql/profile-flags-sql';
 import { txIfNotInOne } from '../sql';
@@ -255,6 +256,23 @@ export const getProfileFlagsForAccount = async (
     return await db
       .task<ProfileFlag[]>(async t =>
         t.manyOrNone(getProfileFlagsByAccountSql, { accountSid }),
+      )
+      .then(data => newOk({ data }));
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+export const getProfileFlagsByIdentifier = async (
+  accountSid: string,
+  identifier: string,
+): Promise<TResult<ProfileFlag[]>> => {
+  try {
+    return await db
+      .task<ProfileFlag[]>(async t =>
+        t.manyOrNone(getProfileFlagsByIdentifierSql, { accountSid, identifier }),
       )
       .then(data => newOk({ data }));
   } catch (err) {

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -48,6 +48,30 @@ profilesRouter.get('/identifier/:identifier', publicEndpoint, async (req, res, n
   }
 });
 
+profilesRouter.get(
+  '/identifier/:identifier/flags',
+  publicEndpoint,
+  async (req, res, next) => {
+    try {
+      const { accountSid } = req;
+      const { identifier } = req.params;
+
+      const result = await profileController.getProfileFlagsByIdentifier(
+        accountSid,
+        identifier,
+      );
+
+      if (isErr(result)) {
+        return next(createError(result.statusCode, result.message));
+      }
+
+      res.json(result.data);
+    } catch (err) {
+      return next(createError(500, err.message));
+    }
+  },
+);
+
 profilesRouter.get('/:profileId/contacts', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -147,6 +147,7 @@ export const disassociateProfileFromProfileFlag = async (
 };
 
 export const getProfileFlags = profileDB.getProfileFlagsForAccount;
+export const getProfileFlagsByIdentifier = profileDB.getProfileFlagsByIdentifier;
 
 // While this is just a wrapper around profileDB.createProfileSection, we'll need more code to handle permissions soon
 export const createProfileSection = async (

--- a/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-flags-sql.ts
@@ -42,6 +42,15 @@ export const getProfileFlagsByAccountSql = `
   WHERE "accountSid" = $<accountSid> OR "accountSid" IS NULL
 `;
 
+export const getProfileFlagsByIdentifierSql = `
+  SELECT DISTINCT pf.* FROM "Identifiers" ids
+  LEFT JOIN "ProfilesToIdentifiers" p2i ON p2i."identifierId" = ids.id AND p2i."accountSid" = ids."accountSid"
+  LEFT JOIN "ProfilesToProfileFlags" p2f ON p2f."profileId" = p2i."profileId" AND p2f."accountSid" = p2i."accountSid"
+  LEFT JOIN "ProfileFlags" pf ON pf.id = p2f."profileFlagId" AND (pf."accountSid" = p2f."accountSid" OR pf."accountSid" IS NULL)
+  WHERE ids."identifier" = $<identifier> AND ids."accountSid" = $<accountSid>
+`;
+// WHERE ids."identifier" = '190.2.98.203' -- AND ids."accountSid" = ''
+
 type AssociateProfileToProfileFlagParams = {
   profileId: number;
   profileFlagId: number;

--- a/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
+++ b/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
@@ -38,7 +38,13 @@ declare global {
  * IMPORTANT: This kind of static key acces should never be used to retrieve sensitive information.
  */
 const canAccessResourceWithStaticKey = (path: string, method: string): boolean => {
-  return path.endsWith('/postSurveys') && method === 'POST';
+  // If the requests is to create a new post survey record, grant access
+  if (path.endsWith('/postSurveys') && method === 'POST') return true;
+
+  // If the requests is retrieve the list of flags associated to a given identifier, grant access
+  if (/\/profiles\/identifier\/[^/]+\/flags$/.test(path) && method === 'GET') return true;
+
+  return false;
 };
 
 type TokenValidatorResponse = { worker_sid: string; roles: string[] };


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/serverless/pull/536.

## Description
This PR is part of the PoC for rejecting contacts for profiles that have been marked as "blocked".

This PR 
- Adds a new endpoint, `'profiles/identifier/:identifier/flags'`, which will return all the profile flags associated to the identifier `:identifier` (using the profiles as the relationship table to link them).
- Whitelists the above endpoint to be accessed with the static key.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2327)
- [ ] New tests added

### Verification steps
Refer to the linked PR for steps.