### PR TITLE
CHI-2255: filterExternalTranscripts handles undefined conversationMedia prop

### DIFF
--- a/hrm-domain/hrm-service/src/contact/contactService.ts
+++ b/hrm-domain/hrm-service/src/contact/contactService.ts
@@ -92,7 +92,7 @@ export type CreateContactPayload = NewContactRecord & {
 
 const filterExternalTranscripts = (contact: Contact): Contact => {
   const { conversationMedia, ...rest } = contact;
-  const filteredConversationMedia = conversationMedia.filter(
+  const filteredConversationMedia = (conversationMedia ?? []).filter(
     m => !isS3StoredTranscript(m),
   );
 


### PR DESCRIPTION
## Description

E2E tests look to be broken by a contact with no conversationMedia property. Not sure if there was a change that made this possible or it's down to version switching. Putting this fix in for now to unblock e2e tests

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added

Fixes CHI-2255 tests

### Verification steps

Automated tests should cover it