### PR TITLE
Decode file name before submitting to aws client

### DIFF
--- a/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
+++ b/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
@@ -63,18 +63,6 @@ const getSignedS3Url = async (event: AlbHandlerEvent): Promise<GetSignedS3UrlRes
 
   const key = decodeURIComponent(encodedKey);
 
-  console.log('>>>>> parseParametersResult.data', parseParametersResult.data);
-  console.log('>>>>> params', {
-    accountSid,
-    bucket,
-    key,
-    method,
-    objectType,
-    objectId,
-    fileType,
-  });
-  console.log('>>>>> key', key);
-
   const authorization = event.headers?.Authorization || event.headers?.authorization;
 
   const authenticateResult = await authenticate({

--- a/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
+++ b/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
@@ -51,8 +51,29 @@ const getSignedS3Url = async (event: AlbHandlerEvent): Promise<GetSignedS3UrlRes
     return parseParametersResult;
   }
 
-  const { accountSid, bucket, key, method, objectType, objectId, fileType } =
-    parseParametersResult.data;
+  const {
+    accountSid,
+    bucket,
+    key: encodedKey,
+    method,
+    objectType,
+    objectId,
+    fileType,
+  } = parseParametersResult.data;
+
+  const key = decodeURIComponent(encodedKey);
+
+  console.log('>>>>> parseParametersResult.data', parseParametersResult.data);
+  console.log('>>>>> params', {
+    accountSid,
+    bucket,
+    key,
+    method,
+    objectType,
+    objectId,
+    fileType,
+  });
+  console.log('>>>>> key', key);
 
   const authorization = event.headers?.Authorization || event.headers?.authorization;
 

--- a/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
+++ b/hrm-domain/lambdas/files-urls/getSignedS3Url.ts
@@ -51,17 +51,8 @@ const getSignedS3Url = async (event: AlbHandlerEvent): Promise<GetSignedS3UrlRes
     return parseParametersResult;
   }
 
-  const {
-    accountSid,
-    bucket,
-    key: encodedKey,
-    method,
-    objectType,
-    objectId,
-    fileType,
-  } = parseParametersResult.data;
-
-  const key = decodeURIComponent(encodedKey);
+  const { accountSid, bucket, key, method, objectType, objectId, fileType } =
+    parseParametersResult.data;
 
   const authorization = event.headers?.Authorization || event.headers?.authorization;
 

--- a/hrm-domain/lambdas/files-urls/parseParameters.ts
+++ b/hrm-domain/lambdas/files-urls/parseParameters.ts
@@ -78,7 +78,19 @@ export const parseParameters = (event: AlbHandlerEvent): ParseParametersResult =
     return newErr({ message: ERROR_MESSAGES.MISSING_QUERY_STRING_PARAMETERS });
   }
 
-  const { method, bucket, key, objectType, objectId, fileType } = queryStringParameters;
+  const method =
+    queryStringParameters.method && decodeURIComponent(queryStringParameters.method);
+  const bucket =
+    queryStringParameters.bucket && decodeURIComponent(queryStringParameters.bucket);
+  const key = queryStringParameters.key && decodeURIComponent(queryStringParameters.key);
+  const objectType =
+    queryStringParameters.objectType &&
+    decodeURIComponent(queryStringParameters.objectType);
+  const objectId =
+    queryStringParameters.objectId && decodeURIComponent(queryStringParameters.objectId);
+  const fileType =
+    queryStringParameters.fileType && decodeURIComponent(queryStringParameters.fileType);
+
   const { accountSid } = parsePathParameters(path);
   if (!method || !bucket || !key || !accountSid || !objectType || !fileType) {
     return newErr({
@@ -115,10 +127,10 @@ export const parseParameters = (event: AlbHandlerEvent): ParseParametersResult =
       method,
       bucket,
       key,
-      accountSid,
-      fileType: fileType as FileTypes,
       objectType,
       objectId,
+      fileType: fileType as FileTypes,
+      accountSid,
     },
   });
 };


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/1879.

## Description
This PR fixes an issue that was spotted in our production accounts.
The bug causes incompatibilities between the case documents:
- Those that were uploaded **before** https://github.com/techmatters/flex-plugins/commit/7728d5edc6244ceaf26407d839d96a54ed3fca36, can't be consumed in the current version.
  This bug is caused because the client is sending the file name encoded (`encodeURIComponent(fileNameAtAws)`). The fix for the client is in the above related PR.
- Those that were uploaded **after** this change can be consumed, but they have malformed names in the AWS S3 bucket where they are stored (e.g. `1700853007803-Untitled%20Diagram.drawio.png` where it should be `1700853007803-Untitled Diagram.drawio.png`).
  This bug is caused because `files-urls` lambda (and all lambdas really) don't decode the url-encoded parameters sent in the query params, which come via `event.queryStringParameters`. The fix for the client is in this PR, where we just make a call to `decodeURIComponent` before passing the parameters around.
  NOTE: this PR is just decoding the `key` attribute, as it is the only one that can be edited by a user, hence the only one subject to contain spaces (or other special url-encoded characters). We could instead decode all parameters, if considered worth it.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

### Verification steps
This PR is deployed to Development instance.
- Start Flex development server using the above related branch.
- Confirm that old case documents can be retrieved (an example can be found in case with id 1770, submitted by Nick).
- Confirm that uploading a new document does not contains encoded characters in the S3 bucket. Confirm that it can be consumed without troubles.