### PR TITLE
fix: improve performance of identifiers query.

### DIFF
--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -81,12 +81,20 @@ export const getIdentifierWithProfiles =
     const params = { accountSid, identifier, identifierId };
     try {
       const data = await txIfNotInOne<IdentifierWithProfiles>(task, async t => {
+        /* We run two queries here, one to get the identifier and one to get the profiles
+           because writing a single PERFORMANT query against tables that could eventually
+           have millions of rows is hard. There is probably a better way to do this...
+           but dev time is limited and this works for now.
+
+           If you are thinking of changing this, please profile against a db with millions
+           of rows in the tables and make sure it is performant.
+        */
         const identifierData: Identifier = await t.oneOrNone(
           profileGetSql.getIdentifierSql,
           params,
         );
 
-        if (!identifier) {
+        if (!identifierData) {
           return null;
         }
 

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -92,7 +92,7 @@ export const getProfilesByIdentifierSql = `
     profiles.id AS id,
     profiles.name AS name,
     CAST(COUNT(DISTINCT CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS INTEGER) AS "casesCount",
-    CAST(COUNT(*) AS INTEGER) AS "contactsCount"
+    CAST(COUNT(CASE WHEN "Contacts"."profileId" IS NOT NULL THEN 1 END) AS INTEGER) AS "contactsCount"
   FROM "Identifiers" ids
   LEFT JOIN "ProfilesToIdentifiers" p2i ON ids.id = p2i."identifierId"
   LEFT JOIN "Profiles" profiles ON profiles.id = p2i."profileId"

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -91,11 +91,11 @@ export const getProfilesByIdentifierSql = `
   SELECT
     profiles.id AS id,
     profiles.name AS name,
-    COUNT(DISTINCT CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS casesCount,
-    COUNT(CASE WHEN "Contacts"."caseId" IS NOT NULL THEN 1 END) AS contactsCount
+    CAST(COUNT(DISTINCT CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS INTEGER) AS "casesCount",
+    CAST(COUNT(*) AS INTEGER) AS "contactsCount"
   FROM "Identifiers" ids
   LEFT JOIN "ProfilesToIdentifiers" p2i ON ids.id = p2i."identifierId"
-  LEFT JOIN "Profiles" profiles ON profiles.id = p2i."profileId" AND profiles."accountSid" = p2i."accountSid"
+  LEFT JOIN "Profiles" profiles ON profiles.id = p2i."profileId"
   LEFT JOIN "Contacts" ON "Contacts"."profileId" = profiles.id
   ${WHERE_IDENTIFIER_CLAUSE}
   GROUP BY profiles.id, profiles.name;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
I spent hours profiling queries trying to accomplish decent performance in a single query. I gave up. This is almost acceptably performant (based on profiling and manually running the queries against the development db, it hasn't been deployed yet) even with the massive number of duplicate identifiers and profiles that currently exist in the db. It should more than suffice for the near term amount of data we will have in the db. At least it shouldn't lock up the tiny db instance. ;)
