### PR TITLE
chore: Create time-based jobs for unblocking profiles

### DIFF
--- a/hrm-domain/hrm-service/package.json
+++ b/hrm-domain/hrm-service/package.json
@@ -9,6 +9,7 @@
     "start:job-cleanup": "cd dist && node ./jobCleanup",
     "start:job-case-status-transition": "cd dist && node ./jobCaseStatusTransition",
     "start:job-cleanup:local": "AWS_REGION=us-east-1 SSM_ENDPOINT=http://localhost:4566 SQS_ENDPOINT=http://localhost:4566 run-s start:job-cleanup",
+    "start:profile-flags-cleanup": "cd dist && node ./bin/profileFlagsCleanup",
     "migrate": "run-s test:service:ci:migrate",
     "seed": "RDS_PASSWORD=postgres node ./db-seed",
     "docker:build": "docker build -t hrm-service -f Dockerfile ../../",
@@ -51,7 +52,8 @@
     "@tech-matters/resources-service": "^1.0.0",
     "@tech-matters/hrm-data-pull": "^1.0.0",
     "@tech-matters/contact-job-cleanup": "^1.0.0",
-    "@tech-matters/case-status-transition": "^1.0.0"
+    "@tech-matters/case-status-transition": "^1.0.0",
+    "@tech-matters/profile-flags-cleanup": "^1.0.0"
   },
   "devDependencies": {
     "@tech-matters/testing": "^1.0.0",

--- a/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
@@ -15,25 +15,15 @@
  */
 
 import { cleanupProfileFlags } from '@tech-matters/profile-flags-cleanup';
-import { addDays, subDays, subHours, subMinutes } from 'date-fns';
+import { addDays, subDays } from 'date-fns';
 import { db } from '@tech-matters/hrm-core/connection-pool';
 import { accountSid } from '../mocks';
-// import * as profileApi from '@tech-matters/hrm-core/profile/profile';
 import * as profileDB from '@tech-matters/hrm-core/profile/profile-data-access';
 
-let createdProfile: profileDB.Profile = null;
-let createdProfileFlag: profileDB.ProfileFlag = null;
-let profileFlags: profileDB.ProfileFlag[] = null;
+let createdProfile: profileDB.Profile;
+let createdProfileFlag: profileDB.ProfileFlag;
+let profileFlags: profileDB.ProfileFlag[];
 beforeAll(async () => {
-  // db.task(async t => {
-  // const profile = await t.one(
-  //   `INSERT INTO "Profiles"("name", "accountSid", "createdAt", "updatedAt")
-  //   VALUES (NULL, $<accountSid>, '2023-08-30 12:23:24.99+00', '2023-08-30 12:23:24.99+00')
-  //   RETURNING *`,
-  //   { accountSid },
-  // );
-  // });
-
   [createdProfile, createdProfileFlag] = await Promise.all([
     profileDB.createProfile()(accountSid, {
       name: 'TEST_PROFILE',

--- a/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cleanupProfileFlags } from '@tech-matters/profile-flags-cleanup';
+import { addDays, subDays, subHours, subMinutes } from 'date-fns';
+import { db } from '@tech-matters/hrm-core/connection-pool';
+import { accountSid } from '../mocks';
+// import * as profileApi from '@tech-matters/hrm-core/profile/profile';
+import * as profileDB from '@tech-matters/hrm-core/profile/profile-data-access';
+
+let createdProfile: profileDB.Profile = null;
+let createdProfileFlag: profileDB.ProfileFlag = null;
+let profileFlags: profileDB.ProfileFlag[] = null;
+beforeAll(async () => {
+  // db.task(async t => {
+  // const profile = await t.one(
+  //   `INSERT INTO "Profiles"("name", "accountSid", "createdAt", "updatedAt")
+  //   VALUES (NULL, $<accountSid>, '2023-08-30 12:23:24.99+00', '2023-08-30 12:23:24.99+00')
+  //   RETURNING *`,
+  //   { accountSid },
+  // );
+  // });
+
+  [createdProfile, createdProfileFlag] = await Promise.all([
+    profileDB.createProfile()(accountSid, {
+      name: 'TEST_PROFILE',
+    }),
+    (
+      await profileDB.createProfileFlag(accountSid, {
+        name: 'TEST_PROFILE_FLAG',
+      })
+    ).unwrap(),
+  ]);
+
+  profileFlags = (await profileDB.getProfileFlagsForAccount(accountSid)).unwrap();
+});
+
+afterAll(async () => {
+  await db.task(async t => {
+    await Promise.all([
+      t.none(`DELETE FROM "ProfileFlags" WHERE id = $<id>`, {
+        id: createdProfileFlag.id,
+      }),
+      t.none(`DELETE FROM "Profiles" WHERE id = $<id>`, { id: createdProfile.id }),
+    ]);
+  });
+});
+
+describe('cleanupProfileFlags', () => {
+  afterEach(async () => {
+    const p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    await Promise.all(
+      p.profileFlags.map(pf =>
+        profileDB.disassociateProfileFromProfileFlag()(accountSid, p.id, pf.id),
+      ),
+    );
+  });
+
+  test('when associations are null, cleanupProfileFlags does nothing', async () => {
+    await Promise.all(
+      profileFlags.map(pf =>
+        profileDB.associateProfileToProfileFlag()(
+          accountSid,
+          createdProfile.id,
+          pf.id,
+          null,
+        ),
+      ),
+    );
+
+    let p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(3);
+
+    await cleanupProfileFlags();
+
+    p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(3);
+  });
+
+  test('when associations are not expired yet, cleanupProfileFlags does nothing', async () => {
+    const futureDate = addDays(new Date(), 1);
+    await Promise.all(
+      profileFlags.map(pf =>
+        profileDB.associateProfileToProfileFlag()(
+          accountSid,
+          createdProfile.id,
+          pf.id,
+          futureDate,
+        ),
+      ),
+    );
+
+    let p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(3);
+
+    await cleanupProfileFlags();
+
+    p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(3);
+  });
+
+  test('when associations are expired, cleanupProfileFlags removes them', async () => {
+    const pastDate = subDays(new Date(), 1);
+    await Promise.all(
+      profileFlags.map(pf =>
+        profileDB.associateProfileToProfileFlag()(
+          accountSid,
+          createdProfile.id,
+          pf.id,
+          pastDate,
+        ),
+      ),
+    );
+
+    let p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(3);
+
+    await cleanupProfileFlags();
+
+    p = await profileDB.getProfileById()(accountSid, createdProfile.id);
+    expect(p.profileFlags).toHaveLength(0);
+  });
+});

--- a/hrm-domain/hrm-service/src/profileFlagsCleanup.ts
+++ b/hrm-domain/hrm-service/src/profileFlagsCleanup.ts
@@ -14,13 +14,16 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const enableCreateContactJobsFlag = /^true$/i.test(
-  process.env.ENABLE_CREATE_CONTACT_JOBS,
-);
-export const enableProcessContactJobsFlag = /^true$/i.test(
-  process.env.ENABLE_PROCESS_CONTACT_JOBS,
-);
-export const enableCleanupJobs = /^true$/i.test(process.env.ENABLE_CLEANUP_JOBS);
-export const enableProfileFlagsCleanup = /^true$/i.test(
-  process.env.ENABLE_PROFILE_FLAGS_CLEANUP,
-);
+import { handleSignals } from './handleSignals';
+import { enableProfileFlagsCleanup } from '@tech-matters/hrm-core/featureFlags';
+import { cleanupProfileFlags } from '@tech-matters/profile-flags-cleanup';
+
+const gracefulExit = async () => {
+  //TODO: this should probably handle closing any running processes and open db connections
+};
+
+if (enableProfileFlagsCleanup) {
+  cleanupProfileFlags();
+
+  handleSignals(gracefulExit);
+}

--- a/hrm-domain/hrm-service/tsconfig.build.json
+++ b/hrm-domain/hrm-service/tsconfig.build.json
@@ -18,6 +18,7 @@
     { "path": "hrm-domain/scheduled-tasks/hrm-data-pull" },
     { "path": "hrm-domain/scheduled-tasks/contact-job-cleanup" },
     { "path": "hrm-domain/scheduled-tasks/case-status-transition" },
+    { "path": "hrm-domain/scheduled-tasks/profile-flags-cleanup" },
     { "path": "hrm-domain/hrm-service" }
   ]
 }

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import { isErr } from '@tech-matters/types';
+import * as profileApi from './dataAccess';
+
+export const cleanupProfileFlags = async (): Promise<void> => {
+  try {
+    console.info(`[scheduled-task:profile-flags-cleanup]: Starting automatic cleanup...`);
+
+    const result = await profileApi.cleanupProfileFlags();
+
+    if (isErr(result)) {
+      console.error(
+        `[scheduled-task:profile-flags-cleanup]: Error during cleanup: ${result.error}, ${result.message}`,
+      );
+      return;
+    }
+
+    console.info(
+      `[scheduled-task:profile-flags-cleanup]: Removed ${result.data} profile to profile flags associations`,
+    );
+  } catch (err) {
+    console.error(`[scheduled-task:profile-flags-cleanup]: Error during cleanup: ${err}`);
+  }
+};

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/index.ts
@@ -30,7 +30,7 @@ export const cleanupProfileFlags = async (): Promise<void> => {
     }
 
     console.info(
-      `[scheduled-task:profile-flags-cleanup]: Removed ${result.data} profile to profile flags associations`,
+      `[scheduled-task:profile-flags-cleanup]: Removed ${result.data.count} profiles-to-profile-flags associations`,
     );
   } catch (err) {
     console.error(`[scheduled-task:profile-flags-cleanup]: Error during cleanup: ${err}`);

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/jest.config.js
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/jest.config.js
@@ -14,13 +14,18 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export const enableCreateContactJobsFlag = /^true$/i.test(
-  process.env.ENABLE_CREATE_CONTACT_JOBS,
-);
-export const enableProcessContactJobsFlag = /^true$/i.test(
-  process.env.ENABLE_PROCESS_CONTACT_JOBS,
-);
-export const enableCleanupJobs = /^true$/i.test(process.env.ENABLE_CLEANUP_JOBS);
-export const enableProfileFlagsCleanup = /^true$/i.test(
-  process.env.ENABLE_PROFILE_FLAGS_CLEANUP,
-);
+module.exports = config => {
+  return (
+    config || {
+      preset: 'ts-jest',
+      rootDir: './',
+      maxWorkers: 1,
+      globals: {
+        'ts-jest': {
+          // to give support to const enum. Not working, conflicting with module resolution
+          useExperimentalLanguageServer: true,
+        },
+      },
+    }
+  );
+};

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/package.json
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@tech-matters/profile-flags-cleanup",
+  "version": "1.0.0",
+  "description": "The easiest way to run the tests locally is to run the test DB in docker.",
+  "scripts": {
+    "start": "cd dist && node ./index"
+  },
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "dependencies" : {
+    "@tech-matters/hrm-core": "^1.0.0",
+    "@tech-matters/ssm-cache": "^1.0.0",
+    "@tech-matters/twilio-client": "^1.0.0",
+    "@tech-matters/types": "^1.0.0",
+    "date-fns": "^2.28.0"
+  }
+}

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/tsconfig.json
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/tsconfig.json
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/tsconfig.json
@@ -4,5 +4,6 @@
   "exclude": ["node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "outDir": "./dist"
-  }
+  },
+  "declaration": true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
         "@tech-matters/hrm-core": "^1.0.0",
         "@tech-matters/hrm-data-pull": "^1.0.0",
         "@tech-matters/http": "^1.0.0",
+        "@tech-matters/profile-flags-cleanup": "^1.0.0",
         "@tech-matters/resources-service": "^1.0.0",
         "@tech-matters/twilio-worker-auth": "^1.0.0",
         "@types/debug": "^4.1.8",
@@ -265,6 +266,17 @@
         "@tech-matters/hrm-core": "^1.0.0",
         "@tech-matters/s3-client": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
+        "date-fns": "^2.28.0"
+      }
+    },
+    "hrm-domain/scheduled-tasks/profile-flags-cleanup": {
+      "name": "@tech-matters/profile-flags-cleanup",
+      "version": "1.0.0",
+      "dependencies": {
+        "@tech-matters/hrm-core": "^1.0.0",
+        "@tech-matters/ssm-cache": "^1.0.0",
+        "@tech-matters/twilio-client": "^1.0.0",
+        "@tech-matters/types": "^1.0.0",
         "date-fns": "^2.28.0"
       }
     },
@@ -3848,6 +3860,10 @@
     },
     "node_modules/@tech-matters/job-errors": {
       "resolved": "packages/job-errors",
+      "link": true
+    },
+    "node_modules/@tech-matters/profile-flags-cleanup": {
+      "resolved": "hrm-domain/scheduled-tasks/profile-flags-cleanup",
       "link": true
     },
     "node_modules/@tech-matters/resources-import-producer": {
@@ -17502,6 +17518,7 @@
         "@tech-matters/hrm-core": "^1.0.0",
         "@tech-matters/hrm-data-pull": "^1.0.0",
         "@tech-matters/http": "^1.0.0",
+        "@tech-matters/profile-flags-cleanup": "^1.0.0",
         "@tech-matters/resources-service": "^1.0.0",
         "@tech-matters/testing": "^1.0.0",
         "@tech-matters/twilio-client": "^1.0.0",
@@ -17578,6 +17595,16 @@
     },
     "@tech-matters/job-errors": {
       "version": "file:packages/job-errors"
+    },
+    "@tech-matters/profile-flags-cleanup": {
+      "version": "file:hrm-domain/scheduled-tasks/profile-flags-cleanup",
+      "requires": {
+        "@tech-matters/hrm-core": "^1.0.0",
+        "@tech-matters/ssm-cache": "^1.0.0",
+        "@tech-matters/twilio-client": "^1.0.0",
+        "@tech-matters/types": "^1.0.0",
+        "date-fns": "^2.28.0"
+      }
     },
     "@tech-matters/resources-import-producer": {
       "version": "file:resources-domain/lambdas/import-producer",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "hrm-domain/scheduled-tasks/hrm-data-pull" },
     { "path": "hrm-domain/scheduled-tasks/contact-job-cleanup" },
     { "path": "hrm-domain/scheduled-tasks/case-status-transition" },
+    { "path": "hrm-domain/scheduled-tasks/profile-flags-cleanup" },
     { "path": "resources-domain/packages/resources-search-config" },
     { "path": "resources-domain/resources-service/tsconfig.scripts.json" },
     { "path": "resources-domain/lambdas/import-consumer" },


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/infrastructure-config/pull/312.

## Description
This PR adds a new scheduled task, `profileFlagsCleanup`, which will cleanup all the records in the `ProfilesToProfileFlags` association table if their `validUntil` date has already expired.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2365)
- [x] New tests added

### Verification steps
- Service tests or
- 