### PR TITLE
refactor: Adjust client profiles list endpoint

### DIFF
--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -61,7 +61,7 @@ describe('/profiles', () => {
 
   describe('GET', () => {
     let createdProfiles: Profile[];
-    let existingProfiles: any; //Profile[];
+    let existingProfiles: any;
     const profilesNames = ['Murray', 'Antonella', null];
     let defaultFlags: profilesDB.ProfileFlag[];
     beforeAll(async () => {
@@ -73,17 +73,27 @@ describe('/profiles', () => {
       defaultFlags = await profilesDB
         .getProfileFlagsForAccount(accountSid)
         .then(result => result.unwrap());
+
+      const murray = createdProfiles.find(p => p.name === 'Murray');
+      const antonella = createdProfiles.find(p => p.name === 'Antonella');
+
       await Promise.all([
         profilesDB.associateProfileToProfileFlag()(
           accountSid,
-          createdProfiles.find(p => p.name === 'Murray')!.id,
+          murray!.id,
           defaultFlags[0].id,
         ),
         profilesDB.associateProfileToProfileFlag()(
           accountSid,
-          createdProfiles.find(p => p.name === 'Antonella')!.id,
+          antonella!.id,
           defaultFlags[1].id,
         ),
+        profilesDB.createProfileSection(antonella!.accountSid, {
+          content: 'some example content',
+          sectionType: 'summary',
+          createdBy: 'worker',
+          profileId: antonella!.id,
+        }),
       ]);
     });
 
@@ -106,7 +116,6 @@ describe('/profiles', () => {
         query: '',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(
             existingProfiles.length + createdProfiles.length,
           );
@@ -118,12 +127,12 @@ describe('/profiles', () => {
         query: 'sortBy=name',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(
             existingProfiles.length + createdProfiles.length,
           );
           expect(response.body.profiles[0].name).toBe('Murray');
           expect(response.body.profiles[1].name).toBe('Antonella');
+          expect(response.body.profiles[1].summary).toBe('some example content');
           response.body.profiles.slice(2).forEach(p => expect(p.name).toBeNull());
         },
       },
@@ -133,7 +142,6 @@ describe('/profiles', () => {
         query: 'sortBy=name&sortDirection=asc',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(
             existingProfiles.length + createdProfiles.length,
           );
@@ -148,7 +156,6 @@ describe('/profiles', () => {
         query: 'profileFlagIds=1',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(1);
           expect(response.body.profiles[0].name).toBe('Murray');
         },
@@ -159,7 +166,6 @@ describe('/profiles', () => {
         query: 'profileFlagIds=1,2',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(2);
           expect(response.body.profiles[0].name).toBe('Antonella');
           expect(response.body.profiles[1].name).toBe('Murray');
@@ -171,7 +177,6 @@ describe('/profiles', () => {
         query: 'profileFlagIds=9999999',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(0);
         },
       },
@@ -181,7 +186,6 @@ describe('/profiles', () => {
         query: 'profileFlagIds=not-a-number',
         expectStatus: 200,
         expectFunction: response => {
-          console.log(response.body);
           expect(response.body.count).toBe(
             existingProfiles.length + createdProfiles.length,
           );


### PR DESCRIPTION
## Description
Adds Client Name, Status, Identifier and Summary information to the "list profiles" endpoint payload, in order to comply with the expectations of the Frontend Client (see mocks).

![Screenshot 2024-01-03 at 8 54 45 AM](https://github.com/techmatters/hrm/assets/15805319/3f5df672-22a7-4a67-872d-8a34b71cca9c)

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2469)
- [x] New tests added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
