### PR TITLE
[Client Profiles] Backend work for listing profiles

### DIFF
--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -23,7 +23,7 @@ import * as profilesDB from '../src/profile/profile-data-access';
 import { getRequest, getServer, headers, useOpenRules } from './server';
 import * as mocks from './mocks';
 import { mockSuccessfulTwilioAuthentication, mockingProxy } from '@tech-matters/testing';
-import { getOrCreateProfileWithIdentifier } from '../src/profile/profile';
+import { getOrCreateProfileWithIdentifier, Profile } from '../src/profile/profile';
 import { IdentifierWithProfiles } from '../src/profile/profile-data-access';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 
@@ -58,6 +58,148 @@ beforeEach(async () => {
 describe('/profiles', () => {
   const baseRoute = `/v0/accounts/${accountSid}/profiles`;
   const identifier = 'identifier';
+
+  describe.only('GET', () => {
+    let createdProfiles: Profile[];
+    let existingProfiles: any; //Profile[];
+    const profilesNames = ['Murray', 'Antonella', null];
+    let defaultFlags: profilesDB.ProfileFlag[];
+    beforeAll(async () => {
+      existingProfiles = (await profilesDB.listProfiles(accountSid, {}, {})).unwrap()
+        .profiles;
+      createdProfiles = await Promise.all(
+        profilesNames.map(name => profilesDB.createProfile()(accountSid, { name })),
+      );
+      defaultFlags = await profilesDB
+        .getProfileFlagsForAccount(accountSid)
+        .then(result => result.unwrap());
+      await Promise.all([
+        profilesDB.associateProfileToProfileFlag()(
+          accountSid,
+          createdProfiles.find(p => p.name === 'Murray')!.id,
+          defaultFlags[0].id,
+        ),
+        profilesDB.associateProfileToProfileFlag()(
+          accountSid,
+          createdProfiles.find(p => p.name === 'Antonella')!.id,
+          defaultFlags[1].id,
+        ),
+      ]);
+    });
+
+    afterAll(async () => {
+      await Promise.all(
+        createdProfiles.map(p => deleteFromTableById('Profiles')(p.id, p.accountSid)),
+      );
+    });
+
+    each([
+      {
+        description: 'auth is missing',
+        expectDescription: 'request is rejected',
+        expectStatus: 401,
+        customHeaders: {},
+      },
+      {
+        description: 'no query passed',
+        expectDescription: 'return all profiles',
+        query: '',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(
+            existingProfiles.length + createdProfiles.length,
+          );
+        },
+      },
+      {
+        description: 'sort by name desc',
+        expectDescription: 'return all profiles, sorted',
+        query: 'sortBy=name',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(
+            existingProfiles.length + createdProfiles.length,
+          );
+          expect(response.body.profiles[0].name).toBe('Murray');
+          expect(response.body.profiles[1].name).toBe('Antonella');
+          response.body.profiles.slice(2).forEach(p => expect(p.name).toBeNull());
+        },
+      },
+      {
+        description: 'sort by name asc',
+        expectDescription: 'return all profiles, sorted',
+        query: 'sortBy=name&sortDirection=asc',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(
+            existingProfiles.length + createdProfiles.length,
+          );
+          expect(response.body.profiles[0].name).toBe('Antonella');
+          expect(response.body.profiles[1].name).toBe('Murray');
+          response.body.profiles.slice(2).forEach(p => expect(p.name).toBeNull());
+        },
+      },
+      {
+        description: 'filter by single flag',
+        expectDescription: 'return profiles linked to that one flag only',
+        query: 'profileFlagIds=1',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(1);
+          expect(response.body.profiles[0].name).toBe('Murray');
+        },
+      },
+      {
+        description: 'filter by multiple flags',
+        expectDescription: 'return profiles linked to those flag only',
+        query: 'profileFlagIds=1,2',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(2);
+          expect(response.body.profiles[0].name).toBe('Antonella');
+          expect(response.body.profiles[1].name).toBe('Murray');
+        },
+      },
+      {
+        description: 'filter by flags with no associated profile´',
+        expectDescription: 'return zero profiles',
+        query: 'profileFlagIds=9999999',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(0);
+        },
+      },
+      {
+        description: 'invalid profileFlagIds is provided',
+        expectDescription: 'ignore filter',
+        query: 'profileFlagIds=not-a-number',
+        expectStatus: 200,
+        expectFunction: response => {
+          console.log(response.body);
+          expect(response.body.count).toBe(
+            existingProfiles.length + createdProfiles.length,
+          );
+        },
+      },
+    ]).test(
+      'when $description, $expectDescription',
+      async ({ expectStatus, customHeaders, query, expectFunction }) => {
+        const response = await request
+          .get(`${baseRoute}?${query}`)
+          .set(customHeaders || headers);
+        expect(response.statusCode).toBe(expectStatus);
+        if (expectFunction) {
+          expectFunction(response);
+        }
+      },
+    );
+  });
 
   describe('/profiles/identifier/:identifier', () => {
     const buildRoute = (id: string) => `${baseRoute}/identifier/${id}`;

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -59,7 +59,7 @@ describe('/profiles', () => {
   const baseRoute = `/v0/accounts/${accountSid}/profiles`;
   const identifier = 'identifier';
 
-  describe.only('GET', () => {
+  describe('GET', () => {
     let createdProfiles: Profile[];
     let existingProfiles: any; //Profile[];
     const profilesNames = ['Murray', 'Antonella', null];

--- a/hrm-domain/hrm-service/src/case/case-data-access.ts
+++ b/hrm-domain/hrm-service/src/case/case-data-access.ts
@@ -19,7 +19,6 @@ import { getPaginationElements } from '../search';
 import { updateByIdSql } from './sql/case-update-sql';
 import {
   OrderByColumnType,
-  OrderByDirectionType,
   SearchQueryBuilder,
   selectCaseSearch,
   selectCaseSearchByProfileId,
@@ -31,6 +30,7 @@ import {
 import { DELETE_BY_ID } from './sql/case-delete-sql';
 import { selectSingleCaseByIdSql } from './sql/case-get-sql';
 import { Contact } from '../contact/contact-data-access';
+import { OrderByDirectionType } from '../sql';
 
 export type CaseRecordCommon = {
   info: any;

--- a/hrm-domain/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-domain/hrm-service/src/case/sql/case-search-sql.ts
@@ -20,16 +20,7 @@ import { CaseListFilters, DateExistsCondition, DateFilter } from '../case-data-a
 import { selectCoalesceCsamReportsByContactId } from '../../csam-report/sql/csam-report-get-sql';
 import { selectCoalesceReferralsByContactId } from '../../referral/sql/referral-get-sql';
 import { selectCoalesceConversationMediasByContactId } from '../../conversation-media/sql/conversation-media-get-sql';
-
-export const OrderByDirection = {
-  ascendingNullsLast: 'ASC NULLS LAST',
-  descendingNullsLast: 'DESC NULLS LAST',
-  ascending: 'ASC',
-  descending: 'DESC',
-} as const;
-
-export type OrderByDirectionType =
-  (typeof OrderByDirection)[keyof typeof OrderByDirection];
+import { OrderByClauseItem, OrderByDirection } from '../../sql';
 
 export const OrderByColumn = {
   ID: 'id',
@@ -48,8 +39,6 @@ const ORDER_BY_FIELDS: Record<OrderByColumnType, string> = {
   'info.followUpDate': `"info"->>'followUpDate'`,
   childName: pgp.as.name('childName'),
 } as const;
-
-type OrderByClauseItem = { sortBy: string; sortDirection: OrderByDirectionType };
 
 const DEFAULT_SORT: OrderByClauseItem[] = [
   { sortBy: 'id', sortDirection: OrderByDirection.descending },

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -141,7 +141,7 @@ const createIdentifier =
 
 export type Profile = NewProfileRecord & RecordCommons;
 
-const createProfile =
+export const createProfile =
   (task?) =>
   async (accountSid: string, profile: NewProfileRecord): Promise<Profile> => {
     const now = new Date();
@@ -244,12 +244,12 @@ export const listProfiles = async (
 
     const { count, rows } = await db.task(async connection => {
       const result = await connection.any<Profile & { totalCount: number }>(
-        listProfilesSql(filters, orderClause),
+        listProfilesSql(filters || {}, orderClause),
         {
           accountSid,
           limit,
           offset,
-          profileFlagIds: filters.profileFlagIds,
+          profileFlagIds: filters?.profileFlagIds,
         },
       );
 

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -29,7 +29,7 @@ import {
   getProfileFlagsByAccountSql,
   insertProfileFlagSql,
 } from './sql/profile-flags-sql';
-import { txIfNotInOne } from '../sql';
+import { OrderByDirectionType, txIfNotInOne } from '../sql';
 import * as profileGetSql from './sql/profile-get-sql';
 import { db } from '../connection-pool';
 import {
@@ -38,6 +38,14 @@ import {
   insertProfileSectionSql,
   updateProfileSectionByIdSql,
 } from './sql/profile-sections-sql';
+import {
+  OrderByColumnType,
+  ProfilesListFilters,
+  listProfilesSql,
+} from './sql/profile-list-sql';
+import { getPaginationElements } from '../search';
+
+export { ProfilesListFilters } from './sql/profile-list-sql';
 
 type RecordCommons = {
   id: number;
@@ -212,6 +220,49 @@ export const getProfileById =
       return t.oneOrNone(profileGetSql.getProfileByIdSql, { accountSid, profileId });
     });
   };
+
+export type ProfileListConfiguration = {
+  sortBy?: OrderByColumnType;
+  sortDirection?: OrderByDirectionType;
+  offset?: string;
+  limit?: string;
+};
+
+export type SearchParameters = {
+  filters?: ProfilesListFilters;
+};
+export const listProfiles = async (
+  accountSid: string,
+  listConfiguration: ProfileListConfiguration,
+  { filters }: SearchParameters,
+): Promise<TResult<{ profiles: Profile[]; count: number }>> => {
+  try {
+    const { limit, offset, sortBy, sortDirection } =
+      getPaginationElements(listConfiguration);
+    const orderClause = [{ sortBy, sortDirection }];
+
+    const { count, rows } = await db.task(async connection => {
+      const result = await connection.any<Profile & { totalCount: number }>(
+        listProfilesSql(filters, orderClause),
+        {
+          accountSid,
+          limit,
+          offset,
+          profileFlagIds: filters.profileFlagIds,
+        },
+      );
+
+      const totalCount: number = result.length ? result[0].totalCount : 0;
+      return { rows: result, count: totalCount };
+    });
+
+    return newOk({ data: { profiles: rows, count } });
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
 
 export const associateProfileToProfileFlag =
   (task?) =>

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -39,10 +39,12 @@ profilesRouter.get('/', publicEndpoint, async (req, res, next) => {
     const { accountSid } = req;
     const { sortDirection, sortBy, limit, offset, ...rest } = req.query;
 
-    const profileFlagIds = decodeURIComponent(rest.profileFlagIds)
-      .split(',')
-      .map(s => parseInt(s, 10))
-      .filter(v => v && !isNaN(v));
+    const profileFlagIds = rest.profileFlagIds
+      ? decodeURIComponent(rest.profileFlagIds)
+          .split(',')
+          .map(s => parseInt(s, 10))
+          .filter(v => v && !isNaN(v))
+      : undefined;
 
     const filters = {
       profileFlagIds,

--- a/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-routes-v0.ts
@@ -24,6 +24,46 @@ import { getCasesByProfileId } from '../case/caseService';
 
 const profilesRouter = SafeRouter();
 
+/**
+ * Returns a filterable list of cases for a helpline
+ *
+ * @param {string} req.accountSid - SID of the helpline
+ * @param {profileController.ProfileListConfiguration['sortDirection']} req.query.sortDirection - Sort direction
+ * @param {profileController.ProfileListConfiguration['sortBy']} req.query.sortBy - Sort by
+ * @param {profileController.ProfileListConfiguration['limit']} req.query.limit - Limit
+ * @param {profileController.ProfileListConfiguration['offset']} req.query.offset - Offset
+ * @param {profileController.SearchParameters['filters']['profileFlagIds']} req.query.profileFlagIds
+ */
+profilesRouter.get('/', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { sortDirection, sortBy, limit, offset, ...rest } = req.query;
+
+    const profileFlagIds = decodeURIComponent(rest.profileFlagIds)
+      .split(',')
+      .map(s => parseInt(s, 10))
+      .filter(v => v && !isNaN(v));
+
+    const filters = {
+      profileFlagIds,
+    };
+
+    const result = await profileController.listProfiles(
+      accountSid,
+      { sortDirection, sortBy, limit, offset },
+      { filters },
+    );
+
+    if (isErr(result)) {
+      return next(createError(result.statusCode, result.message));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    return next(createError(500, err.message));
+  }
+});
+
 profilesRouter.get('/identifier/:identifier', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;

--- a/hrm-domain/hrm-service/src/profile/profile.ts
+++ b/hrm-domain/hrm-service/src/profile/profile.ts
@@ -22,6 +22,7 @@ import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import type { NewProfileSectionRecord } from './sql/profile-sections-sql';
 
 export { Identifier, Profile, getIdentifierWithProfiles } from './profile-data-access';
+export { ProfileListConfiguration, SearchParameters } from './profile-data-access';
 
 export const getProfile =
   (task?) =>
@@ -95,6 +96,8 @@ export const getIdentifierByIdentifier = async (
     });
   }
 };
+
+export const listProfiles = profileDB.listProfiles;
 
 export const associateProfileToProfileFlag = async (
   accountSid: string,

--- a/hrm-domain/hrm-service/src/profile/sql/profile-list-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-list-sql.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { pgp } from '../../connection-pool';
+import { OrderByClauseItem, OrderByDirection } from '../../sql';
+
+export const OrderByColumn = {
+  ID: 'id',
+  NAME: 'name',
+} as const;
+
+export type OrderByColumnType = (typeof OrderByColumn)[keyof typeof OrderByColumn];
+
+const ORDER_BY_FIELDS: Record<OrderByColumnType, string> = {
+  id: pgp.as.name('id'),
+  name: pgp.as.name('name'),
+} as const;
+
+const DEFAULT_SORT: OrderByClauseItem[] = [
+  { sortBy: 'id', sortDirection: OrderByDirection.descending },
+];
+
+const generateOrderByClause = (clauses: OrderByClauseItem[]): string => {
+  const validClauses = clauses.filter(c => ORDER_BY_FIELDS[c.sortBy]);
+  if (clauses.length > 0) {
+    return ` ORDER BY ${validClauses
+      .map(t => `${ORDER_BY_FIELDS[t.sortBy]} ${t.sortDirection}`)
+      .join(', ')}`;
+  } else return '';
+};
+
+const selectProfilesUnorderedSql = (whereClause: string) => `
+  SELECT (count(*) OVER())::INTEGER AS "totalCount", id, name
+  FROM "Profiles" profiles
+  ${whereClause}
+`;
+
+const listProfilesPaginatedSql = (whereClause: string, orderByClause: string) => `
+  SELECT *
+  FROM (${selectProfilesUnorderedSql(whereClause)}) AS profiles
+  ${orderByClause}
+  OFFSET $<offset>
+  LIMIT $<limit>;
+`;
+
+export type ProfilesListFilters = {
+  profileFlagIds?: number[];
+};
+
+const filterSql = ({ profileFlagIds }: ProfilesListFilters) => {
+  const filterSqlClauses: string[] = [];
+  if (profileFlagIds && profileFlagIds.length) {
+    filterSqlClauses.push(
+      `profiles.id IN (SELECT "profileId" FROM "ProfilesToProfileFlags" WHERE "profileFlagId" IN ($<profileFlagIds:csv>))`,
+    );
+  }
+  return filterSqlClauses.join(`
+  AND `);
+};
+
+export type ListProfilesQueryBuilder = (
+  filters: ProfilesListFilters,
+  orderByClauses?: OrderByClauseItem[],
+) => string;
+
+const listProfilesBaseQuery = (whereClause: string): ListProfilesQueryBuilder => {
+  return (filters, orderByClauses) => {
+    const whereSql = [whereClause, filterSql(filters)].filter(sql => sql).join(`
+    AND `);
+    const orderBySql = generateOrderByClause(orderByClauses.concat(DEFAULT_SORT));
+    return listProfilesPaginatedSql(whereSql, orderBySql);
+  };
+};
+
+export const listProfilesSql = listProfilesBaseQuery(`
+  WHERE profiles."accountSid" = $<accountSid>
+`);

--- a/hrm-domain/hrm-service/src/sql.ts
+++ b/hrm-domain/hrm-service/src/sql.ts
@@ -23,6 +23,11 @@ export const OrderByDirection = {
   descending: 'DESC',
 } as const;
 
+export type OrderByDirectionType =
+  (typeof OrderByDirection)[keyof typeof OrderByDirection];
+
+export type OrderByClauseItem = { sortBy: string; sortDirection: OrderByDirectionType };
+
 export class DatabaseError extends Error {
   cause: Error;
 


### PR DESCRIPTION
## Description
This PR adds `/profiles` endpoint, which accepts a `GET` operation.
- This endpoint returns the paginated and limited list of client profiles. 
- The following query parameters are valid:
  - `limit` and `offset`: numbers for the pagination.
  - `sortBy`: valid values are`id` and `name`. Used to sort the list. Defaults to `id`.
  - `sortDirection`: valid values are `desc` and `asc`. Used to specify the sort direction. Defaults to `desc`.
  - `profileFlagIds`: a comma separated list of numbers, each representing a profile flag id. If provided, will list the profiles that are associated to at least one of the flags (inclusive OR). Some examples are `profileFlagIds=1`, `profileFlagIds=1,2,3`.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2328)
- [x] New tests added

### Verification steps
Service tests should be enough.