### PR TITLE
CHI-2476: Remove support for legacy contact category format

### DIFF
--- a/hrm-domain/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case-search.test.ts
@@ -28,8 +28,8 @@ import {
   validateCaseListResponse,
   validateSingleCaseResponse,
 } from './case-validation';
-import * as contactDb from '../src/contact/contact-data-access';
-import { Contact } from '../src/contact/contact-data-access';
+import * as contactDb from '../src/contact/contactDataAccess';
+import { Contact } from '../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import * as mocks from './mocks';
 import { ruleFileWithOneActionOverride } from './permissions-overrides';
@@ -423,28 +423,12 @@ describe('/cases route', () => {
               ),
           ),
         ).toBeTruthy();
-        expect(
-          (<caseApi.CaseService[]>response.body.cases).every(
-            caseObj =>
-              caseObj.connectedContacts?.every(
-                c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
-              ),
-          ),
-        ).toBeTruthy();
       } else {
         expect(
           (<caseApi.CaseService[]>response.body.cases).every(
             caseObj =>
               caseObj.connectedContacts?.every(
                 c => c.conversationMedia?.some(isS3StoredTranscript),
-              ),
-          ),
-        ).toBeFalsy();
-        expect(
-          (<caseApi.CaseService[]>response.body.cases).every(
-            caseObj =>
-              caseObj.connectedContacts?.every(
-                c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
               ),
           ),
         ).toBeFalsy();
@@ -1316,28 +1300,12 @@ describe('/cases route', () => {
                 ),
             ),
           ).toBeTruthy();
-          expect(
-            (<caseApi.CaseService[]>response.body.cases).every(
-              caseObj =>
-                caseObj.connectedContacts?.every(
-                  c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
-                ),
-            ),
-          ).toBeTruthy();
         } else {
           expect(
             (<caseApi.CaseService[]>response.body.cases).every(
               caseObj =>
                 caseObj.connectedContacts?.every(
                   c => c.conversationMedia?.some(isS3StoredTranscript),
-                ),
-            ),
-          ).toBeFalsy();
-          expect(
-            (<caseApi.CaseService[]>response.body.cases).every(
-              caseObj =>
-                caseObj.connectedContacts?.every(
-                  c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
                 ),
             ),
           ).toBeFalsy();

--- a/hrm-domain/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case-search.test.ts
@@ -24,7 +24,6 @@ import * as caseDb from '../src/case/case-data-access';
 import { CaseListFilters, DateExistsCondition } from '../src/case/case-data-access';
 import { db } from '../src/connection-pool';
 import {
-  addLegacyCategoriesToContact,
   fillNameAndPhone,
   validateCaseListResponse,
   validateSingleCaseResponse,
@@ -359,7 +358,7 @@ describe('/cases route', () => {
           const response = await request.get(listRoute).set(headers);
           validateCaseListResponse(
             response,
-            addLegacyCategoriesToContact(expectedCasesAndContacts()),
+            expectedCasesAndContacts(),
             expectedTotalCount,
           );
         },
@@ -1241,7 +1240,7 @@ describe('/cases route', () => {
                 expectedCasesAndContacts(
                   createdCasesAndContacts.map(cc => ({
                     case: cc.case,
-                    contact: addLegacyCategoriesToContact(cc?.contact),
+                    contact: cc?.contact,
                   })),
                 ),
                 expectedTotalCount,

--- a/hrm-domain/hrm-service/service-tests/case-validation.ts
+++ b/hrm-domain/hrm-service/service-tests/case-validation.ts
@@ -16,12 +16,7 @@
 
 import { WELL_KNOWN_CASE_SECTION_NAMES } from '../src/case/caseService';
 import { NewContactRecord } from '../src/contact/sql/contact-insert-sql';
-import {
-  ContactRawJson,
-  CreateContactPayload,
-  WithLegacyCategories,
-} from '../src/contact/contactService';
-import { Contact } from '../src/contact/contact-data-access';
+import { ContactRawJson, CreateContactPayload } from '../src/contact/contactService';
 
 declare global {
   namespace jest {
@@ -101,30 +96,6 @@ export const convertCaseInfoToExpectedInfo = (
   return expectedCase;
 };
 
-export const addLegacyCategoriesToContact = (
-  contact: Contact,
-): WithLegacyCategories<Contact> => {
-  if (contact?.rawJson) {
-    const legacyCategoryEntries = Object.entries(contact.rawJson.categories ?? {}).map(
-      ([category, subcategoryList]) => [
-        category,
-        Object.fromEntries(subcategoryList.map(sc => [sc, true])),
-      ],
-    );
-    return {
-      ...contact,
-      rawJson: {
-        ...contact.rawJson,
-        caseInformation: {
-          ...contact.rawJson.caseInformation,
-          categories: Object.fromEntries(legacyCategoryEntries),
-        },
-      },
-    };
-  }
-  return contact as WithLegacyCategories<Contact>;
-};
-
 export const validateCaseListResponse = (actual, expectedCaseAndContactModels, count) => {
   expect(actual.status).toBe(200);
   if (count === 0) {
@@ -153,7 +124,7 @@ export const validateCaseListResponse = (actual, expectedCaseAndContactModels, c
 
       expect(actual.body.cases[index].connectedContacts).toStrictEqual([
         expect.objectContaining({
-          ...addLegacyCategoriesToContact(expectedContactModel),
+          ...expectedContactModel,
           csamReports: [],
           referrals: [],
           timeOfContact: expect.toParseAsDate(expectedContactModel.timeOfContact),

--- a/hrm-domain/hrm-service/service-tests/case.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case.test.ts
@@ -612,6 +612,10 @@ describe('/cases route', () => {
           originalCase: originalCaseGetter = () => cases.blank,
           customWorkerSid = undefined,
         }) => {
+          if (customWorkerSid) {
+            await mockSuccessfulTwilioAuthentication(customWorkerSid);
+            await new Promise(resolve => setTimeout(resolve, 300));
+          }
           const caseUpdate =
             typeof caseUpdateParam === 'function' ? caseUpdateParam() : caseUpdateParam;
           const originalCase = originalCaseGetter();
@@ -626,7 +630,6 @@ describe('/cases route', () => {
             can: () => true,
           });
 
-          await mockSuccessfulTwilioAuthentication(customWorkerSid ?? workerSid);
           const response = await request
             .put(subRoute(originalCase.id))
             .set(headers)

--- a/hrm-domain/hrm-service/service-tests/case.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case.test.ts
@@ -322,20 +322,10 @@ describe('/cases route', () => {
               c => c.conversationMedia?.some(isS3StoredTranscript),
             ),
           ).toBeTruthy();
-          expect(
-            (<caseApi.CaseService>response.body).connectedContacts?.every(
-              c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
-            ),
-          ).toBeTruthy();
         } else {
           expect(
             (<caseApi.CaseService>response.body).connectedContacts?.every(
               c => c.conversationMedia?.some(isS3StoredTranscript),
-            ),
-          ).toBeFalsy();
-          expect(
-            (<caseApi.CaseService>response.body).connectedContacts?.every(
-              c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
             ),
           ).toBeFalsy();
         }
@@ -717,11 +707,6 @@ describe('/cases route', () => {
           expect(
             (<caseApi.CaseService>response.body).connectedContacts?.every(
               c => c.conversationMedia?.some(isS3StoredTranscript),
-            ),
-          ).toBeTruthy();
-          expect(
-            (<caseApi.CaseService>response.body).connectedContacts?.every(
-              c => c.rawJson?.conversationMedia?.some(cm => cm.store === 'S3'),
             ),
           ).toBeTruthy();
         } else {

--- a/hrm-domain/hrm-service/service-tests/contact-job/contact-job-cleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/contact-job-cleanup.test.ts
@@ -25,7 +25,7 @@ import {
   updateConversationMediaData,
 } from '../../src/conversation-media/conversation-media';
 import { S3ContactMediaType } from '../../src/conversation-media/conversation-media';
-import { getById as getContactById } from '../../src/contact/contact-data-access';
+import { getById as getContactById } from '../../src/contact/contactDataAccess';
 import * as cleanupContactJobsApi from '../../src/contact-job/contact-job-cleanup';
 import {
   completeContactJob,
@@ -40,7 +40,7 @@ useOpenRules();
 const server = getServer();
 const request = getRequest(server);
 
-import type { Contact } from '../../src/contact/contact-data-access';
+import type { Contact } from '../../src/contact/contactDataAccess';
 
 let twilioSpy: jest.SpyInstance;
 

--- a/hrm-domain/hrm-service/service-tests/contact-job/contact-job-data-access.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/contact-job-data-access.test.ts
@@ -32,7 +32,7 @@ useOpenRules();
 const server = getServer();
 const request = getRequest(server);
 
-import type { Contact } from '../../src/contact/contact-data-access';
+import type { Contact } from '../../src/contact/contactDataAccess';
 
 beforeAll(async () => {
   await mockingProxy.start();

--- a/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieve-transcript.test.ts
@@ -32,6 +32,7 @@ import {
   ContactJobType,
 } from '@tech-matters/types';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
+import { CreateContactPayload } from '../../../src/contact/contactService';
 
 const { S3ContactMediaType, isS3StoredTranscriptPending } = conversationMediaApi;
 
@@ -97,20 +98,19 @@ afterAll(async () => {
 });
 
 const createChatContact = async (channel: string, startedTimestamp: number) => {
-  const contactTobeCreated = {
+  const contactTobeCreated: CreateContactPayload = {
     ...withTaskId,
-    rawJson: {
-      ...withTaskId.rawJson,
-      conversationMedia: [
-        {
-          store: 'S3' as const,
+    channel,
+    taskId: `${withTaskId.taskId}-${channel}`,
+    conversationMedia: [
+      {
+        storeType: 'S3' as const,
+        storeTypeSpecificData: {
           type: S3ContactMediaType.TRANSCRIPT,
           location: undefined,
         },
-      ],
-    },
-    channel,
-    taskId: `${withTaskId.taskId}-${channel}`,
+      },
+    ],
   };
   const contact = await contactApi.createContact(
     accountSid,
@@ -122,12 +122,6 @@ const createChatContact = async (channel: string, startedTimestamp: number) => {
       user: twilioUser(workerSid, []),
     },
   );
-
-  const contactWithoutLegacyCompatibility = {
-    ...contact,
-  };
-  delete contactWithoutLegacyCompatibility.rawJson.caseInformation.categories;
-  delete contactWithoutLegacyCompatibility.rawJson.conversationMedia;
 
   const jobs = await selectJobsByContactId(contact.id, contact.accountSid);
 
@@ -156,12 +150,7 @@ const createChatContact = async (channel: string, startedTimestamp: number) => {
   createdContact = contact;
   createdJobs = jobs;
 
-  return [
-    contact,
-    retrieveContactTranscriptJob,
-    jobs,
-    contactWithoutLegacyCompatibility,
-  ] as const;
+  return [contact, retrieveContactTranscriptJob, jobs] as const;
 };
 
 describe('publish retrieve-transcript job type', () => {
@@ -171,8 +160,10 @@ describe('publish retrieve-transcript job type', () => {
     })),
   ).test('$channel pending job is published when considered due', async ({ channel }) => {
     const startedTimestamp = Date.now();
-    const [contact, retrieveContactTranscriptJob, , contactWithoutLegacyCompatibility] =
-      await createChatContact(channel, startedTimestamp);
+    const [contact, retrieveContactTranscriptJob] = await createChatContact(
+      channel,
+      startedTimestamp,
+    );
 
     const publishDueContactJobsSpy = jest.spyOn(
       contactJobPublish,
@@ -208,7 +199,7 @@ describe('publish retrieve-transcript job type', () => {
       lastAttempt: expect.any(Date),
       numberOfAttempts: 1,
       resource: {
-        ...contactWithoutLegacyCompatibility,
+        ...contact,
         conversationMedia: contact.conversationMedia?.map(cm => ({
           ...cm,
           createdAt: expect.toParseAsDate(cm.createdAt),

--- a/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
@@ -25,7 +25,7 @@ import { accountSid, contact1, withTaskIdAndTranscript, workerSid } from '../moc
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import each from 'jest-each';
 import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
-import * as contactDb from '../../src/contact/contact-data-access';
+import * as contactDb from '../../src/contact/contactDataAccess';
 import { ruleFileWithOneActionOverride } from '../permissions-overrides';
 import { isS3StoredTranscript } from '../../src/conversation-media/conversation-media-data-access';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
@@ -642,19 +642,9 @@ describe('/contacts/:contactId route', () => {
         expect(
           (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
         ).toBeTruthy();
-        expect(
-          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-            cm => cm.store === 'S3',
-          ),
-        ).toBeTruthy();
       } else {
         expect(
           (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
-        ).toBeFalsy();
-        expect(
-          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-            cm => cm.store === 'S3',
-          ),
         ).toBeFalsy();
       }
 

--- a/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contact-patch.test.ts
@@ -18,7 +18,6 @@ import {
   ContactRawJson,
   CreateContactPayload,
   PatchPayload,
-  WithLegacyCategories,
 } from '../../src/contact/contactService';
 import '../case-validation';
 import * as contactApi from '../../src/contact/contactService';
@@ -39,9 +38,6 @@ import {
   deleteContactById,
   deleteJobsByContactId,
 } from './db-cleanup';
-
-type ContactRawJsonWithLegacyCategories =
-  WithLegacyCategories<contactDb.Contact>['rawJson'];
 
 useOpenRules();
 const server = getServer();
@@ -72,7 +68,7 @@ describe('/contacts/:contactId route', () => {
       patch: PatchPayload['rawJson'];
       description: string;
       original?: ContactRawJson;
-      expected: ContactRawJsonWithLegacyCategories;
+      expected: Partial<ContactRawJson>;
     };
     const subRoute = contactId => `${route}/${contactId}`;
 
@@ -93,24 +89,16 @@ describe('/contacts/:contactId route', () => {
       expect(response.status).toBe(401);
       expect(response.body.error).toBe('Authorization failed');
     });
-    describe('rawJson changes', () => {
+
+    describe('rawJson is updated to be compatible', () => {
       const sampleRawJson: ContactRawJson = {
-        ...(contact1.rawJson as ContactRawJson),
+        ...contact1.rawJson,
         categories: {
           a: ['a2'],
           b: ['b1'],
         },
       };
-      const sampleRawJsonWithLegacyCategories = {
-        ...sampleRawJson,
-        caseInformation: {
-          ...sampleRawJson.caseInformation,
-          categories: {
-            a: { a2: true },
-            b: { b1: true },
-          },
-        },
-      };
+
       const tests: TestOptions[] = [
         {
           description: 'set callType to data call type',
@@ -119,9 +107,6 @@ describe('/contacts/:contactId route', () => {
           },
           expected: {
             callType: 'Child calling about self',
-            caseInformation: {
-              categories: {},
-            },
           },
         },
         {
@@ -131,9 +116,6 @@ describe('/contacts/:contactId route', () => {
           },
           expected: {
             callType: 'Hang up',
-            caseInformation: {
-              categories: {},
-            },
           },
         },
         {
@@ -151,9 +133,6 @@ describe('/contacts/:contactId route', () => {
               lastName: 'Ballantyne',
               some: 'property',
             },
-            caseInformation: {
-              categories: {},
-            },
           },
         },
         {
@@ -170,9 +149,6 @@ describe('/contacts/:contactId route', () => {
               firstName: 'Lorna',
               lastName: 'Ballantyne',
               some: 'other property',
-            },
-            caseInformation: {
-              categories: {},
             },
           },
         },
@@ -192,9 +168,6 @@ describe('/contacts/:contactId route', () => {
             },
             caseInformation: {
               other: 'case property',
-              categories: {
-                category1: { subcategory1: true, subcategory2: true },
-              },
             },
           },
         },
@@ -208,7 +181,6 @@ describe('/contacts/:contactId route', () => {
           expected: {
             caseInformation: {
               other: 'case property',
-              categories: {},
             },
           },
         },
@@ -218,20 +190,13 @@ describe('/contacts/:contactId route', () => {
             categories: {
               category1: ['subcategory1', 'subcategory2'],
             },
-            caseInformation: {},
           },
           expected: {
-            caseInformation: {
-              categories: {
-                category1: { subcategory1: true, subcategory2: true },
-              },
-            },
             categories: {
               category1: ['subcategory1', 'subcategory2'],
             },
           },
         },
-
         {
           description: 'overwrite callType as data call type',
           original: sampleRawJson,
@@ -239,7 +204,7 @@ describe('/contacts/:contactId route', () => {
             callType: 'Child calling about self',
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             callType: 'Child calling about self',
           },
         },
@@ -250,7 +215,7 @@ describe('/contacts/:contactId route', () => {
             callType: 'Hang up',
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             callType: 'Hang up',
           },
         },
@@ -265,7 +230,7 @@ describe('/contacts/:contactId route', () => {
             },
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             childInformation: {
               firstName: 'Lorna',
               lastName: 'Ballantyne',
@@ -284,7 +249,7 @@ describe('/contacts/:contactId route', () => {
             },
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             callerInformation: {
               firstName: 'Lorna',
               lastName: 'Ballantyne',
@@ -304,12 +269,9 @@ describe('/contacts/:contactId route', () => {
             },
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             caseInformation: {
               other: 'overwrite case property',
-              categories: {
-                category1: { subcategory1: true, subcategory2: true },
-              },
             },
             categories: {
               category1: ['subcategory1', 'subcategory2'],
@@ -325,10 +287,9 @@ describe('/contacts/:contactId route', () => {
             },
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
+            ...sampleRawJson,
             caseInformation: {
               other: 'case property',
-              categories: sampleRawJsonWithLegacyCategories.caseInformation.categories,
             },
           },
         },
@@ -341,17 +302,7 @@ describe('/contacts/:contactId route', () => {
             },
           },
           expected: {
-            ...sampleRawJsonWithLegacyCategories,
-            caseInformation: {
-              ...sampleRawJsonWithLegacyCategories.caseInformation,
-              categories: {
-                category1: {
-                  subcategory1: true,
-                  subcategory2: true,
-                },
-              },
-            },
-
+            ...sampleRawJson,
             categories: {
               category1: ['subcategory1', 'subcategory2'],
             },
@@ -380,25 +331,7 @@ describe('/contacts/:contactId route', () => {
               .send({ rawJson: patch });
 
             expect(response.status).toBe(200);
-            const { categories, ...caseInformationWithoutLegacyCategories } =
-              expected?.caseInformation ?? {};
-            const expectedInDb: Partial<ContactRawJson> = expected?.caseInformation
-              ? {
-                  ...expected,
-                  caseInformation: caseInformationWithoutLegacyCategories as Record<
-                    string,
-                    string | boolean
-                  >,
-                }
-              : (expected as Partial<ContactRawJson>);
-            // Bodge a corner case where an absent caseInformation is untouched by the patch operation
-            if (
-              !original?.caseInformation &&
-              !patch?.caseInformation &&
-              !patch?.categories
-            ) {
-              delete expectedInDb.caseInformation;
-            }
+
             expect(response.body).toStrictEqual({
               ...createdContact,
               timeOfContact: expect.toParseAsDate(createdContact.timeOfContact),
@@ -419,7 +352,7 @@ describe('/contacts/:contactId route', () => {
               createdAt: expect.toParseAsDate(createdContact.createdAt),
               updatedAt: expect.toParseAsDate(),
               updatedBy: workerSid,
-              rawJson: expectedInDb,
+              rawJson: expected,
               csamReports: [],
               referrals: [],
             });
@@ -515,7 +448,7 @@ describe('/contacts/:contactId route', () => {
             original,
             { user: twilioUser(workerSid, []), can: () => true },
           );
-          const expected: WithLegacyCategories<contactDb.Contact> = {
+          const expected: contactDb.Contact = {
             ...createdContact,
             ...expectedDifferences,
             rawJson: {
@@ -524,7 +457,6 @@ describe('/contacts/:contactId route', () => {
               caseInformation: {
                 ...createdContact.rawJson!.caseInformation,
                 ...expectedDifferences?.rawJson?.caseInformation,
-                categories: {},
               },
             },
           };
@@ -536,28 +468,6 @@ describe('/contacts/:contactId route', () => {
               .send(patch);
 
             expect(response.status).toBe(200);
-            const { categories, ...caseInformationWithoutLegacyCategories } =
-              expected.rawJson?.caseInformation ?? {};
-            const expectedInDb: contactApi.Contact = expected.rawJson?.caseInformation
-              ? ({
-                  ...expected,
-                  rawJson: {
-                    ...expected.rawJson,
-                    caseInformation: caseInformationWithoutLegacyCategories as Record<
-                      string,
-                      string | boolean
-                    >,
-                  },
-                } as contactApi.Contact)
-              : (expected as contactApi.Contact);
-            // Bodge a corner case where an absent caseInformation is untouched by the patch operation
-            if (
-              !original.rawJson?.caseInformation &&
-              !patch.rawJson?.caseInformation &&
-              !patch.rawJson?.categories
-            ) {
-              delete (expectedInDb.rawJson as any).caseInformation;
-            }
             expect(response.body).toStrictEqual({
               ...expected,
               timeOfContact: expect.toParseAsDate(expected.timeOfContact),
@@ -571,7 +481,7 @@ describe('/contacts/:contactId route', () => {
             const savedContact = await contactDb.getById(accountSid, existingContactId);
 
             expect(savedContact).toStrictEqual({
-              ...expectedInDb,
+              ...expected,
               createdAt: expect.toParseAsDate(createdContact.createdAt),
               updatedAt: expect.toParseAsDate(),
               updatedBy: workerSid,

--- a/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
@@ -16,7 +16,7 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson, WithLegacyCategories } from '../../src/contact/contactService';
+import { ContactRawJson } from '../../src/contact/contact-json';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
@@ -45,7 +45,7 @@ const cleanup = async () => {
   await cleanupCases();
 };
 
-let createdContact: WithLegacyCategories<contactDb.Contact>;
+let createdContact: contactDb.Contact;
 
 beforeEach(async () => {
   await cleanup();

--- a/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
@@ -16,11 +16,11 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson } from '../../src/contact/contact-json';
+import { ContactRawJson } from '../../src/contact/contactJson';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
-import * as contactDb from '../../src/contact/contact-data-access';
+import * as contactDb from '../../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import {
   cleanupCases,

--- a/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
@@ -16,7 +16,7 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson, WithLegacyCategories } from '../../src/contact/contactService';
+import { ContactRawJson } from '../../src/contact/contact-json';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
@@ -45,7 +45,7 @@ const cleanup = async () => {
   await cleanupCases();
 };
 
-let createdContact: WithLegacyCategories<contactDb.Contact>;
+let createdContact: contactDb.Contact;
 
 beforeEach(async () => {
   await cleanup();

--- a/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
@@ -16,11 +16,11 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson } from '../../src/contact/contact-json';
+import { ContactRawJson } from '../../src/contact/contactJson';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
-import * as contactDb from '../../src/contact/contact-data-access';
+import * as contactDb from '../../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import {
   cleanupCases,

--- a/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
@@ -16,11 +16,11 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson } from '../../src/contact/contact-json';
+import { ContactRawJson } from '../../src/contact/contactJson';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
-import * as contactDb from '../../src/contact/contact-data-access';
+import * as contactDb from '../../src/contact/contactDataAccess';
 import {
   isS3StoredTranscript,
   NewConversationMedia,
@@ -274,12 +274,6 @@ describe('/contacts/:contactId/conversationMedia route', () => {
             accountSid,
           }),
         );
-        const legacyExpectedContactMedia = (expectedContactMedia ?? postedMedia).map(
-          media => ({
-            store: media.storeType,
-            ...media.storeTypeSpecificData,
-          }),
-        );
 
         const expectedResponse = {
           ...createdContact,
@@ -288,10 +282,6 @@ describe('/contacts/:contactId/conversationMedia route', () => {
           updatedAt: expect.toParseAsDate(),
           timeOfContact: expect.toParseAsDate(),
           conversationMedia: fullExpectedContactMedia,
-          rawJson: {
-            ...createdContact.rawJson,
-            conversationMedia: legacyExpectedContactMedia,
-          },
         };
 
         const response = await request
@@ -386,20 +376,10 @@ describe('/contacts/:contactId/conversationMedia route', () => {
               isS3StoredTranscript,
             ),
           ).toBeTruthy();
-          expect(
-            (<contactApi.Contact>contactWithMedia).rawJson?.conversationMedia?.some(
-              cm => cm.store === 'S3',
-            ),
-          ).toBeTruthy();
         } else {
           expect(
             (<contactApi.Contact>contactWithMedia).conversationMedia?.some(
               isS3StoredTranscript,
-            ),
-          ).toBeFalsy();
-          expect(
-            (<contactApi.Contact>contactWithMedia).rawJson?.conversationMedia?.some(
-              cm => cm.store === 'S3',
             ),
           ).toBeFalsy();
         }

--- a/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
@@ -16,7 +16,7 @@
 
 import * as contactApi from '../../src/contact/contactService';
 import '../case-validation';
-import { ContactRawJson, WithLegacyCategories } from '../../src/contact/contactService';
+import { ContactRawJson } from '../../src/contact/contact-json';
 import { accountSid, contact1, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
@@ -55,7 +55,7 @@ const cleanup = async () => {
   await cleanupCases();
 };
 
-let createdContact: WithLegacyCategories<contactDb.Contact>;
+let createdContact: contactDb.Contact;
 
 beforeEach(async () => {
   await cleanup();

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -248,7 +248,7 @@ describe('/contacts route', () => {
       },
       {
         contact: {
-          rawJson: {},
+          rawJson: {} as ContactRawJson,
           twilioWorkerId: null,
           helpline: null,
           queueName: null,
@@ -1110,20 +1110,6 @@ describe('/contacts route', () => {
         );
       });
 
-      const expectLegacyRawJsonToEqualRawJson = (
-        actual: contactApi.WithLegacyCategories<contactDb.Contact>['rawJson'],
-        expected: contactApi.WithLegacyCategories<contactDb.Contact>['rawJson'],
-        legacyCategories: Record<string, Record<string, boolean>> = {},
-      ) => {
-        expect(actual).toStrictEqual({
-          ...expected,
-          caseInformation: {
-            ...expected.caseInformation,
-            categories: legacyCategories,
-          },
-        });
-      };
-
       each([
         {
           body: { firstName: 'jh', lastName: 'he' },
@@ -1134,8 +1120,8 @@ describe('/contacts route', () => {
             const { contacts, count } = response.body;
 
             const [c2, c1] = contacts; // result is sorted DESC
-            expectLegacyRawJsonToEqualRawJson(c1.details, contact1.rawJson);
-            expectLegacyRawJsonToEqualRawJson(c2.details, contact2.rawJson);
+            expect(c1.details).toStrictEqual(contact1.rawJson);
+            expect(c2.details).toStrictEqual(contact2.rawJson);
 
             // Test the association
             expect(c1.csamReports).toHaveLength(0);
@@ -1155,8 +1141,8 @@ describe('/contacts route', () => {
             const { contacts, count } = response.body;
 
             const [c2, c1] = contacts; // result is sorted DESC
-            expectLegacyRawJsonToEqualRawJson(c1.details, contact1.rawJson);
-            expectLegacyRawJsonToEqualRawJson(c2.details, contact2.rawJson);
+            expect(c1.details).toStrictEqual(contact1.rawJson);
+            expect(c2.details).toStrictEqual(contact2.rawJson);
 
             // Test the association
             expect(c1.csamReports).toHaveLength(0);
@@ -1185,7 +1171,7 @@ describe('/contacts route', () => {
             expect(response.status).toBe(200);
             expect(count).toBe(1);
             const [a] = contacts;
-            expectLegacyRawJsonToEqualRawJson(a.details, another1.rawJson);
+            expect(a.details).toStrictEqual(another1.rawJson);
           },
         },
         {
@@ -1257,7 +1243,7 @@ describe('/contacts route', () => {
               const { count, contacts } = response.body;
               expect(response.status).toBe(200);
               expect(count).toBe(1);
-              expectLegacyRawJsonToEqualRawJson(contacts[0].details, another2.rawJson);
+              expect(contacts[0].details).toStrictEqual(another2.rawJson);
             },
           };
         }),
@@ -1277,7 +1263,7 @@ describe('/contacts route', () => {
               const { count, contacts } = response.body;
               expect(response.status).toBe(200);
               expect(count).toBe(1);
-              expectLegacyRawJsonToEqualRawJson(contacts[0].details, another2.rawJson);
+              expect(contacts[0].details).toStrictEqual(another2.rawJson);
             },
           };
         }),
@@ -1449,9 +1435,8 @@ describe('/contacts route', () => {
             expect(count).toBe(2);
 
             const [c2, c1] = contacts; // result is sorted DESC
-            expectLegacyRawJsonToEqualRawJson(c1.details, contact1.rawJson);
-            expectLegacyRawJsonToEqualRawJson(c2.details, contact2.rawJson);
-
+            expect(c1.details).toStrictEqual(contact1.rawJson);
+            expect(c2.details).toStrictEqual(contact2.rawJson);
             // Test the association
             expect(c1.csamReports).toHaveLength(0);
             expect(c2.csamReports).toHaveLength(0);

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -19,7 +19,7 @@ import { addSeconds, parseISO, subDays, subHours, subSeconds } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 
 import { db } from '../src/connection-pool';
-import { ContactRawJson } from '../src/contact/contact-json';
+import { ContactRawJson } from '../src/contact/contactJson';
 import {
   isS3StoredTranscript,
   NewConversationMedia,
@@ -46,7 +46,7 @@ import './case-validation';
 import * as caseApi from '../src/case/caseService';
 import * as caseDb from '../src/case/case-data-access';
 import * as contactApi from '../src/contact/contactService';
-import * as contactDb from '../src/contact/contact-data-access';
+import * as contactDb from '../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import * as contactJobDataAccess from '../src/contact-job/contact-job-data-access';
 import { chatChannels } from '../src/contact/channelTypes';
@@ -792,15 +792,14 @@ describe('/contacts route', () => {
         channel,
         contact: {
           ...withTaskId,
-          rawJson: {
-            ...withTaskId.rawJson,
-            conversationMedia: [
-              {
-                store: 'S3',
+          conversationMedia: [
+            {
+              storeType: 'S3',
+              storeTypeSpecificData: {
                 type: S3ContactMediaType.TRANSCRIPT,
               },
-            ],
-          },
+            },
+          ],
           channel,
           taskId: `${withTaskId.taskId}-${channel}`,
         },
@@ -852,15 +851,14 @@ describe('/contacts route', () => {
         channel,
         contact: {
           ...withTaskId,
-          rawJson: {
-            ...withTaskId.rawJson,
-            conversationMedia: [
-              {
-                store: 'S3',
+          conversationMedia: [
+            {
+              storeType: 'S3',
+              storeSpecificData: {
                 type: S3ContactMediaType.TRANSCRIPT,
               },
-            ],
-          },
+            },
+          ],
           channel,
           taskId: `${withTaskId.taskId}-${channel}`,
         },
@@ -897,15 +895,14 @@ describe('/contacts route', () => {
         channel,
         contact: {
           ...withTaskId,
-          rawJson: {
-            ...withTaskId.rawJson,
-            conversationMedia: [
-              {
-                store: 'S3',
+          conversationMedia: [
+            {
+              storeType: 'S3',
+              storeTypeSpecificData: {
                 type: S3ContactMediaType.TRANSCRIPT,
               },
-            ],
-          },
+            },
+          ],
           channel,
           taskId: `${withTaskId.taskId}-${channel}`,
         },
@@ -977,8 +974,8 @@ describe('/contacts route', () => {
           (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
         ).toBeTruthy();
         expect(
-          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-            cm => cm.store === 'S3',
+          (<contactApi.Contact>res.body).conversationMedia?.some(
+            cm => cm.storeType === 'S3',
           ),
         ).toBeTruthy();
       } else {
@@ -986,8 +983,8 @@ describe('/contacts route', () => {
           (<contactApi.Contact>res.body).conversationMedia?.some(isS3StoredTranscript),
         ).toBeFalsy();
         expect(
-          (<contactApi.Contact>res.body).rawJson?.conversationMedia?.some(
-            cm => cm.store === 'S3',
+          (<contactApi.Contact>res.body).conversationMedia?.some(
+            cm => cm.storeType === 'S3',
           ),
         ).toBeFalsy();
       }
@@ -1497,9 +1494,9 @@ describe('/contacts route', () => {
             ),
           ).toBeTruthy();
           expect(
-            (<contactApi.SearchContact>(
-              res.body.contacts[0]
-            )).details.conversationMedia?.some(cm => cm.store === 'S3'),
+            (<contactApi.SearchContact>res.body.contacts[0]).conversationMedia?.some(
+              cm => cm.storeType === 'S3',
+            ),
           ).toBeTruthy();
         } else {
           expect(
@@ -1508,9 +1505,9 @@ describe('/contacts route', () => {
             ),
           ).toBeFalsy();
           expect(
-            (<contactApi.SearchContact>(
-              res.body.contacts[0]
-            )).details.conversationMedia?.some(cm => cm.store === 'S3'),
+            (<contactApi.SearchContact>res.body.contacts[0]).conversationMedia?.some(
+              cm => cm.storeType === 'S3',
+            ),
           ).toBeFalsy();
         }
 

--- a/hrm-domain/hrm-service/service-tests/mocks.ts
+++ b/hrm-domain/hrm-service/service-tests/mocks.ts
@@ -17,7 +17,7 @@
 import { CaseService } from '../src/case/caseService';
 import { channelTypes } from '../src/contact/channelTypes';
 import { S3ContactMediaType } from '../src/conversation-media/conversation-media';
-import { Contact } from '../src/contact/contact-data-access';
+import { Contact } from '../src/contact/contactDataAccess';
 import { CreateContactPayload } from '../src/contact/contactService';
 
 export const accountSid = 'ACCOUNT_SID';
@@ -302,17 +302,19 @@ export const withTaskIdAndTranscript: CreateContactPayload = {
       firstName: 'withTaskIdAndTranscript',
       lastName: 'withTaskIdAndTranscript',
     },
-    conversationMedia: [
-      {
-        store: 'S3' as const,
+  },
+  conversationMedia: [
+    {
+      storeType: 'S3',
+      storeTypeSpecificData: {
         type: S3ContactMediaType.TRANSCRIPT,
         location: {
           bucket: 'mock-bucket',
           key: 'mockKey',
         },
       },
-    ],
-  },
+    },
+  ],
   channel: channelTypes.web,
   taskId: `${withTaskId.taskId}-transcript-permissions-test`,
 };

--- a/hrm-domain/hrm-service/service-tests/permissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/permissions.test.ts
@@ -24,7 +24,7 @@ import {
   S3ContactMediaType,
 } from '../src/conversation-media/conversation-media';
 import { db } from '../src/connection-pool';
-import * as contactDB from '../src/contact/contact-data-access';
+import * as contactDB from '../src/contact/contactDataAccess';
 import * as conversationMediaDB from '../src/conversation-media/conversation-media-data-access';
 import { NewContactRecord } from '../src/contact/sql/contact-insert-sql';
 

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -416,9 +416,7 @@ describe('/profiles', () => {
         );
       });
 
-      const convertContactToExpect = (
-        contact: contactApi.WithLegacyCategories<contactApi.Contact>,
-      ) => ({
+      const convertContactToExpect = (contact: contactApi.Contact) => ({
         ...contact,
         createdAt: expect.toParseAsDate(),
         updatedAt: expect.toParseAsDate(),

--- a/hrm-domain/hrm-service/service-tests/search-permissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/search-permissions.test.ts
@@ -29,7 +29,7 @@ import {
   defaultConfig,
   useOpenRules,
 } from './server';
-import { SearchParameters as ContactSearchParameters } from '../src/contact/contact-data-access';
+import { SearchParameters as ContactSearchParameters } from '../src/contact/contactDataAccess';
 import { SearchParameters as CaseSearchParameters } from '../src/case/caseService';
 
 useOpenRules();

--- a/hrm-domain/hrm-service/src/case/case-data-access.ts
+++ b/hrm-domain/hrm-service/src/case/case-data-access.ts
@@ -29,7 +29,7 @@ import {
 } from './sql/case-sections-sql';
 import { DELETE_BY_ID } from './sql/case-delete-sql';
 import { selectSingleCaseByIdSql } from './sql/case-get-sql';
-import { Contact } from '../contact/contact-data-access';
+import { Contact } from '../contact/contactDataAccess';
 import { OrderByDirectionType } from '../sql';
 
 export type CaseRecordCommon = {

--- a/hrm-domain/hrm-service/src/case/caseService.ts
+++ b/hrm-domain/hrm-service/src/case/caseService.ts
@@ -35,7 +35,7 @@ import {
   update,
 } from './case-data-access';
 import { randomUUID } from 'crypto';
-import type { Contact } from '../contact/contact-data-access';
+import type { Contact } from '../contact/contactDataAccess';
 import { setupCanForRules } from '../permissions/setupCanForRules';
 import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { bindApplyTransformations as bindApplyContactTransformations } from '../contact/contactService';

--- a/hrm-domain/hrm-service/src/case/caseService.ts
+++ b/hrm-domain/hrm-service/src/case/caseService.ts
@@ -38,10 +38,7 @@ import { randomUUID } from 'crypto';
 import type { Contact } from '../contact/contact-data-access';
 import { setupCanForRules } from '../permissions/setupCanForRules';
 import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
-import {
-  bindApplyTransformations as bindApplyContactTransformations,
-  WithLegacyCategories,
-} from '../contact/contactService';
+import { bindApplyTransformations as bindApplyContactTransformations } from '../contact/contactService';
 import type { SearchPermissions } from '../permissions/search-permissions';
 import type { Profile } from '../profile/profile-data-access';
 import type { PaginationQuery } from '../search';
@@ -87,11 +84,7 @@ export type CaseService = CaseRecordCommon & {
   id: number;
   childName?: string;
   categories: Record<string, string[]>;
-  connectedContacts?: WithLegacyCategories<Contact>[];
-};
-
-type CaseRecordWithLegacyCategoryContacts = Omit<CaseRecord, 'connectedContacts'> & {
-  connectedContacts: WithLegacyCategories<Contact>[];
+  connectedContacts?: Contact[];
 };
 
 /**
@@ -150,7 +143,7 @@ const caseSectionRecordsToInfo = (
   }, infoLists);
 };
 
-const addCategories = (caseItem: CaseRecordWithLegacyCategoryContacts) => {
+const addCategories = (caseItem: CaseRecord) => {
   const fstContact = (caseItem.connectedContacts ?? [])[0];
 
   return { ...caseItem, categories: fstContact?.rawJson?.categories ?? {} };
@@ -191,7 +184,7 @@ const caseToCaseRecord = (
   };
 };
 
-const caseRecordToCase = (record: CaseRecordWithLegacyCategoryContacts): CaseService => {
+const caseRecordToCase = (record: CaseRecord): CaseService => {
   // Remove legacy case sections
   const info = {
     ...record.info,
@@ -245,8 +238,7 @@ export const createCase = async (
   const created = await create(record, accountSid);
 
   // A new case is always initialized with empty connected contacts. No need to apply mapContactTransformations here
-  // This also means the cast to the legacy category type is safe
-  return caseRecordToCase(created as CaseRecordWithLegacyCategoryContacts);
+  return caseRecordToCase(created);
 };
 
 export const updateCase = async (

--- a/hrm-domain/hrm-service/src/case/sql/case-search-sql.ts
+++ b/hrm-domain/hrm-service/src/case/sql/case-search-sql.ts
@@ -188,16 +188,8 @@ const SEARCH_WHERE_CLAUSE = `(
           AND (
             (
             ${nameAndPhoneNumberSearchSql(
-              [
-                "c.\"rawJson\"->'childInformation'->>'firstName'",
-                // Legacy format support, remove when old contacts are migrated
-                "c.\"rawJson\"->'childInformation'->'name'->>'firstName'",
-              ],
-              [
-                "c.\"rawJson\"->'childInformation'->>'lastName'",
-                // Legacy format support, remove when old contacts are migrated
-                "c.\"rawJson\"->'childInformation'->'name'->>'lastName'",
-              ],
+              ["c.\"rawJson\"->'childInformation'->>'firstName'"],
+              ["c.\"rawJson\"->'childInformation'->>'lastName'"],
               [
                 "c.\"rawJson\"->'childInformation'->'location'->>'phone1'",
                 "c.\"rawJson\"->'childInformation'->'location'->>'phone2'",
@@ -207,16 +199,8 @@ const SEARCH_WHERE_CLAUSE = `(
             -- search on callerInformation of connectedContacts
             OR ( 
               ${nameAndPhoneNumberSearchSql(
-                [
-                  "c.\"rawJson\"->'callerInformation'->>'firstName'",
-                  // Legacy format support, remove when old contacts are migrated
-                  "c.\"rawJson\"->'callerInformation'->'name'->>'firstName'",
-                ],
-                [
-                  "c.\"rawJson\"->'callerInformation'->>'lastName'",
-                  // Legacy format support, remove when old contacts are migrated
-                  "c.\"rawJson\"->'callerInformation'->'name'->>'lastName'",
-                ],
+                ["c.\"rawJson\"->'callerInformation'->>'firstName'"],
+                ["c.\"rawJson\"->'callerInformation'->>'lastName'"],
                 [
                   "c.\"rawJson\"->'callerInformation'->'location'->>'phone1'",
                   "c.\"rawJson\"->'callerInformation'->'location'->>'phone2'",

--- a/hrm-domain/hrm-service/src/contact-job/contact-job-data-access.ts
+++ b/hrm-domain/hrm-service/src/contact-job/contact-job-data-access.ts
@@ -15,7 +15,7 @@
  */
 
 import { db, pgp } from '../connection-pool';
-import type { Contact } from '../contact/contact-data-access';
+import type { Contact } from '../contact/contactDataAccess';
 import {
   ADD_FAILED_ATTEMPT_PAYLOAD,
   ContactJobCleanupStatus,

--- a/hrm-domain/hrm-service/src/contact/canPerformContactAction.ts
+++ b/hrm-domain/hrm-service/src/contact/canPerformContactAction.ts
@@ -15,12 +15,7 @@
  */
 
 import asyncHandler from '../async-handler';
-import {
-  Contact,
-  getContactById,
-  PatchPayload,
-  WithLegacyCategories,
-} from './contactService';
+import { Contact, getContactById, PatchPayload } from './contactService';
 import { actionsMaps } from '../permissions';
 import { getClient } from '@tech-matters/twilio-client';
 import { isTwilioTaskTransferTarget } from '@tech-matters/twilio-client';
@@ -29,11 +24,8 @@ import { getCase } from '../case/caseService';
 
 const authorizeIfAdditionalValidationPasses = async (
   req: any,
-  contact: WithLegacyCategories<Contact>,
-  additionalValidation: (
-    contact: WithLegacyCategories<Contact>,
-    req: any,
-  ) => Promise<boolean>,
+  contact: Contact,
+  additionalValidation: (contact: Contact, req: any) => Promise<boolean>,
 ) => {
   if (await additionalValidation(contact, req)) {
     req.authorize();
@@ -44,10 +36,8 @@ const authorizeIfAdditionalValidationPasses = async (
 
 const canPerformActionOnContact = (
   action: (typeof actionsMaps.contact)[keyof typeof actionsMaps.contact],
-  additionalValidation: (
-    contact: WithLegacyCategories<Contact>,
-    req: any,
-  ) => Promise<boolean> = () => Promise.resolve(true),
+  additionalValidation: (contact: Contact, req: any) => Promise<boolean> = () =>
+    Promise.resolve(true),
 ) =>
   asyncHandler(async (req, res, next) => {
     if (!req.isAuthorized()) {
@@ -164,7 +154,7 @@ const canRemoveFromCase = async (
 const canConnectContact = canPerformActionOnContact(
   actionsMaps.contact.ADD_CONTACT_TO_CASE,
   async (
-    { caseId: originalCaseId }: WithLegacyCategories<Contact>,
+    { caseId: originalCaseId }: Contact,
     { can, user, accountSid, body: { caseId: targetCaseId } },
   ) => {
     if (!(await canRemoveFromCase(originalCaseId, { can, user, accountSid }))) {
@@ -181,7 +171,7 @@ const canConnectContact = canPerformActionOnContact(
 
 export const canDisconnectContact = canPerformActionOnContact(
   actionsMaps.contact.REMOVE_CONTACT_FROM_CASE,
-  async ({ caseId }: WithLegacyCategories<Contact>, { can, user, accountSid }) =>
+  async ({ caseId }: Contact, { can, user, accountSid }) =>
     canRemoveFromCase(caseId, { can, user, accountSid }),
 );
 

--- a/hrm-domain/hrm-service/src/contact/contactDataAccess.ts
+++ b/hrm-domain/hrm-service/src/contact/contactDataAccess.ts
@@ -26,7 +26,7 @@ import {
   selectSingleContactByTaskId,
 } from './sql/contact-get-sql';
 import { INSERT_CONTACT_SQL, NewContactRecord } from './sql/contact-insert-sql';
-import { ContactRawJson, ReferralWithoutContactId } from './contact-json';
+import { ContactRawJson, ReferralWithoutContactId } from './contactJson';
 import type { ITask } from 'pg-promise';
 import { txIfNotInOne } from '../sql';
 import { ConversationMedia } from '../conversation-media/conversation-media';
@@ -81,7 +81,6 @@ const BLANK_CONTACT_UPDATES: ContactUpdates = {
   helpline: undefined,
   channel: undefined,
   number: undefined,
-  conversationMedia: undefined,
   timeOfContact: undefined,
   taskId: undefined,
   channelSid: undefined,

--- a/hrm-domain/hrm-service/src/contact/contactJson.ts
+++ b/hrm-domain/hrm-service/src/contact/contactJson.ts
@@ -13,7 +13,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { LegacyConversationMedia } from '../conversation-media/conversation-media';
 import { Referral } from '../referral/referral-data-access';
 
 /**
@@ -33,7 +32,6 @@ export type ContactRawJson = {
     [key: string]: string | boolean;
   };
   contactlessTask?: { [key: string]: string | boolean };
-  conversationMedia?: LegacyConversationMedia[];
   referrals?: Referral[];
 };
 

--- a/hrm-domain/hrm-service/src/contact/contactService.ts
+++ b/hrm-domain/hrm-service/src/contact/contactService.ts
@@ -58,18 +58,6 @@ import { DatabaseUniqueConstraintViolationError, inferPostgresError } from '../s
 export { Contact } from './contact-data-access';
 export * from './contact-json';
 
-export type WithLegacyCategories<T extends Contact | NewContactRecord | PatchPayload> =
-  Omit<T, 'rawJson'> & {
-    rawJson?: Partial<
-      Omit<ContactRawJson, 'caseInformation'> & {
-        caseInformation: Record<
-          string,
-          string | boolean | Record<string, Record<string, boolean>>
-        > & { categories?: Record<string, Record<string, boolean>> };
-      }
-    >;
-  };
-
 export type PatchPayload = Omit<
   ExistingContactRecord,
   'id' | 'accountSid' | 'updatedAt' | 'rawJson' | 'createdAt'

--- a/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contact-insert-sql.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { ContactRawJson } from '../contact-json';
+import { ContactRawJson } from '../contactJson';
 import { selectSingleContactByTaskId } from './contact-get-sql';
 
 export type NewContactRecord = {

--- a/hrm-domain/hrm-service/src/conversation-media/conversation-media.ts
+++ b/hrm-domain/hrm-service/src/conversation-media/conversation-media.ts
@@ -14,8 +14,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { S3ContactMediaType } from './conversation-media-data-access';
-
 export {
   S3ContactMediaType,
   NewConversationMedia,
@@ -30,32 +28,3 @@ export {
   getByContactId as getConversationMediaByContactId,
   updateSpecificData as updateConversationMediaData,
 } from './conversation-media-data-access';
-
-/** Legacy types, used until everything is migrated */
-export type LegacyTwilioStoredMedia = {
-  store: 'twilio';
-  reservationSid: string;
-};
-
-export type LegacyS3StoredTranscript = {
-  store: 'S3';
-  type: S3ContactMediaType.TRANSCRIPT;
-  location?: {
-    bucket: string;
-    key: string;
-  };
-};
-
-export type LegacyS3StoredRecording = {
-  store: 'S3';
-  type: S3ContactMediaType.RECORDING;
-  location?: {
-    bucket: string;
-    key: string;
-  };
-};
-
-type LegacyS3StoredMedia = LegacyS3StoredTranscript | LegacyS3StoredRecording;
-
-export type LegacyConversationMedia = LegacyTwilioStoredMedia | LegacyS3StoredMedia;
-/** */

--- a/hrm-domain/hrm-service/unit-tests/case/case.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/case/case.test.ts
@@ -142,13 +142,7 @@ describe('searchCases', () => {
         csamReports: [],
         rawJson: {
           childInformation: { firstName: 'name', lastName: 'last' },
-          caseInformation: {
-            categories: {
-              cat1: {
-                sub2: true,
-              },
-            },
-          },
+          caseInformation: {},
           callerInformation: {},
           callType: '',
           categories: {

--- a/hrm-domain/hrm-service/unit-tests/contact/contact-builder.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact-builder.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Contact } from '../../src/contact/contact-data-access';
+import { Contact } from '../../src/contact/contactDataAccess';
 
 const defaultContact: Contact = {
   id: 0,

--- a/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
@@ -16,7 +16,7 @@
 
 import * as pgPromise from 'pg-promise';
 import { mockConnection, mockTask, mockTransaction } from '../mock-db';
-import { search, create } from '../../src/contact/contact-data-access';
+import { search, create } from '../../src/contact/contactDataAccess';
 import { ContactBuilder } from './contact-builder';
 import { NewContactRecord } from '../../src/contact/sql/contact-insert-sql';
 

--- a/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
@@ -23,7 +23,6 @@ import {
   patchContact,
   SearchContact,
   searchContacts,
-  WithLegacyCategories,
 } from '../../src/contact/contactService';
 
 import * as csamReportsApi from '../../src/csam-report/csam-report';
@@ -37,7 +36,6 @@ import { subHours } from 'date-fns';
 import { newOk } from '@tech-matters/types';
 import * as profilesDB from '../../src/profile/profile-data-access';
 
-import { addLegacyCategoriesToContact } from '../../service-tests/case-validation';
 jest.mock('../../src/contact/contact-data-access');
 jest.mock('../../src/referral/referral-data-access', () => ({
   createReferralRecord: () => async () => ({}),
@@ -80,15 +78,6 @@ const mockContact: contactDb.Contact = {
   rawJson: {} as any,
 };
 
-const mockReturnContact: WithLegacyCategories<contactDb.Contact> = {
-  ...mockContact,
-  rawJson: {
-    caseInformation: {
-      categories: {},
-    },
-  },
-};
-
 describe('createContact', () => {
   beforeEach(() => {
     const conn = mockConnection();
@@ -122,36 +111,6 @@ describe('createContact', () => {
     number: "that's numberwang",
     channelSid: 'a channel',
     serviceSid: 'a service',
-  };
-
-  const sampleLegacyCreateContactPayload = {
-    rawJson: {
-      childInformation: {
-        firstName: 'Lorna',
-        lastName: 'Ballantyne',
-      },
-      callType: 'carrier pigeon',
-      caseInformation: {
-        categories: {
-          a: {
-            category: true,
-          },
-        },
-      },
-    },
-    queueName: 'Q',
-    conversationDuration: 100,
-    twilioWorkerId: 'owning-worker-id',
-    timeOfContact: new Date(2010, 5, 15),
-    createdBy: 'ignored-worker-id',
-    helpline: 'a helpline',
-    taskId: 'a task',
-    channel: 'morse code',
-    number: "that's numberwang",
-    channelSid: 'a channel',
-    serviceSid: 'a service',
-    profileId: 1,
-    identifierId: 1,
   };
 
   const spyOnContactAndAssociations = ({
@@ -208,7 +167,7 @@ describe('createContact', () => {
       'parameter account-sid',
       'contact-creator',
       true,
-      sampleLegacyCreateContactPayload,
+      sampleCreateContactPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
@@ -229,7 +188,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test("If no identifier record exists for 'number', call createIdentifierAndProfile", async () => {
@@ -255,7 +214,7 @@ describe('createContact', () => {
       'parameter account-sid',
       'contact-creator',
       true,
-      sampleLegacyCreateContactPayload,
+      sampleCreateContactPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
@@ -276,7 +235,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test('Missing values are converted to empty strings for several fields', async () => {
@@ -286,16 +245,6 @@ describe('createContact', () => {
       createContactJobMock,
       createContactMock,
     } = spyOnContactAndAssociations();
-
-    const minimalLegacyPayload = omit(
-      sampleLegacyCreateContactPayload,
-      'helpline',
-      'number',
-      'channel',
-      'channelSid',
-      'serviceSid',
-      'twilioWorkerId',
-    );
 
     const minimalPayload = omit(
       sampleCreateContactPayload,
@@ -310,7 +259,7 @@ describe('createContact', () => {
       'parameter account-sid',
       'contact-creator',
       true,
-      minimalLegacyPayload,
+      minimalPayload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
@@ -337,7 +286,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test('Missing timeOfContact value is substituted with current date', async () => {
@@ -349,12 +298,11 @@ describe('createContact', () => {
     } = spyOnContactAndAssociations();
 
     const payload = omit(sampleCreateContactPayload, 'timeOfContact');
-    const legacyPayload = omit(sampleLegacyCreateContactPayload, 'timeOfContact');
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
       true,
-      legacyPayload,
+      payload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
@@ -376,7 +324,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test('empty array will be passed for csamReportIds if csamReport property is missing', async () => {
@@ -388,12 +336,11 @@ describe('createContact', () => {
     } = spyOnContactAndAssociations();
 
     const payload = omit(sampleCreateContactPayload, 'csamReport');
-    const legacyPayload = omit(sampleLegacyCreateContactPayload, 'csamReport');
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
       true,
-      legacyPayload,
+      payload,
       {
         can: () => true,
         user: twilioUser(workerSid, []),
@@ -414,7 +361,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test('ids will be passed in csamReportIds if csamReport property is populated', async () => {
@@ -441,7 +388,7 @@ describe('createContact', () => {
     });
 
     const payload = {
-      ...sampleLegacyCreateContactPayload,
+      ...sampleCreateContactPayload,
       csamReports,
     };
     const returnValue = await createContact(
@@ -475,7 +422,7 @@ describe('createContact', () => {
     expect(createContactJobMock).not.toHaveBeenCalled();
 
     expect(returnValue).toStrictEqual({
-      ...mockReturnContact,
+      ...mockContact,
       csamReports: csamReports.map(r => ({ ...r, contactId: mockContact.id })),
     });
   });
@@ -497,7 +444,7 @@ describe('createContact', () => {
     });
 
     const payload = {
-      ...sampleLegacyCreateContactPayload,
+      ...sampleCreateContactPayload,
       referrals,
     };
     const returnValue = await createContact(
@@ -531,7 +478,7 @@ describe('createContact', () => {
     expect(connectCsamMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual({ ...mockReturnContact, referrals });
+    expect(returnValue).toStrictEqual({ ...mockContact, referrals });
   });
 
   test('queue will be empty if not present', async () => {
@@ -543,7 +490,7 @@ describe('createContact', () => {
     } = spyOnContactAndAssociations();
 
     const payload = omit(sampleCreateContactPayload, 'queueName');
-    const legacyPayload = omit(sampleLegacyCreateContactPayload, 'queueName');
+    const legacyPayload = omit(sampleCreateContactPayload, 'queueName');
     const returnValue = await createContact(
       'parameter account-sid',
       'contact-creator',
@@ -570,7 +517,7 @@ describe('createContact', () => {
     expect(createReferralMock).not.toHaveBeenCalled();
     expect(createContactJobMock).not.toHaveBeenCalled();
 
-    expect(returnValue).toStrictEqual(mockReturnContact);
+    expect(returnValue).toStrictEqual(mockContact);
   });
 
   test('referrals specified - these will be added to the database using the created contact ID', async () => {
@@ -600,7 +547,7 @@ describe('createContact', () => {
     });
 
     const payload = {
-      ...sampleLegacyCreateContactPayload,
+      ...sampleCreateContactPayload,
       referrals,
     };
 
@@ -637,7 +584,7 @@ describe('createContact', () => {
     expect(createContactJobMock).not.toHaveBeenCalled();
 
     expect(returnValue).toStrictEqual({
-      ...mockReturnContact,
+      ...mockContact,
       referrals,
     });
   });
@@ -659,7 +606,7 @@ describe('connectContactToCase', () => {
       },
     );
     expect(connectSpy).toHaveBeenCalledWith('accountSid', '1234', '4321');
-    expect(result).toStrictEqual(mockReturnContact);
+    expect(result).toStrictEqual(mockContact);
   });
   test('Throws if data access layer returns undefined', () => {
     jest.spyOn(contactDb, 'connectToCase').mockResolvedValue(undefined);
@@ -706,7 +653,7 @@ describe('patchContact', () => {
         user: twilioUser(workerSid, []),
       },
     );
-    expect(result).toStrictEqual(mockReturnContact);
+    expect(result).toStrictEqual(mockContact);
     expect(patchSpy).toHaveBeenCalledWith('accountSid', '1234', true, {
       updatedBy: 'contact-patcher',
       childInformation: {
@@ -789,7 +736,7 @@ describe('searchContacts', () => {
             conversationDuration: 10,
             taskId: 'jill-smith-task',
           },
-          details: addLegacyCategoriesToContact(jillSmith).rawJson,
+          details: jillSmith.rawJson,
           csamReports: [],
           referrals: [],
           conversationMedia: [],
@@ -809,7 +756,7 @@ describe('searchContacts', () => {
             channel: '',
             conversationDuration: undefined,
           },
-          details: addLegacyCategoriesToContact(sarahPark).rawJson,
+          details: sarahPark.rawJson,
           csamReports: [],
           referrals: [],
           conversationMedia: [],

--- a/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact.test.ts
@@ -15,7 +15,7 @@
  */
 import each from 'jest-each';
 import { mockTransaction, mockConnection } from '../mock-db';
-import * as contactDb from '../../src/contact/contact-data-access';
+import * as contactDb from '../../src/contact/contactDataAccess';
 import {
   connectContactToCase,
   createContact,
@@ -36,7 +36,7 @@ import { subHours } from 'date-fns';
 import { newOk } from '@tech-matters/types';
 import * as profilesDB from '../../src/profile/profile-data-access';
 
-jest.mock('../../src/contact/contact-data-access');
+jest.mock('../../src/contact/contactDataAccess');
 jest.mock('../../src/referral/referral-data-access', () => ({
   createReferralRecord: () => async () => ({}),
 }));

--- a/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/pull-contacts.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/pull-contacts.test.ts
@@ -23,7 +23,6 @@ import * as contactApi from '../../../src/contact/contactService';
 import * as context from '../../../src/data-pull-task/khp-data-pull-task/context';
 import { defaultLimitAndOffset } from '../../../src/data-pull-task/khp-data-pull-task/auto-paginate';
 import { pullContacts } from '../../../src/data-pull-task/khp-data-pull-task/pull-contacts';
-import { addLegacyCategoriesToContact } from '../../../service-tests/case-validation';
 
 const { maxPermissions } = context;
 
@@ -116,10 +115,7 @@ describe('KHP Data Pull - Pull Contacts', () => {
 
     const searchContactsResponse = Promise.resolve({
       count: 2,
-      contacts: [
-        addLegacyCategoriesToContact(contact1),
-        addLegacyCategoriesToContact(contact2),
-      ],
+      contacts: [contact1, contact2],
     });
 
     jest.spyOn(contactApi, 'searchContacts').mockReturnValue(searchContactsResponse);


### PR DESCRIPTION
## Description

* Removes support for the category format expected by flex plugin v2.10 and earlier

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added

### Related Issues
CHI-2476

### Verification steps

Automated tests cover it