### PR TITLE
CHI-2467 :remove legacy search format

### DIFF
--- a/hrm-domain/hrm-service/service-tests/case-search.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case-search.test.ts
@@ -27,7 +27,7 @@ import {
   fillNameAndPhone,
   validateCaseListResponse,
   validateSingleCaseResponse,
-} from './case-validation';
+} from './caseValidation';
 import * as contactDb from '../src/contact/contactDataAccess';
 import { Contact } from '../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
@@ -41,6 +41,7 @@ import {
 import { getRequest, getServer, headers, setRules, useOpenRules } from './server';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 import { isS3StoredTranscript } from '../src/conversation-media/conversation-media';
+import { ALWAYS_CAN } from './mocks';
 
 useOpenRules();
 const server = getServer();
@@ -145,7 +146,6 @@ const insertSampleCases = async ({
       const { contact: savedContact } = await contactDb.create()(
         accounts[i % accounts.length],
         contactToCreate,
-        true,
       );
       connectedContact = await contactDb.connectToCase()(
         savedContact.accountSid,
@@ -153,10 +153,11 @@ const insertSampleCases = async ({
         createdCase.id.toString(),
         workerSid,
       );
-      createdCase = await getCase(createdCase.id, accounts[i % accounts.length], {
-        user: twilioUser(workerSid, []),
-        can: () => true,
-      }); // reread case from DB now it has a contact connected
+      createdCase = await getCase(
+        createdCase.id,
+        accounts[i % accounts.length],
+        ALWAYS_CAN,
+      ); // reread case from DB now it has a contact connected
     }
     createdCasesAndContacts.push({
       contact: connectedContact,
@@ -232,18 +233,14 @@ describe('/cases route', () => {
         contactToCreate.taskId = `TASK_SID`;
         contactToCreate.channelSid = `CHANNEL_SID`;
         contactToCreate.serviceSid = 'SERVICE_SID';
-        createdContact = (await contactDb.create()(accountSid, contactToCreate, true))
-          .contact;
+        createdContact = (await contactDb.create()(accountSid, contactToCreate)).contact;
         createdContact = await contactDb.connectToCase()(
           accountSid,
           createdContact.id.toString(),
           createdCase.id,
           workerSid,
         );
-        createdCase = await getCase(createdCase.id, accountSid, {
-          user: twilioUser(workerSid, []),
-          can: () => true,
-        }); // refresh case from DB now it has a contact connected
+        createdCase = await getCase(createdCase.id, accountSid, ALWAYS_CAN); // refresh case from DB now it has a contact connected
       });
 
       afterEach(async () => {
@@ -385,15 +382,14 @@ describe('/cases route', () => {
       let createdContact = await createContact(
         accountSid,
         workerSid,
-        true,
         mocks.withTaskId,
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
       createdContact = await addConversationMediaToContact(
         accountSid,
         createdContact.id.toString(),
         mocks.conversationMedia,
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
       await connectContactToCase(
         accountSid,
@@ -526,7 +522,7 @@ describe('/cases route', () => {
           toCreate.channelSid = `CHANNEL_SID`;
           toCreate.serviceSid = 'SERVICE_SID';
           // Connects createdContact with createdCase2
-          createdContact = (await contactDb.create()(accountSid, toCreate, true)).contact;
+          createdContact = (await contactDb.create()(accountSid, toCreate)).contact;
           createdContact = await contactDb.connectToCase()(
             accountSid,
             createdContact.id.toString(),
@@ -534,10 +530,7 @@ describe('/cases route', () => {
             workerSid,
           );
           // Get case 2 again, now a contact is connected
-          createdCase2 = await caseApi.getCase(createdCase2.id, accountSid, {
-            user: twilioUser(workerSid, []),
-            can: () => true,
-          });
+          createdCase2 = await caseApi.getCase(createdCase2.id, accountSid, ALWAYS_CAN);
         });
 
         afterEach(async () => {
@@ -1268,9 +1261,8 @@ describe('/cases route', () => {
         let createdContact = await createContact(
           accountSid,
           workerSid,
-          true,
           mocks.withTaskId,
-          { user: twilioUser(workerSid, []), can: () => true },
+          ALWAYS_CAN,
         );
         createdContact = await addConversationMediaToContact(
           accountSid,

--- a/hrm-domain/hrm-service/service-tests/case.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case.test.ts
@@ -27,7 +27,7 @@ import {
 } from '../src/contact/contactService';
 import { CaseService } from '../src/case/caseService';
 import * as caseDb from '../src/case/case-data-access';
-import { convertCaseInfoToExpectedInfo, without } from './case-validation';
+import { convertCaseInfoToExpectedInfo, without } from './caseValidation';
 import { isBefore } from 'date-fns';
 
 // const each = require('jest-each').default;
@@ -37,6 +37,7 @@ import { ruleFileWithOneActionOverride } from './permissions-overrides';
 import { headers, getRequest, getServer, setRules, useOpenRules } from './server';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 import { isS3StoredTranscript } from '../src/conversation-media/conversation-media';
+import { ALWAYS_CAN } from './mocks';
 
 useOpenRules();
 const server = getServer();
@@ -295,9 +296,8 @@ describe('/cases route', () => {
         let createdContact = await createContact(
           accountSid,
           workerSid,
-          true,
           mocks.withTaskId,
-          { user: twilioUser(workerSid, []), can: () => true },
+          ALWAYS_CAN,
         );
         createdContact = await addConversationMediaToContact(
           accountSid,
@@ -614,6 +614,7 @@ describe('/cases route', () => {
           customWorkerSid = undefined,
         }) => {
           if (customWorkerSid) {
+            await new Promise(resolve => setTimeout(resolve, 300));
             await mockSuccessfulTwilioAuthentication(customWorkerSid);
             await new Promise(resolve => setTimeout(resolve, 300));
           }
@@ -685,9 +686,8 @@ describe('/cases route', () => {
         let createdContact = await createContact(
           accountSid,
           workerSid,
-          true,
           mocks.withTaskId,
-          { user: twilioUser(workerSid, []), can: () => true },
+          ALWAYS_CAN,
         );
         createdContact = await addConversationMediaToContact(
           accountSid,

--- a/hrm-domain/hrm-service/service-tests/caseValidation.ts
+++ b/hrm-domain/hrm-service/service-tests/caseValidation.ts
@@ -15,8 +15,8 @@
  */
 
 import { WELL_KNOWN_CASE_SECTION_NAMES } from '../src/case/caseService';
-import { NewContactRecord } from '../src/contact/sql/contact-insert-sql';
-import { ContactRawJson, CreateContactPayload } from '../src/contact/contactService';
+import { NewContactRecord } from '../src/contact/sql/contactInsertSql';
+import { ContactRawJson } from '../src/contact/contactJson';
 
 declare global {
   namespace jest {
@@ -150,14 +150,14 @@ export const validateSingleCaseResponse = (
 };
 
 export const fillNameAndPhone = (
-  contact: CreateContactPayload,
+  contact: NewContactRecord,
   name = {
     firstName: 'Maria',
     lastName: 'Silva',
   },
   number = '+1-202-555-0184',
 ): NewContactRecord => {
-  const modifiedContact: NewContactRecord = {
+  return {
     ...contact,
     rawJson: {
       ...(contact.rawJson as ContactRawJson),
@@ -168,8 +168,4 @@ export const fillNameAndPhone = (
     },
     number,
   };
-
-  delete (<any>modifiedContact).form;
-
-  return modifiedContact;
 };

--- a/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
@@ -21,7 +21,7 @@ import timers from 'timers';
 import { withTaskId, accountSid, workerSid } from '../../mocks';
 import * as contactJobApi from '../../../src/contact-job/contact-job-data-access';
 import { db } from '../../../src/connection-pool';
-import '../../case-validation';
+import '../../caseValidation';
 import * as conversationMediaApi from '../../../src/conversation-media/conversation-media';
 import { chatChannels } from '../../../src/contact/channelTypes';
 import { JOB_MAX_ATTEMPTS } from '../../../src/contact-job/contact-job-processor';
@@ -32,8 +32,8 @@ import {
   ContactJobType,
 } from '@tech-matters/types';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
-import { CreateContactPayload } from '../../../src/contact/contactService';
 import { NewConversationMedia } from '../../../src/conversation-media/conversation-media';
+import { NewContactRecord } from '../../../src/contact/sql/contactInsertSql';
 
 const { S3ContactMediaType, isS3StoredTranscriptPending } = conversationMediaApi;
 
@@ -107,7 +107,7 @@ const SAMPLE_CONVERSATION_MEDIA: NewConversationMedia = {
 };
 
 const createChatContact = async (channel: string, startedTimestamp: number) => {
-  const contactTobeCreated: CreateContactPayload = {
+  const contactTobeCreated: NewContactRecord = {
     ...withTaskId,
     channel,
     taskId: `${withTaskId.taskId}-${channel}`,
@@ -115,7 +115,6 @@ const createChatContact = async (channel: string, startedTimestamp: number) => {
   let contact = await contactApi.createContact(
     accountSid,
     workerSid,
-    true,
     contactTobeCreated,
     {
       can: () => true,

--- a/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactById.test.ts
@@ -15,10 +15,9 @@
  */
 
 import * as contactApi from '../../src/contact/contactService';
-import '../case-validation';
+import '../caseValidation';
 import { ContactRawJson } from '../../src/contact/contactJson';
-import { accountSid, contact1, workerSid } from '../mocks';
-import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
+import { accountSid, ALWAYS_CAN, contact1, workerSid } from '../mocks';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
 import * as contactDb from '../../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
@@ -53,13 +52,11 @@ beforeEach(async () => {
   createdContact = await contactApi.createContact(
     accountSid,
     workerSid,
-    true,
     {
       ...contact1,
       rawJson: <ContactRawJson>{},
-      csamReports: [],
     },
-    { user: twilioUser(workerSid, []), can: () => true },
+    ALWAYS_CAN,
   );
 });
 

--- a/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactByTaskId.test.ts
@@ -15,10 +15,9 @@
  */
 
 import * as contactApi from '../../src/contact/contactService';
-import '../case-validation';
+import '../caseValidation';
 import { ContactRawJson } from '../../src/contact/contactJson';
-import { accountSid, contact1, workerSid } from '../mocks';
-import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
+import { accountSid, ALWAYS_CAN, contact1, workerSid } from '../mocks';
 import { getRequest, getServer, headers, useOpenRules } from '../server';
 import * as contactDb from '../../src/contact/contactDataAccess';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
@@ -53,13 +52,11 @@ beforeEach(async () => {
   createdContact = await contactApi.createContact(
     accountSid,
     workerSid,
-    true,
     {
       ...contact1,
       rawJson: <ContactRawJson>{},
-      csamReports: [],
     },
-    { user: twilioUser(workerSid, []), can: () => true },
+    ALWAYS_CAN,
   );
 });
 

--- a/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactConversationMedia.test.ts
@@ -15,10 +15,9 @@
  */
 
 import * as contactApi from '../../src/contact/contactService';
-import '../case-validation';
+import '../caseValidation';
 import { ContactRawJson } from '../../src/contact/contactJson';
-import { accountSid, contact1, workerSid } from '../mocks';
-import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
+import { accountSid, ALWAYS_CAN, contact1, workerSid } from '../mocks';
 import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
 import * as contactDb from '../../src/contact/contactDataAccess';
 import {
@@ -63,13 +62,11 @@ beforeEach(async () => {
   createdContact = await contactApi.createContact(
     accountSid,
     workerSid,
-    true,
     {
       ...contact1,
       rawJson: <ContactRawJson>{},
-      csamReports: [],
     },
-    { user: twilioUser(workerSid, []), can: () => true },
+    ALWAYS_CAN,
   );
 });
 afterEach(() => {

--- a/hrm-domain/hrm-service/service-tests/contact/contactPatch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactPatch.test.ts
@@ -14,15 +14,15 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import * as contactApi from '../../src/contact/contactService';
 import {
   addConversationMediaToContact,
   ContactRawJson,
-  CreateContactPayload,
   PatchPayload,
 } from '../../src/contact/contactService';
-import '../case-validation';
-import * as contactApi from '../../src/contact/contactService';
-import { accountSid, contact1, withTaskId, workerSid } from '../mocks';
+import '../caseValidation';
+import * as mocks from '../mocks';
+import { accountSid, ALWAYS_CAN, contact1, withTaskId, workerSid } from '../mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 import each from 'jest-each';
 import { getRequest, getServer, headers, setRules, useOpenRules } from '../server';
@@ -39,7 +39,8 @@ import {
   deleteContactById,
   deleteJobsByContactId,
 } from './db-cleanup';
-import * as mocks from '../mocks';
+import { NewContactRecord } from '../../src/contact/sql/contactInsertSql';
+import { finalizeContact } from './finalizeContact';
 
 useOpenRules();
 const server = getServer();
@@ -75,17 +76,17 @@ describe('/contacts/:contactId route', () => {
     const subRoute = contactId => `${route}/${contactId}`;
 
     test('should return 401', async () => {
-      const createdContact = await contactApi.createContact(
+      let createdContact = await contactApi.createContact(
         accountSid,
         workerSid,
-        true,
         {
           ...contact1,
           rawJson: <ContactRawJson>{},
-          csamReports: [],
         },
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
+      createdContact = await finalizeContact(createdContact);
+
       const response = await request.patch(subRoute(createdContact.id)).send({});
 
       expect(response.status).toBe(401);
@@ -314,17 +315,17 @@ describe('/contacts/:contactId route', () => {
       each(tests).test(
         'should $description if that is specified in the payload',
         async ({ patch, expected, original }: TestOptions) => {
-          const createdContact = await contactApi.createContact(
+          let createdContact = await contactApi.createContact(
             accountSid,
             workerSid,
-            true,
             {
               ...contact1,
               rawJson: original || <ContactRawJson>{},
-              csamReports: [],
             },
-            { user: twilioUser(workerSid, []), can: () => true },
+            ALWAYS_CAN,
           );
+          createdContact = await finalizeContact(createdContact);
+
           try {
             const existingContactId = createdContact.id;
             const response = await request
@@ -378,13 +379,14 @@ describe('/contacts/:contactId route', () => {
       });
 
       test('Not permitted on finalized contact', async () => {
-        const createdContact = await contactApi.createContact(
+        let createdContact = await contactApi.createContact(
           accountSid,
           workerSid,
-          true,
           contact1,
-          { user: twilioUser(workerSid, []), can: () => true },
+          ALWAYS_CAN,
         );
+        createdContact = await finalizeContact(createdContact);
+
         const response = await request
           .patch(subRoute(createdContact.id))
           .set(headers)
@@ -437,7 +439,7 @@ describe('/contacts/:contactId route', () => {
           originalDifferences,
           finalize = false,
         }: FullPatchTestOptions) => {
-          const original: CreateContactPayload = {
+          const original: NewContactRecord = {
             ...contact1,
             ...originalDifferences,
             rawJson: {
@@ -448,9 +450,8 @@ describe('/contacts/:contactId route', () => {
           const createdContact = await contactApi.createContact(
             accountSid,
             workerSid,
-            false,
             original,
-            { user: twilioUser(workerSid, []), can: () => true },
+            ALWAYS_CAN,
           );
           const expected: contactDb.Contact = {
             ...createdContact,
@@ -505,9 +506,8 @@ describe('/contacts/:contactId route', () => {
       const contactToBeDeleted = await contactApi.createContact(
         accountSid,
         workerSid,
-        true,
         <any>contact1,
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
       const nonExistingContactId = contactToBeDeleted.id;
       await deleteContactById(contactToBeDeleted.id, contactToBeDeleted.accountSid);
@@ -528,7 +528,6 @@ describe('/contacts/:contactId route', () => {
       const createdContact = await contactApi.createContact(
         accountSid,
         'another creator',
-        false,
         <any>{
           ...contact1,
           twilioWorkerId: 'another owner',
@@ -547,9 +546,8 @@ describe('/contacts/:contactId route', () => {
       const createdContact = await contactApi.createContact(
         accountSid,
         'another creator',
-        false,
         <any>contact1,
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
       const response = await request
         .patch(subRoute(createdContact.id))
@@ -563,12 +561,11 @@ describe('/contacts/:contactId route', () => {
       const createdContact = await contactApi.createContact(
         accountSid,
         workerSid,
-        false,
         <any>{
           ...contact1,
           twilioWorkerId: 'another owner',
         },
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
       const response = await request
         .patch(subRoute(createdContact.id))
@@ -579,26 +576,30 @@ describe('/contacts/:contactId route', () => {
     });
 
     test('malformed payload should return 400', async () => {
-      const contact = await contactApi.createContact(
+      let contact = await contactApi.createContact(
         accountSid,
         workerSid,
-        true,
         <any>{ ...contact1, taskId: 'malformed-task-id' },
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
+
+      contact = await finalizeContact(contact);
+
       const response = await request.patch(subRoute(contact.id)).set(headers).send([]);
 
       expect(response.status).toBe(400);
     });
 
     test('no body should be a noop', async () => {
-      const createdContact = await contactApi.createContact(
+      let createdContact = await contactApi.createContact(
         accountSid,
         workerSid,
-        true,
         <any>contact1,
-        { user: twilioUser(workerSid, []), can: () => true },
+        ALWAYS_CAN,
       );
+
+      createdContact = await finalizeContact(createdContact);
+
       const response = await request
         .patch(subRoute(createdContact.id))
         .set(headers)
@@ -626,19 +627,20 @@ describe('/contacts/:contactId route', () => {
         description: `without viewExternalTranscript excludes transcripts`,
       },
     ]).test(`$description`, async ({ expectTranscripts }) => {
+      const permission = ALWAYS_CAN;
       let createdContact = await contactApi.createContact(
         accountSid,
         workerSid,
-        true,
         withTaskId,
-        { user: twilioUser(workerSid, []), can: () => true },
+        permission,
       );
       createdContact = await addConversationMediaToContact(
         accountSid,
         createdContact.id.toString(),
         mocks.conversationMedia,
-        { user: twilioUser(workerSid, []), can: () => true },
+        permission,
       );
+      createdContact = await finalizeContact(createdContact);
 
       if (!expectTranscripts) {
         setRules(ruleFileWithOneActionOverride('viewExternalTranscript', false));

--- a/hrm-domain/hrm-service/service-tests/contact/finalizeContact.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/finalizeContact.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import * as contactApi from '../../src/contact/contactService';
+import { accountSid, ALWAYS_CAN, workerSid } from '../mocks';
+
+export const finalizeContact = async (
+  contact: contactApi.Contact,
+): Promise<contactApi.Contact> =>
+  contactApi.patchContact(
+    accountSid,
+    workerSid,
+    true,
+    contact.id.toString(),
+    {},
+    ALWAYS_CAN,
+  );

--- a/hrm-domain/hrm-service/service-tests/csam-reports.test.ts
+++ b/hrm-domain/hrm-service/service-tests/csam-reports.test.ts
@@ -16,7 +16,7 @@
 
 import each from 'jest-each';
 import * as mocks from './mocks';
-import './case-validation';
+import './caseValidation';
 import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
 import { db } from '../src/connection-pool';
 import * as csamReportsApi from '../src/csam-report/csam-report';

--- a/hrm-domain/hrm-service/service-tests/db-tests/audit_trigger.test.ts
+++ b/hrm-domain/hrm-service/service-tests/db-tests/audit_trigger.test.ts
@@ -21,7 +21,7 @@
 
 import { db } from '../../src/connection-pool';
 
-import '../case-validation';
+import '../caseValidation';
 
 const workerSid = 'WK-worker-sid';
 const anotherWorkerSid = 'WK-another-worker-sid';

--- a/hrm-domain/hrm-service/service-tests/mocks.ts
+++ b/hrm-domain/hrm-service/service-tests/mocks.ts
@@ -20,11 +20,13 @@ import {
   S3ContactMediaType,
 } from '../src/conversation-media/conversation-media';
 import { Contact } from '../src/contact/contactDataAccess';
-import { CreateContactPayload } from '../src/contact/contactService';
+import { ContactRawJson } from '../src/contact/contactJson';
+import { NewContactRecord } from '../src/contact/sql/contactInsertSql';
+import { twilioUser } from '@tech-matters/twilio-worker-auth/dist';
 
 export const accountSid = 'ACCOUNT_SID';
 // TODO: Turn these into proper API types (will probably break so many tests...)
-export const contact1: CreateContactPayload = {
+export const contact1: NewContactRecord = {
   rawJson: {
     callType: 'Child calling about self',
     childInformation: {
@@ -84,7 +86,7 @@ export const contact1: CreateContactPayload = {
   identifierId: undefined,
 };
 
-export const contact2: CreateContactPayload = {
+export const contact2: NewContactRecord = {
   rawJson: {
     callType: 'Someone calling about a child',
     childInformation: {
@@ -144,7 +146,7 @@ export const contact2: CreateContactPayload = {
   identifierId: undefined,
 };
 
-export const nonData1: CreateContactPayload = {
+export const nonData1: NewContactRecord = {
   ...contact1,
   taskId: 'nonData1-task-sid',
   rawJson: {
@@ -155,7 +157,7 @@ export const nonData1: CreateContactPayload = {
     callerInformation: {},
   },
 };
-export const nonData2: CreateContactPayload = {
+export const nonData2: NewContactRecord = {
   ...contact2,
   taskId: 'nonData2-task-sid',
   rawJson: {
@@ -167,12 +169,12 @@ export const nonData2: CreateContactPayload = {
   },
 };
 // Non data contacts with actual information
-export const broken1: CreateContactPayload = {
+export const broken1: NewContactRecord = {
   ...contact1,
   taskId: 'broken1-task-sid',
   rawJson: { ...contact1.rawJson, callType: 'Joke' },
 };
-export const broken2: CreateContactPayload = {
+export const broken2: NewContactRecord = {
   ...contact2,
   taskId: 'broken2-task-sid',
   rawJson: { ...contact2.rawJson, callType: 'Blank' },
@@ -184,20 +186,20 @@ export const anotherChild: Contact['rawJson']['childInformation'] = {
   lastName: 'Curie',
 };
 
-export const anotherCaller: Contact['rawJson']['callerInformation'] = {
+export const anotherCaller: ContactRawJson['callerInformation'] = {
   ...contact2.rawJson.callerInformation,
   firstName: 'Marie',
   lastName: 'Curie',
 };
 
-export const another1: CreateContactPayload = {
+export const another1: NewContactRecord = {
   ...contact1,
   taskId: 'another1-task-sid',
   rawJson: { ...contact1.rawJson, childInformation: anotherChild },
   helpline: 'Helpline 1',
 };
 
-export const another2: CreateContactPayload = {
+export const another2: NewContactRecord = {
   ...contact2,
   taskId: 'another2-task-sid',
   rawJson: {
@@ -217,13 +219,13 @@ export const another2: CreateContactPayload = {
   number: '+12125551212',
 };
 
-export const noHelpline: CreateContactPayload = {
+export const noHelpline: NewContactRecord = {
   ...another1,
   taskId: 'noHelpline-task-sid',
   helpline: '',
 };
 
-export const withTaskId: CreateContactPayload = {
+export const withTaskId: NewContactRecord = {
   rawJson: {
     callType: 'Child calling about self',
     childInformation: {
@@ -307,3 +309,5 @@ export const conversationMedia: NewConversationMedia[] = [
     },
   },
 ];
+
+export const ALWAYS_CAN = { user: twilioUser(workerSid, []), can: () => true };

--- a/hrm-domain/hrm-service/service-tests/permissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/permissions.test.ts
@@ -26,7 +26,7 @@ import {
 import { db } from '../src/connection-pool';
 import * as contactDB from '../src/contact/contactDataAccess';
 import * as conversationMediaDB from '../src/conversation-media/conversation-media-data-access';
-import { NewContactRecord } from '../src/contact/sql/contact-insert-sql';
+import { NewContactRecord } from '../src/contact/sql/contactInsertSql';
 
 const server = getServer({
   permissions: undefined,
@@ -155,11 +155,7 @@ describe('/permissions/:action route with contact objectType', () => {
           serviceSid: 'serviceSid',
         } as NewContactRecord;
 
-        const { contact: createdContact } = await contactDB.create()(
-          accountSid,
-          contact,
-          true,
-        );
+        const { contact: createdContact } = await contactDB.create()(accountSid, contact);
         createdContacts[accountSid] = createdContact;
 
         await Promise.all(

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -15,7 +15,7 @@
  */
 
 import each from 'jest-each';
-import './case-validation';
+import './caseValidation';
 import { db } from '../src/connection-pool';
 import * as caseApi from '../src/case/caseService';
 import * as contactApi from '../src/contact/contactService';
@@ -26,6 +26,7 @@ import { mockSuccessfulTwilioAuthentication, mockingProxy } from '@tech-matters/
 import { getOrCreateProfileWithIdentifier, Profile } from '../src/profile/profile';
 import { IdentifierWithProfiles } from '../src/profile/profile-data-access';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
+import { ALWAYS_CAN } from './mocks';
 
 useOpenRules();
 const server = getServer();
@@ -229,17 +230,13 @@ describe('/profiles', () => {
             contactApi.createContact(
               acc,
               workerSid,
-              true,
               {
                 ...contact1,
                 number: identifier,
                 profileId: createdProfiles[acc].profiles[0].id,
                 identifierId: createdProfiles[acc].id,
               },
-              {
-                user: twilioUser(workerSid, []),
-                can: () => true,
-              },
+              ALWAYS_CAN,
             ),
           ),
         )
@@ -363,7 +360,6 @@ describe('/profiles', () => {
                 .createContact(
                   createdCase.accountSid,
                   workerSid,
-                  true,
                   {
                     ...contact1,
                     number: identifier,
@@ -371,10 +367,7 @@ describe('/profiles', () => {
                     profileId: createdProfile.profiles[0].id,
                     identifierId: createdProfile.id,
                   },
-                  {
-                    user: twilioUser(workerSid, []),
-                    can: () => true,
-                  },
+                  ALWAYS_CAN,
                 )
                 .then(contact =>
                   // Associate contact to case

--- a/hrm-domain/hrm-service/src/contact/contactDataAccess.ts
+++ b/hrm-domain/hrm-service/src/contact/contactDataAccess.ts
@@ -25,7 +25,7 @@ import {
   selectSingleContactByIdSql,
   selectSingleContactByTaskId,
 } from './sql/contact-get-sql';
-import { INSERT_CONTACT_SQL, NewContactRecord } from './sql/contact-insert-sql';
+import { INSERT_CONTACT_SQL, NewContactRecord } from './sql/contactInsertSql';
 import { ContactRawJson, ReferralWithoutContactId } from './contactJson';
 import type { ITask } from 'pg-promise';
 import { txIfNotInOne } from '../sql';
@@ -178,11 +178,7 @@ type CreateResult = { contact: Contact; isNewRecord: boolean };
 
 export const create =
   (task?) =>
-  async (
-    accountSid: string,
-    newContact: NewContactRecord,
-    finalize: boolean,
-  ): Promise<CreateResult> => {
+  async (accountSid: string, newContact: NewContactRecord): Promise<CreateResult> => {
     return txIfNotInOne(
       task,
       async (conn: ITask<{ contact: Contact; isNewRecord: boolean }>) => {
@@ -193,7 +189,6 @@ export const create =
             accountSid,
             createdAt: now,
             updatedAt: now,
-            finalize,
           });
 
         return { contact: created, isNewRecord };

--- a/hrm-domain/hrm-service/src/contact/contactRoutesV0.ts
+++ b/hrm-domain/hrm-service/src/contact/contactRoutesV0.ts
@@ -39,14 +39,13 @@ const contactsRouter = SafeRouter();
 /**
  * @param {any} req. - Request
  * @param {any} res - User for requested
- * @param {CreateContactPayload} req.body - Contact to create
+ * @param {NewContactRecord} req.body - Contact to create
  *
  * @returns {Contact} - Created contact
  */
 contactsRouter.post('/', publicEndpoint, async (req, res) => {
   const { accountSid, user } = req;
-  const finalize = req.query.finalize !== 'false'; // Default to true for backwards compatibility
-  const contact = await createContact(accountSid, user.workerSid, finalize, req.body, {
+  const contact = await createContact(accountSid, user.workerSid, req.body, {
     can: req.can,
     user,
   });

--- a/hrm-domain/hrm-service/src/contact/contactRoutesV0.ts
+++ b/hrm-domain/hrm-service/src/contact/contactRoutesV0.ts
@@ -128,19 +128,11 @@ contactsRouter.delete(
 contactsRouter.post('/search', publicEndpoint, async (req, res) => {
   const { accountSid } = req;
 
-  const searchResults = await searchContacts(
-    accountSid,
-    req.body,
-    req.query,
-    {
-      can: req.can,
-      user: req.user,
-      searchPermissions: req.searchPermissions,
-    },
-    // This logic seems odd until you realise that we are moving to the 'original' format by default, the other format is 'legacy
-    // After Flex 2.12 is deployed everywhere, support for the legacy format can be removed
-    req.query.legacyFormat === 'false',
-  );
+  const searchResults = await searchContacts(accountSid, req.body, req.query, {
+    can: req.can,
+    user: req.user,
+    searchPermissions: req.searchPermissions,
+  });
   res.json(searchResults);
 });
 

--- a/hrm-domain/hrm-service/src/contact/sql/contactInsertSql.ts
+++ b/hrm-domain/hrm-service/src/contact/sql/contactInsertSql.ts
@@ -56,8 +56,7 @@ export const INSERT_CONTACT_SQL = `
       "channelSid",
       "serviceSid",
       "profileId",
-      "identifierId",
-      "finalizedAt"
+      "identifierId"
     ) (SELECT 
         $<accountSid>, 
         $<rawJson>, 
@@ -75,8 +74,7 @@ export const INSERT_CONTACT_SQL = `
         $<channelSid>, 
         $<serviceSid>,
         $<profileId>,
-        $<identifierId>,
-        CASE WHEN $<finalize> = true THEN CURRENT_TIMESTAMP ELSE NULL END
+        $<identifierId>
       WHERE NOT EXISTS (
         ${selectSingleContactByTaskId('Contacts')}
       )

--- a/hrm-domain/hrm-service/src/csam-report/csam-report-data-access.ts
+++ b/hrm-domain/hrm-service/src/csam-report/csam-report-data-access.ts
@@ -20,11 +20,7 @@ import {
   selectSingleCsamReportByIdSql,
   selectCsamReportsByContactIdSql,
 } from './sql/csam-report-get-sql';
-import {
-  updateContactIdByCsamReportIdsSql,
-  updateAcknowledgedByCsamReportIdSql,
-} from './sql/csam-report-update-sql';
-import { txIfNotInOne } from '../sql';
+import { updateAcknowledgedByCsamReportIdSql } from './sql/csam-report-update-sql';
 
 export type NewCSAMReport = {
   reportType: 'counsellor-generated' | 'self-generated';
@@ -70,22 +66,6 @@ export const getByContactId = async (contactId: number, accountSid: string) =>
       accountSid,
     }),
   );
-
-export const updateContactIdByCsamReportIds =
-  (task?) =>
-  async (
-    contactId: number,
-    reportIds: CSAMReport['id'][],
-    accountSid: string,
-  ): Promise<CSAMReport[]> => {
-    return txIfNotInOne(task, conn =>
-      conn.manyOrNone<CSAMReport>(updateContactIdByCsamReportIdsSql, {
-        contactId,
-        reportIds,
-        accountSid,
-      }),
-    );
-  };
 
 export const updateAcknowledgedByCsamReportId =
   (acknowledged: boolean) => async (reportId: number, accountSid: string) =>

--- a/hrm-domain/hrm-service/src/csam-report/csam-report.ts
+++ b/hrm-domain/hrm-service/src/csam-report/csam-report.ts
@@ -17,7 +17,6 @@
 import { randomUUID } from 'crypto';
 import {
   NewCSAMReport,
-  updateContactIdByCsamReportIds,
   create,
   getById,
   getByContactId,
@@ -35,8 +34,8 @@ export const createCSAMReport = async (
 ) => {
   const { reportType, contactId, twilioWorkerId } = body;
 
-  const csamReportId = reportType === 'self-generated' ? randomUUID() : body.csamReportId;
-  const acknowledged = reportType === 'self-generated' ? false : true;
+  const acknowledged = reportType !== 'self-generated';
+  const csamReportId = acknowledged ? body.csamReportId : randomUUID();
 
   // TODO: Should we check if the randomUUID exists in DB here?
 
@@ -54,7 +53,5 @@ export const createCSAMReport = async (
 
 // While this is being used in test only, chances are we'll use it when we move out to making separate calls to fetch different entities
 export const getCsamReportsByContactId = getByContactId;
-
-export const connectContactToCsamReports = updateContactIdByCsamReportIds;
 
 export const acknowledgeCsamReport = updateAcknowledgedByCsamReportId(true);

--- a/hrm-domain/hrm-service/src/csam-report/sql/csam-report-update-sql.ts
+++ b/hrm-domain/hrm-service/src/csam-report/sql/csam-report-update-sql.ts
@@ -15,14 +15,6 @@
  */
 
 const ID_WHERE_CLAUSE = `WHERE "accountSid" = $<accountSid> AND "id" = $<reportId>`;
-const IN_IDS_WHERE_CLAUSE = `WHERE "accountSid" = $<accountSid> AND "id" IN ($<reportIds:csv>)`;
-
-export const updateContactIdByCsamReportIdsSql = `
-  UPDATE "CSAMReports"
-  SET "contactId" = $<contactId>
-  ${IN_IDS_WHERE_CLAUSE}
-  RETURNING *
-`;
 
 export const updateAcknowledgedByCsamReportIdSql = `
   UPDATE "CSAMReports"

--- a/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/pull-contacts.ts
+++ b/hrm-domain/hrm-service/src/data-pull-task/khp-data-pull-task/pull-contacts.ts
@@ -33,14 +33,12 @@ export const pullContacts = async (startDate: Date, endDate: Date) => {
   const { accountSid, bucket } = await getContext();
 
   const searchParams = getSearchParams(startDate, endDate);
-  const originalFormat = true;
 
   const contacts = await autoPaginate(contactApi.searchContacts, [
     accountSid,
     searchParams,
     defaultLimitAndOffset,
     maxPermissions,
-    originalFormat,
   ]);
 
   const uploadPromises = contacts.map(contact => {

--- a/hrm-domain/hrm-service/unit-tests/case/case.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/case/case.test.ts
@@ -19,7 +19,7 @@ import * as caseApi from '../../src/case/caseService';
 import { createMockCase, createMockCaseRecord } from './mock-cases';
 import each from 'jest-each';
 import { CaseRecord, NewCaseRecord } from '../../src/case/case-data-access';
-import '../../service-tests/case-validation';
+import '../../service-tests/caseValidation';
 import { workerSid, accountSid } from '../../service-tests/mocks';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 

--- a/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contact-data-access.test.ts
@@ -18,7 +18,7 @@ import * as pgPromise from 'pg-promise';
 import { mockConnection, mockTask, mockTransaction } from '../mock-db';
 import { search, create } from '../../src/contact/contactDataAccess';
 import { ContactBuilder } from './contact-builder';
-import { NewContactRecord } from '../../src/contact/sql/contact-insert-sql';
+import { NewContactRecord } from '../../src/contact/sql/contactInsertSql';
 
 let conn: pgPromise.ITask<unknown>;
 
@@ -57,13 +57,12 @@ describe('create', () => {
 
     jest.spyOn(conn, 'one').mockResolvedValue(returnValue);
 
-    const created = await create()('parameter account-sid', sampleNewContact, true);
+    const created = await create()('parameter account-sid', sampleNewContact);
     expect(conn.one).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), {
       ...sampleNewContact,
       updatedAt: expect.anything(),
       createdAt: expect.anything(),
       accountSid: 'parameter account-sid',
-      finalize: true,
     });
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({
@@ -78,13 +77,12 @@ describe('create', () => {
 
     jest.spyOn(conn, 'one').mockResolvedValue(returnValue);
 
-    const created = await create()('parameter account-sid', sampleNewContact, true);
+    const created = await create()('parameter account-sid', sampleNewContact);
     expect(conn.one).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO'), {
       ...sampleNewContact,
       updatedAt: expect.anything(),
       createdAt: expect.anything(),
       accountSid: 'parameter account-sid',
-      finalize: true,
     });
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({

--- a/hrm-domain/hrm-service/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/contact/contactService.test.ts
@@ -20,7 +20,6 @@ import {
   connectContactToCase,
   createContact,
   patchContact,
-  SearchContact,
   searchContacts,
 } from '../../src/contact/contactService';
 
@@ -347,7 +346,7 @@ describe('patchContact', () => {
 describe('searchContacts', () => {
   const accountSid = 'account-sid',
     contactSearcher = 'contact-searcher';
-  test('Converts contacts returned by data layer to search results', async () => {
+  test('Returns contacts returned by data layer unmodified', async () => {
     const jillSmith = new ContactBuilder()
       .withId(4321)
       .withHelpline('a helpline')
@@ -377,50 +376,9 @@ describe('searchContacts', () => {
       .withCreatedAt(new Date('2020-03-15T00:00:00Z'))
       .withTimeOfContact(new Date('2020-03-15T00:00:00Z'))
       .build();
-    const expectedSearchResult: { count: number; contacts: SearchContact[] } = {
+    const expectedSearchResult: { count: number; contacts: contactDb.Contact[] } = {
       count: 2,
-      contacts: [
-        {
-          contactId: '4321',
-          overview: {
-            helpline: 'a helpline',
-            dateTime: '2020-03-10T00:00:00.000Z',
-            customerNumber: '+12025550142',
-            createdBy: 'contact-searcher',
-            callType: 'Child calling about self',
-            categories: {},
-            counselor: 'twilio-worker-id',
-            notes: 'Lost young boy',
-            channel: 'voice',
-            conversationDuration: 10,
-            taskId: 'jill-smith-task',
-          },
-          details: jillSmith.rawJson,
-          csamReports: [],
-          referrals: [],
-          conversationMedia: [],
-        },
-        {
-          contactId: '1234',
-          overview: {
-            helpline: undefined,
-            taskId: 'sarah-park-task',
-            dateTime: '2020-03-15T00:00:00.000Z',
-            customerNumber: 'Anonymous',
-            createdBy: 'contact-searcher',
-            callType: 'Child calling about self',
-            categories: {},
-            counselor: 'twilio-worker-id',
-            notes: 'Young pregnant woman',
-            channel: '',
-            conversationDuration: undefined,
-          },
-          details: sarahPark.rawJson,
-          csamReports: [],
-          referrals: [],
-          conversationMedia: [],
-        },
-      ],
+      contacts: [jillSmith, sarahPark],
     };
 
     const mockedResult = {

--- a/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/pull-contacts.test.ts
+++ b/hrm-domain/hrm-service/unit-tests/data-pull-task/khp-data-pull-task/pull-contacts.test.ts
@@ -92,7 +92,6 @@ describe('KHP Data Pull - Pull Contacts', () => {
       searchParams,
       defaultLimitAndOffset,
       maxPermissions,
-      true,
     );
   });
 


### PR DESCRIPTION
## Description

Removes support for the old search result format expected in Flex plugin v2.10 & older

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added


### Related Issues
CHI-2467

### Verification steps

Automated tests
