### PR TITLE
refactor: unify get single profile and list profiles types

### DIFF
--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -135,7 +135,11 @@ describe('/profiles', () => {
           );
           expect(response.body.profiles[0].name).toBe('Murray');
           expect(response.body.profiles[1].name).toBe('Antonella');
-          expect(response.body.profiles[1].summary).toBe('some example content');
+          expect(
+            response.body.profiles[1].profileSections.some(
+              ps => ps.sectionType === 'summary',
+            ),
+          ).toBeTruthy();
           response.body.profiles.slice(2).forEach(p => expect(p.name).toBeNull());
         },
       },

--- a/hrm-domain/hrm-service/src/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-service/src/profile/profile-data-access.ts
@@ -243,17 +243,12 @@ export type SearchParameters = {
   filters?: ProfilesListFilters;
 };
 
-type ListProfile = Pick<Profile, 'id' | 'name'> &
-  Pick<Identifier, 'identifier'> & { profileFlags: ProfileFlagAssociation[] } & {
-    summary: ProfileSection['content'];
-  };
-
 export const listProfiles = async (
   accountSid: string,
   listConfiguration: ProfileListConfiguration,
   { filters }: SearchParameters,
 ): Promise<
-  TResult<'InternalServerError', { profiles: ListProfile[]; count: number }>
+  TResult<'InternalServerError', { profiles: ProfileWithRelationships[]; count: number }>
 > => {
   try {
     const { limit, offset, sortBy, sortDirection } =

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -22,13 +22,6 @@ const WHERE_IDENTIFIER_CLAUSE = `
   )
 `;
 
-// WITH TargetProfiles AS (
-//   ${selectProfilesUnorderedSql(whereClause)}
-//   ${orderByClause}
-//   OFFSET $<offset>
-//   LIMIT $<limit>
-// ),
-// export const getProfileByIdSql = `
 export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
   WITH TargetProfiles AS (
     ${selectTargetProfilesQuery}

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -22,8 +22,19 @@ const WHERE_IDENTIFIER_CLAUSE = `
   )
 `;
 
-export const getProfileByIdSql = `
-  WITH RelatedIdentifiers AS (
+// WITH TargetProfiles AS (
+//   ${selectProfilesUnorderedSql(whereClause)}
+//   ${orderByClause}
+//   OFFSET $<offset>
+//   LIMIT $<limit>
+// ),
+// export const getProfileByIdSql = `
+export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
+  WITH TargetProfiles AS (
+    ${selectTargetProfilesQuery}
+  ),
+
+  RelatedIdentifiers AS (
     SELECT
         p2i."profileId",
         JSONB_AGG(
@@ -32,19 +43,19 @@ export const getProfileByIdSql = `
                 'identifier', identifiers."identifier"
             )
         ) FILTER (WHERE identifiers.id IS NOT NULL) as identifiers
-    FROM "ProfilesToIdentifiers" p2i
-    JOIN "Identifiers" identifiers ON identifiers.id = p2i."identifierId"
-    WHERE p2i."profileId" = $<profileId>
+    FROM TargetProfiles profile
+	  LEFT JOIN "ProfilesToIdentifiers" p2i ON p2i."profileId" = profile.id AND p2i."accountSid" = profile."accountSid"
+    LEFT JOIN "Identifiers" identifiers ON identifiers.id = p2i."identifierId" AND identifiers."accountSid" = p2i."accountSid"
     GROUP BY p2i."profileId"
   ),
-
+  
   ContactCaseCounts AS (
     SELECT
         "Contacts"."profileId",
         COUNT(*) as "contactsCount",
         COUNT(DISTINCT "Contacts"."caseId") as "casesCount"
-    FROM "Contacts"
-    WHERE "Contacts"."profileId" = $<profileId>
+    FROM TargetProfiles profile
+	  LEFT JOIN "Contacts" ON "Contacts"."profileId" = profile.id AND "Contacts"."accountSid" = profile."accountSid"
     GROUP BY "Contacts"."profileId"
   ),
 
@@ -52,8 +63,8 @@ export const getProfileByIdSql = `
     SELECT
         ppf."profileId",
         JSONB_AGG(JSONB_BUILD_OBJECT('id', ppf."profileFlagId", 'validUntil', ppf."validUntil")) AS "profileFlags"
-    FROM "ProfilesToProfileFlags" ppf
-    WHERE ppf."profileId" = $<profileId>
+    FROM TargetProfiles profile
+	  LEFT JOIN "ProfilesToProfileFlags" ppf ON ppf."profileId" = profile.id AND ppf."accountSid" = profile."accountSid"
     GROUP BY ppf."profileId"
   ),
 
@@ -62,8 +73,8 @@ export const getProfileByIdSql = `
       'id', pps.id,
       'sectionType', pps."sectionType"
     )) AS "profileSections"
-    FROM "ProfileSections" pps
-    WHERE pps."profileId" = $<profileId> AND pps."accountSid" = $<accountSid>
+    FROM TargetProfiles profile
+	  LEFT JOIN "ProfileSections" pps ON pps."profileId" = profile.id AND pps."accountSid" = profile."accountSid"
     GROUP BY pps."profileId"
   )
 
@@ -74,13 +85,18 @@ export const getProfileByIdSql = `
     COALESCE(ccc."casesCount"::int, 0) as "casesCount",
     COALESCE(rpf."profileFlags", '[]'::jsonb) as "profileFlags",
     COALESCE(rps."profileSections", '[]'::jsonb) as "profileSections"
-  FROM "Profiles" profiles
+  FROM TargetProfiles tp
+  LEFT JOIN "Profiles" profiles ON profiles.id = tp.id AND profiles."accountSid" = tp."accountSid"
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
   LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"
   LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"
   LEFT JOIN RelatedProfileSections rps ON profiles.id = rps."profileId"
-  WHERE profiles."accountSid" = $<accountSid> AND profiles."id" = $<profileId>
 `;
+
+export const getProfileByIdSql = getProfilesSqlBase(`
+  SELECT * FROM "Profiles" profiles
+  WHERE profiles."accountSid" = $<accountSid> AND profiles."id" = $<profileId>
+`);
 
 export const getIdentifierSql = `
   SELECT * FROM "Identifiers" ids

--- a/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-service/src/profile/sql/profile-get-sql.ts
@@ -79,14 +79,14 @@ export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
   )
 
   SELECT
-    profiles.*,
+    tp.*,
     COALESCE(ri.identifiers, '[]'::jsonb) as identifiers,
     COALESCE(ccc."contactsCount"::int, 0) as "contactsCount",
     COALESCE(ccc."casesCount"::int, 0) as "casesCount",
     COALESCE(rpf."profileFlags", '[]'::jsonb) as "profileFlags",
     COALESCE(rps."profileSections", '[]'::jsonb) as "profileSections"
   FROM TargetProfiles tp
-  LEFT JOIN "Profiles" profiles ON profiles.id = tp.id AND profiles."accountSid" = tp."accountSid"
+  LEFT JOIN "Profiles" profiles ON profiles.id = tp.id AND profiles."accountSid" = tp."accountSid" -- join on profiles so Postgres will use the indexes
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
   LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"
   LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"


### PR DESCRIPTION
## Description
This PR refactors the types returned in the "list profiles" endpoint, so the returned profiles are the same as in the "get profile" endpoint.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added

### Verification steps
- Service tests.
- Manual testing on list profiles (confirm no bugs are introduced).