### PR TITLE
[Client Profiles] Endpoints to configure statuses/flags

### DIFF
--- a/hrm-domain/hrm-core/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-core/profile/profile-data-access.ts
@@ -29,6 +29,7 @@ import {
   getProfileFlagsByAccountSql,
   getProfileFlagsByIdentifierSql,
   insertProfileFlagSql,
+  updateProfileFlagByIdSql,
 } from './sql/profile-flags-sql';
 import { OrderByDirectionType, txIfNotInOne } from '../sql';
 import * as profileGetSql from './sql/profile-get-sql';
@@ -342,6 +343,26 @@ export const getProfileFlagsForAccount = async (
     return await db
       .task<ProfileFlag[]>(async t =>
         t.manyOrNone(getProfileFlagsByAccountSql, { accountSid }),
+      )
+      .then(data => newOk({ data }));
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+      error: 'InternalServerError',
+    });
+  }
+};
+
+export const updateProfileFlagById = async (
+  accountSid: string,
+  payload: NewProfileFlagRecord & { id: number },
+): Promise<TResult<'InternalServerError', ProfileFlag>> => {
+  try {
+    const now = new Date();
+    console.log('>>> Updating profile flag by ID:', payload);
+    return await db
+      .task<ProfileFlag>(async t =>
+        t.oneOrNone(updateProfileFlagByIdSql({ ...payload, updatedAt: now, accountSid })),
       )
       .then(data => newOk({ data }));
   } catch (err) {

--- a/hrm-domain/hrm-core/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-core/profile/profile-data-access.ts
@@ -30,6 +30,7 @@ import {
   getProfileFlagsByIdentifierSql,
   insertProfileFlagSql,
   updateProfileFlagByIdSql,
+  deleteProfileFlagByIdSql,
 } from './sql/profile-flags-sql';
 import { OrderByDirectionType, txIfNotInOne } from '../sql';
 import * as profileGetSql from './sql/profile-get-sql';
@@ -359,12 +360,34 @@ export const updateProfileFlagById = async (
 ): Promise<TResult<'InternalServerError', ProfileFlag>> => {
   try {
     const now = new Date();
-    console.log('>>> Updating profile flag by ID:', payload);
     return await db
       .task<ProfileFlag>(async t =>
         t.oneOrNone(updateProfileFlagByIdSql({ ...payload, updatedAt: now, accountSid })),
       )
       .then(data => newOk({ data }));
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+      error: 'InternalServerError',
+    });
+  }
+};
+
+export const deleteProfileFlagById = async (
+  profileFlagId: number,
+  accountSid: string,
+): Promise<TResult<'InternalServerError', ProfileFlag>> => {
+  try {
+    return await db
+      .task<ProfileFlag>(async t =>
+        t.oneOrNone(deleteProfileFlagByIdSql, {
+          accountSid,
+          profileFlagId,
+        }),
+      )
+      .then(data => {
+        return newOk({ data });
+      });
   } catch (err) {
     return newErr({
       message: err instanceof Error ? err.message : String(err),

--- a/hrm-domain/hrm-core/profile/profile-data-access.ts
+++ b/hrm-domain/hrm-core/profile/profile-data-access.ts
@@ -360,11 +360,12 @@ export const updateProfileFlagById = async (
 ): Promise<TResult<'InternalServerError', ProfileFlag>> => {
   try {
     const now = new Date();
-    return await db
-      .task<ProfileFlag>(async t =>
-        t.oneOrNone(updateProfileFlagByIdSql({ ...payload, updatedAt: now, accountSid })),
-      )
-      .then(data => newOk({ data }));
+    const data = await db.task<ProfileFlag>(async t => {
+      return t.oneOrNone(
+        updateProfileFlagByIdSql({ ...payload, updatedAt: now, accountSid }),
+      );
+    });
+    return newOk({ data });
   } catch (err) {
     return newErr({
       message: err instanceof Error ? err.message : String(err),

--- a/hrm-domain/hrm-core/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-core/profile/profile-routes-v0.ts
@@ -179,21 +179,12 @@ profilesRouter.post('/flags', publicEndpoint, async (req, res, next) => {
     const { accountSid } = req;
     const { name } = req.body;
 
-    const existingFlags = await profileController.getProfileFlags(accountSid);
-
-    if (isErr(existingFlags)) {
-      return next(mapHTTPError(existingFlags, { InternalServerError: 500 }));
-    }
-
-    const existingFlag = existingFlags.data.find(f => f.name === name);
-    if (existingFlag) {
-      return next(createError(409, 'Flag already exists associated with this account'));
-    }
-
     const result = await profileController.createProfileFlag(accountSid, { name });
 
     if (isErr(result)) {
-      return next(mapHTTPError(result, { InternalServerError: 500 }));
+      return next(
+        mapHTTPError(result, { InvalidParameterError: 400, InternalServerError: 500 }),
+      );
     }
 
     res.json(result.data);
@@ -209,23 +200,14 @@ profilesRouter.patch('/flags/:flagId', publicEndpoint, async (req, res, next) =>
     const { flagId } = req.params;
     const { name } = req.body;
 
-    const existingFlags = await profileController.getProfileFlags(accountSid);
-
-    if (isErr(existingFlags)) {
-      return next(mapHTTPError(existingFlags, { InternalServerError: 500 }));
-    }
-
-    const existingFlag = existingFlags.data.find(f => f.name === name);
-    if (existingFlag) {
-      return next(createError(409, 'Flag already exists associated with this account'));
-    }
-
     const result = await profileController.updateProfileFlagById(accountSid, flagId, {
       name,
     });
 
     if (isErr(result)) {
-      return next(mapHTTPError(result, { InternalServerError: 500 }));
+      return next(
+        mapHTTPError(result, { InternalServerError: 500, InvalidParameterError: 400 }),
+      );
     }
 
     if (!result.data) {

--- a/hrm-domain/hrm-core/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-core/profile/profile-routes-v0.ts
@@ -209,6 +209,23 @@ profilesRouter.patch('/flags/:flagId', publicEndpoint, async (req, res, next) =>
   }
 });
 
+profilesRouter.delete('/flags/:flagId', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { flagId } = req.params;
+
+    const result = await profileController.deleteProfileFlagById(flagId, accountSid);
+
+    if (isErr(result)) {
+      return next(mapHTTPError(result, { InternalServerError: 500 }));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    return next(createError(500, err.message));
+  }
+});
+
 profilesRouter.post(
   '/:profileId/flags/:profileFlagId',
   publicEndpoint,

--- a/hrm-domain/hrm-core/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-core/profile/profile-routes-v0.ts
@@ -174,6 +174,35 @@ profilesRouter.get('/flags', publicEndpoint, async (req, res, next) => {
   }
 });
 
+profilesRouter.post('/flags', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { name } = req.body;
+
+    const existingFlags = await profileController.getProfileFlags(accountSid);
+
+    if (isErr(existingFlags)) {
+      return next(mapHTTPError(existingFlags, { InternalServerError: 500 }));
+    }
+
+    const existingFlag = existingFlags.data.find(f => f.name === name);
+    if (existingFlag) {
+      return next(createError(409, 'Flag already exists associated with this account'));
+    }
+
+    const result = await profileController.createProfileFlag(accountSid, { name });
+
+    if (isErr(result)) {
+      return next(mapHTTPError(result, { InternalServerError: 500 }));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    console.error(err);
+    return next(createError(500, err.message));
+  }
+});
+
 profilesRouter.patch('/flags/:flagId', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;

--- a/hrm-domain/hrm-core/profile/profile-routes-v0.ts
+++ b/hrm-domain/hrm-core/profile/profile-routes-v0.ts
@@ -174,6 +174,34 @@ profilesRouter.get('/flags', publicEndpoint, async (req, res, next) => {
   }
 });
 
+profilesRouter.patch('/flags/:flagId', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { flagId } = req.params;
+    const { name } = req.body;
+
+    console.log('>>> route Updating profile flag:', flagId);
+
+    const result = await profileController.updateProfileFlagById(
+      accountSid,
+      flagId,
+      name,
+    );
+
+    if (isErr(result)) {
+      return next(mapHTTPError(result, { InternalServerError: 500 }));
+    }
+
+    if (!result.data) {
+      return next(createError(404));
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    return next(createError(500, err.message));
+  }
+});
+
 profilesRouter.post(
   '/:profileId/flags/:profileFlagId',
   publicEndpoint,

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -180,6 +180,30 @@ export const disassociateProfileFromProfileFlag = async (
 export const getProfileFlags = profileDB.getProfileFlagsForAccount;
 export const getProfileFlagsByIdentifier = profileDB.getProfileFlagsByIdentifier;
 
+export const updateProfileFlagById = async (
+  accountSid: string,
+  flagId: profileDB.ProfileFlag['id'],
+  payload: {
+    name: string;
+  },
+): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
+  try {
+    const { name } = payload;
+    console.log('>>> updateProfileFlagById Updating profile flag:', flagId, name);
+    const profileFlag = await profileDB.updateProfileFlagById(accountSid, {
+      id: flagId,
+      name,
+    });
+
+    return profileFlag;
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+      error: 'InternalServerError',
+    });
+  }
+};
+
 // While this is just a wrapper around profileDB.createProfileSection, we'll need more code to handle permissions soon
 export const createProfileSection = async (
   accountSid: string,

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -189,9 +189,28 @@ export const getProfileFlagsByIdentifier = profileDB.getProfileFlagsByIdentifier
 export const createProfileFlag = async (
   accountSid: string,
   payload: NewProfileFlagRecord,
-): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
+): Promise<
+  TResult<'InternalServerError' | 'InvalidParameterError', profileDB.ProfileFlag>
+> => {
   try {
     const { name } = payload;
+
+    const existingFlags = await getProfileFlags(accountSid);
+
+    if (isErr(existingFlags)) {
+      // Handle the error case here. For example, you can return the error.
+      return existingFlags;
+    }
+
+    const existingFlag = existingFlags.data.find(flag => flag.name === name);
+
+    if (existingFlag) {
+      return newErr({
+        message: `Flag with name "${name}" already exists`,
+        error: 'InvalidParameterError',
+      });
+    }
+
     const pf = await profileDB.createProfileFlag(accountSid, { name });
 
     return pf;
@@ -209,9 +228,27 @@ export const updateProfileFlagById = async (
   payload: {
     name: string;
   },
-): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
+): Promise<
+  TResult<'InternalServerError' | 'InvalidParameterError', profileDB.ProfileFlag>
+> => {
   try {
     const { name } = payload;
+
+    const existingFlags = await getProfileFlags(accountSid);
+
+    if (isErr(existingFlags)) {
+      // Handle the error case here. For example, you can return the error.
+      return existingFlags;
+    }
+
+    const existingFlag = existingFlags.data.find(flag => flag.name === name);
+
+    if (existingFlag) {
+      return newErr({
+        message: `Flag with name "${name}" already exists`,
+        error: 'InvalidParameterError',
+      });
+    }
     const profileFlag = await profileDB.updateProfileFlagById(accountSid, {
       id: flagId,
       name,

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -189,7 +189,6 @@ export const updateProfileFlagById = async (
 ): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
   try {
     const { name } = payload;
-    console.log('>>> updateProfileFlagById Updating profile flag:', flagId, name);
     const profileFlag = await profileDB.updateProfileFlagById(accountSid, {
       id: flagId,
       name,

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -21,9 +21,15 @@ import * as profileDB from './profile-data-access';
 import { db } from '../connection-pool';
 import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import type { NewProfileSectionRecord } from './sql/profile-sections-sql';
+import { NewProfileFlagRecord } from './sql/profile-flags-sql';
 
-export { Identifier, Profile, getIdentifierWithProfiles } from './profile-data-access';
-export { ProfileListConfiguration, SearchParameters } from './profile-data-access';
+export {
+  Identifier,
+  Profile,
+  getIdentifierWithProfiles,
+  ProfileListConfiguration,
+  SearchParameters,
+} from './profile-data-access';
 
 export const getProfile =
   (task?) =>
@@ -179,6 +185,23 @@ export const disassociateProfileFromProfileFlag = async (
 
 export const getProfileFlags = profileDB.getProfileFlagsForAccount;
 export const getProfileFlagsByIdentifier = profileDB.getProfileFlagsByIdentifier;
+
+export const createProfileFlag = async (
+  accountSid: string,
+  payload: NewProfileFlagRecord,
+): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
+  try {
+    const { name } = payload;
+    const pf = await profileDB.createProfileFlag(accountSid, { name });
+
+    return pf;
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+      error: 'InternalServerError',
+    });
+  }
+};
 
 export const updateProfileFlagById = async (
   accountSid: string,

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -203,6 +203,21 @@ export const updateProfileFlagById = async (
   }
 };
 
+export const deleteProfileFlagById = async (
+  flagId: profileDB.ProfileFlag['id'],
+  accountSid: string,
+): Promise<TResult<'InternalServerError', void>> => {
+  try {
+    await profileDB.deleteProfileFlagById(flagId, accountSid);
+    return newOk({ data: undefined });
+  } catch (err) {
+    return newErr({
+      message: err instanceof Error ? err.message : String(err),
+      error: 'InternalServerError',
+    });
+  }
+};
+
 // While this is just a wrapper around profileDB.createProfileSection, we'll need more code to handle permissions soon
 export const createProfileSection = async (
   accountSid: string,

--- a/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
@@ -56,6 +56,16 @@ export const updateProfileFlagByIdSql = (
   );
 };
 
+export const deleteProfileFlagByIdSql = ({
+  profileFlagId,
+  accountSid,
+}: {
+  profileFlagId: number;
+  accountSid: string;
+}) => {
+  return `DELETE FROM "ProfileFlags" WHERE id = ${profileFlagId} AND "accountSid" = '${accountSid}' RETURNING *`;
+};
+
 export const getProfileFlagsByAccountSql = `
   SELECT * FROM "ProfileFlags"
   WHERE "accountSid" = $<accountSid> OR "accountSid" IS NULL

--- a/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
@@ -18,7 +18,7 @@ import { pgp } from '../../connection-pool';
 
 type NewRecordCommons = {
   accountSid: string;
-  createdAt: Date;
+  createdAt?: Date;
   updatedAt: Date;
 };
 
@@ -36,6 +36,23 @@ export const insertProfileFlagSql = (
   )}
   RETURNING *
 `;
+
+export const updateProfileFlagByIdSql = (
+  profileFlag: NewProfileFlagRecord & NewRecordCommons & { id: number },
+) => {
+  console.log('>>> updateProfileFlagByIdSql function', profileFlag);
+  return `
+    ${pgp.helpers.update(
+      profileFlag,
+      ['accountSid', 'name', 'updatedAt'],
+      'ProfileFlags',
+    )}
+    WHERE id = $<id>
+    RETURNING *
+  `;
+};
+
+console.log(updateProfileFlagByIdSql);
 
 export const getProfileFlagsByAccountSql = `
   SELECT * FROM "ProfileFlags"

--- a/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
@@ -40,19 +40,21 @@ export const insertProfileFlagSql = (
 export const updateProfileFlagByIdSql = (
   profileFlag: NewProfileFlagRecord & NewRecordCommons & { id: number },
 ) => {
-  console.log('>>> updateProfileFlagByIdSql function', profileFlag);
-  return `
-    ${pgp.helpers.update(
-      profileFlag,
+  const { updatedAt, ...rest } = profileFlag;
+  const profileFlagWithTimestamp = {
+    ...rest,
+    updatedAt: updatedAt.toISOString(),
+  };
+  return (
+    pgp.helpers.update(
+      profileFlagWithTimestamp,
       ['accountSid', 'name', 'updatedAt'],
       'ProfileFlags',
-    )}
-    WHERE id = $<id>
-    RETURNING *
-  `;
+    ) +
+    ` WHERE id = ${profileFlag.id}
+      RETURNING *`
+  );
 };
-
-console.log(updateProfileFlagByIdSql);
 
 export const getProfileFlagsByAccountSql = `
   SELECT * FROM "ProfileFlags"

--- a/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
@@ -38,20 +38,18 @@ export const insertProfileFlagSql = (
 `;
 
 export const updateProfileFlagByIdSql = (
-  profileFlag: NewProfileFlagRecord & NewRecordCommons & { id: number },
+  profileFlag: NewProfileFlagRecord &
+    NewRecordCommons & { id: number; accountSid: string },
 ) => {
-  const { updatedAt, ...rest } = profileFlag;
+  const { id, accountSid, updatedAt, ...rest } = profileFlag;
   const profileFlagWithTimestamp = {
     ...rest,
     updatedAt: updatedAt.toISOString(),
   };
+
   return (
-    pgp.helpers.update(
-      profileFlagWithTimestamp,
-      ['accountSid', 'name', 'updatedAt'],
-      'ProfileFlags',
-    ) +
-    ` WHERE id = ${profileFlag.id}
+    pgp.helpers.update(profileFlagWithTimestamp, ['name', 'updatedAt'], 'ProfileFlags') +
+    `WHERE id = ${id} AND "accountSid" = '${accountSid}'
       RETURNING *`
   );
 };


### PR DESCRIPTION
## Description

- This PR adds the ability for a product team or developer within Aselo to create a new flag that is account-specific
   -  `profiles/flags` endpoint accepts a `POST` operation and expects a body with a flag name like this: `{"name":"testFlag"}` as JSON object
   - `profiles/flags/:id` endpoint accepts a `PATCH` operation and expects the flag id needing modification and a body with name like this: `{"name":"differentFlag"}` as JSON object
   - `profiles/flags/:id` endpoint accepts a `DELETE` operation and expects the flag id to delete the corresponding row
   - For PATCH and POST endpoints, If a flag with the same name is passed for an account, HTTP error `409` is thrown to communicate that there is a conflict.

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes # https://tech-matters.atlassian.net/browse/CHI-2373

### Verification steps
- Run this branch
- To test, use CURL command or postman with the matching account in the url and the auth bearer token taken from the frontend. 
- Test the endpoints