### PR TITLE
CHI-2375:Allow pull-cases to handle abesent connectedContacts prop

### DIFF
--- a/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/contact/contact-routes-v0.ts
@@ -147,7 +147,7 @@ const validatePatchPayload = ({ body }: Request, res: Response, next: NextFuncti
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const canEditContact = asyncHandler(async (req, res, next) => {
   if (!req.isAuthorized()) {
-    const { accountSid, user, can, body } = req;
+    const { accountSid, user, can, body, query } = req;
     const { contactId } = req.params;
 
     try {
@@ -166,6 +166,14 @@ const canEditContact = asyncHandler(async (req, res, next) => {
           req.unauthorize();
         }
       } else {
+        // Cannot finalize an offline task with a placeholder taskId.
+        // A real task needs to have been created and it's sid assigned to the contact before it can be finalized
+        if (
+          body?.taskId?.startsWith('offline-contact-task-') &&
+          query?.finalize === 'true'
+        ) {
+          req.unauthorize();
+        }
         // If there is no finalized date, then the contact is a draft and can only be edited by the worker who created it or the one who owns it.
         // Offline contacts potentially need to be edited by a creator that won't own them.
         // Transferred tasks need to be edited by an owner that didn't create them.

--- a/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/pull-cases.ts
+++ b/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/pull-cases.ts
@@ -48,7 +48,7 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
 
   const casesWithContactIdOnly = cases.map(cas => ({
     ...cas,
-    connectedContacts: mapContactsToId(cas.connectedContacts),
+    connectedContacts: mapContactsToId(cas?.connectedContacts ?? []),
   }));
 
   const uploadPromises = casesWithContactIdOnly.map(cas => {


### PR DESCRIPTION
## Description

Also disallow finalizing offline tasks with placeholder IDs. Offline contacts need to have been assigned a real Twiulio task before being finalized or as they are being finalized.

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added (tests will be added to master as that has unit tests for the other permission rules)


### Related Issues
Fixes CHI-2375

### Verification steps

Deploy this version & rerun the missing contacts from the export outage described in the ticket - that should pass.

Needs this build to be on prod tho :-/ so nothing except normal regression prior to that