### PR TITLE
chore: Expose admin-cli for HRM internal endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 [![Actions Status](https://github.com/tech-matters/hrm/workflows/hrm-ci/badge.svg)](https://github.com/tech-matters/hrm/actions)
 
+
 The Helpline Relationship Management (HRM) system is the backend for the Aselo system. It is built as an Express/NodeJS REST API accessed by the [Aselo frontend](https://www.twilio.com/docs/flex/developer/plugins). See [aselo.org](https://aselo.org/) or [contact Aselo](https://aselo.org/contact-us/) for more information.
+
+## Scripts and utilities
+- [admin-cli to access private endpoints](./hrm-domain/hrm-service/scripts/README.md)
 
 ## git-secrets
 

--- a/hrm-domain/hrm-core/profile/admin-profile-routes-v0.ts
+++ b/hrm-domain/hrm-core/profile/admin-profile-routes-v0.ts
@@ -78,7 +78,9 @@ adminProfilesRouter.patch('/flags/:flagId', publicEndpoint, async (req, res, nex
       return next(createError(404));
     }
 
-    res.json(result.data);
+    res.json({
+      result: `Succesfully deleted flag ${result.data.name} (ID ${result.data.id})`,
+    });
   } catch (err) {
     return next(createError(500, err.message));
   }

--- a/hrm-domain/hrm-core/profile/profile.ts
+++ b/hrm-domain/hrm-core/profile/profile.ts
@@ -266,10 +266,10 @@ export const updateProfileFlagById = async (
 export const deleteProfileFlagById = async (
   flagId: profileDB.ProfileFlag['id'],
   accountSid: string,
-): Promise<TResult<'InternalServerError', void>> => {
+): Promise<TResult<'InternalServerError', profileDB.ProfileFlag>> => {
   try {
-    await profileDB.deleteProfileFlagById(flagId, accountSid);
-    return newOk({ data: undefined });
+    const result = await profileDB.deleteProfileFlagById(flagId, accountSid);
+    return result;
   } catch (err) {
     return newErr({
       message: err instanceof Error ? err.message : String(err),

--- a/hrm-domain/hrm-service/package.json
+++ b/hrm-domain/hrm-service/package.json
@@ -43,20 +43,23 @@
   },
   "homepage": "https://github.com/tech-matters/hrm#readme",
   "dependencies": {
-    "dotenv": "^16.3.1",
-    "@types/express": "^4.17.13",
-    "@types/debug": "^4.1.8",
-    "@tech-matters/http": "^1.0.0",
-    "@tech-matters/twilio-worker-auth": "^1.0.0",
-    "@tech-matters/hrm-core": "^1.0.0",
-    "@tech-matters/resources-service": "^1.0.0",
-    "@tech-matters/hrm-data-pull": "^1.0.0",
-    "@tech-matters/contact-job-cleanup": "^1.0.0",
     "@tech-matters/case-status-transition": "^1.0.0",
-    "@tech-matters/profile-flags-cleanup": "^1.0.0"
+    "@tech-matters/contact-job-cleanup": "^1.0.0",
+    "@tech-matters/hrm-core": "^1.0.0",
+    "@tech-matters/hrm-data-pull": "^1.0.0",
+    "@tech-matters/http": "^1.0.0",
+    "@tech-matters/profile-flags-cleanup": "^1.0.0",
+    "@tech-matters/resources-service": "^1.0.0",
+    "@tech-matters/twilio-worker-auth": "^1.0.0",
+    "@tech-matters/service-discovery": "^1.0.0",
+    "@types/debug": "^4.1.8",
+    "@types/express": "^4.17.13",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@tech-matters/testing": "^1.0.0",
+    "@tech-matters/twilio-client": "^1.0.0",
+    "@tech-matters/types": "^1.0.0",
     "@types/deep-diff": "^1.0.1",
     "@types/http-errors": "^2.0.1",
     "@types/lodash": "^4.14.191",
@@ -64,8 +67,8 @@
     "@types/supertest": "^2.0.12",
     "chalk": "^4.0.0",
     "cross-env": "^7.0.3",
-    "date-fns-tz": "^2.0.0",
     "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0",
     "global-agent": "^3.0.0",
     "jest-each": "^29.2.1",
     "mockttp": "^3.2.2",
@@ -77,8 +80,8 @@
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3",
     "umzug": "^3.0.0",
+    "undici": "^6.5.0",
     "util": "^0.12.2",
-    "@tech-matters/types": "^1.0.0",
-    "@tech-matters/twilio-client": "^1.0.0"
+    "yargs": "^17.7.2"
   }
 }

--- a/hrm-domain/hrm-service/scripts/README.md
+++ b/hrm-domain/hrm-service/scripts/README.md
@@ -1,0 +1,37 @@
+### Description
+`admin-cli` is an internal tool intended to be used by the Aselo staff.
+
+This is composition of different scripts that will allow to perform actions against HRM server/database without the need to manually running queries or hitting endpoints.
+
+### Requirements
+- Access to Management/EU VPN (depending on the target environment)
+- Access to the devops instance
+- Once connected to the VPN and SSHed into the devops instance you need to clone this repo (if your user does not have it yet)
+  `git clone https://github.com/techmatters/hrm`
+- Install the dependencies (if not done yet)
+  `npm ci`
+
+### Available commands
+```bash
+admin-cli
+├── profiles
+| ├── flags
+|   ├── list:         # List the profile flags for the given account
+|   ├── create:       # Create a new profile flag
+|   ├── edit:         # Edit an existing profile flag
+|   ├── delete:       # Delete an existing profile flag
+```
+
+### Usage
+Run admin commands like
+`npm run admin-cli`
+
+To get more information about the scripts available
+`npm run admin-cli --help`
+
+To get about a specific command
+`npm run admin-cli <command> --help`
+where `<command>` is the command you are trying to run
+
+Each command might have sub-commands. For example, if you want to run "list available profile flags" script
+`npm run admin-cli profile flags list`

--- a/hrm-domain/hrm-service/scripts/admin-cli.ts
+++ b/hrm-domain/hrm-service/scripts/admin-cli.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import yargs from 'yargs';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+// import { fetch, Response } from 'undici';
+// import { AccountSID } from '@tech-matters/types';
+// import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
+
+// const staticKeyPattern = /^STATIC_KEY_ADMIN_HRM=(?<key>.*)$/im;
+
+// const main = async () => {
+//   const argv = yargs
+//     .usage('Usage: $0 <command> [options]')
+//     .help('h')
+//     .alias('h', 'help').argv;
+
+//   const {
+//     e: environment,
+//     r: regionParam,
+//     a: accountSid,
+//     v: verbose,
+//   } = yargs(process.argv.slice(2)).options({
+//     e: {
+//       alias: 'environment',
+//       describe: 'The target environment, defaults to development',
+//       type: 'string',
+//       default: 'development',
+//     },
+//     r: {
+//       alias: 'region',
+//       describe:
+//         'The region you are targeting. If none provided, will use process.env.AWS_REGION',
+//       type: 'string',
+//     },
+//     a: {
+//       alias: 'accountSid',
+//       describe: 'The target account sid under which the admin endpoints will be executed',
+//       type: 'string',
+//     },
+//     v: {
+//       alias: 'verbose',
+//       describe: '',
+//       type: 'boolean',
+//       default: false,
+//     },
+//   });
+
+//   const region = regionParam || process.env.AWS_REGION;
+//   if (!region) {
+//     throw new Error(`region parameter not provided nor set in .env`);
+//   }
+// };
+
+const main = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  yargs
+    .commandDir('admin-commands', {
+      exclude: /^(index|_)/, // Exclude files starting with 'index' or '_'
+      extensions: ['ts'],
+    })
+    .scriptName('admin-cli')
+    .demandCommand(1, 'Please provide a valid command')
+    .version(false)
+    .help().argv;
+};
+
+main();

--- a/hrm-domain/hrm-service/scripts/admin-cli.ts
+++ b/hrm-domain/hrm-service/scripts/admin-cli.ts
@@ -17,56 +17,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import yargs from 'yargs';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-// import { fetch, Response } from 'undici';
-// import { AccountSID } from '@tech-matters/types';
-// import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
-
-// const staticKeyPattern = /^STATIC_KEY_ADMIN_HRM=(?<key>.*)$/im;
-
-// const main = async () => {
-//   const argv = yargs
-//     .usage('Usage: $0 <command> [options]')
-//     .help('h')
-//     .alias('h', 'help').argv;
-
-//   const {
-//     e: environment,
-//     r: regionParam,
-//     a: accountSid,
-//     v: verbose,
-//   } = yargs(process.argv.slice(2)).options({
-//     e: {
-//       alias: 'environment',
-//       describe: 'The target environment, defaults to development',
-//       type: 'string',
-//       default: 'development',
-//     },
-//     r: {
-//       alias: 'region',
-//       describe:
-//         'The region you are targeting. If none provided, will use process.env.AWS_REGION',
-//       type: 'string',
-//     },
-//     a: {
-//       alias: 'accountSid',
-//       describe: 'The target account sid under which the admin endpoints will be executed',
-//       type: 'string',
-//     },
-//     v: {
-//       alias: 'verbose',
-//       describe: '',
-//       type: 'boolean',
-//       default: false,
-//     },
-//   });
-
-//   const region = regionParam || process.env.AWS_REGION;
-//   if (!region) {
-//     throw new Error(`region parameter not provided nor set in .env`);
-//   }
-// };
-
 const main = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   yargs
@@ -77,6 +27,7 @@ const main = () => {
     .scriptName('admin-cli')
     .demandCommand(1, 'Please provide a valid command')
     .version(false)
+    .wrap(120)
     .help().argv;
 };
 

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const command = 'profiles <command>';
+export const desc = 'admin endpoints for profiles';
+export const builder = function (yargs) {
+  return yargs.commandDir('profiles', {
+    exclude: /^(index|_)/, // Exclude files starting with 'index' or '_'
+    extensions: ['ts'],
+  });
+  // .commandDir('common_cmds'); add more
+};
+// export const handler = function (argv) {};

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const command = 'flags <command>';
+export const desc = 'admin endpoints for profiles flags';
+export const builder = function (yargs) {
+  return yargs.commandDir('flags', {
+    exclude: /^(index|_)/, // Exclude files starting with 'index' or '_'
+    extensions: ['ts'],
+  });
+  // .commandDir('common_cmds'); add more
+};
+// export const handler = function (argv) {};

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const command = 'create';
+export const describe = 'Create a new profile flag for the given account';
+export const builder = {
+  a: {
+    describe: 'target account SID',
+    demandOption: true,
+    type: 'string',
+  },
+};
+export const handler = async (argv: { id: any }) => {
+  console.log(`Fetching data for profile ID: ${argv.id}`);
+  // Simulating an asynchronous operation with setTimeout
+  await new Promise(resolve => setTimeout(resolve, 2000));
+  console.log('Async operation completed.');
+};

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
@@ -20,7 +20,7 @@ import { fetch } from 'undici';
 import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
 
 export const command = 'create';
-export const describe = 'Create a new profile flag for the given account';
+export const describe = 'Create a new profile flag';
 export const builder = {
   e: {
     alias: 'environment',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
@@ -14,18 +14,76 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { fetch } from 'undici';
+import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
+
 export const command = 'create';
 export const describe = 'Create a new profile flag for the given account';
 export const builder = {
+  e: {
+    alias: 'environment',
+    describe: 'environment, defaults to development',
+    type: 'string',
+    default: 'development',
+  },
+  r: {
+    alias: 'region',
+    describe: 'region, defaults to us-east-1',
+    type: 'string',
+    default: 'us-east-1',
+  },
   a: {
-    describe: 'target account SID',
+    alias: 'accountSid',
+    describe: 'account SID',
+    demandOption: true,
+    type: 'string',
+  },
+  n: {
+    alias: 'name',
+    describe: 'name for the new flag',
     demandOption: true,
     type: 'string',
   },
 };
-export const handler = async (argv: { id: any }) => {
-  console.log(`Fetching data for profile ID: ${argv.id}`);
-  // Simulating an asynchronous operation with setTimeout
-  await new Promise(resolve => setTimeout(resolve, 2000));
-  console.log('Async operation completed.');
+
+export const handler = async ({ region, environment, accountSid, name }) => {
+  try {
+    const timestamp = new Date().getTime();
+    const assumeRoleParams = {
+      RoleArn: 'arn:aws:iam::712893914485:role/admin-no-pii',
+      RoleSessionName: `hrm-admin-cli-${timestamp}`,
+    };
+
+    const { authKey, internalResourcesUrl } = await getHRMInternalEndpointAccess({
+      region,
+      environment,
+      staticKeyPattern,
+      assumeRoleParams,
+    });
+
+    const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/flags');
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${authKey}`,
+      },
+      body: JSON.stringify({ name }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to submit request: ${response.statusText}`);
+    }
+
+    const jsonResp = await response.json();
+    console.log(JSON.stringify(jsonResp, null, 2));
+  } catch (err) {
+    console.error(
+      `Failed to create flag ${name} account ${accountSid} (${region} ${environment})`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 };

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/create.ts
@@ -24,15 +24,15 @@ export const describe = 'Create a new profile flag';
 export const builder = {
   e: {
     alias: 'environment',
-    describe: 'environment, defaults to development',
+    describe: 'environment (e.g. development, staging, production)',
+    demandOption: true,
     type: 'string',
-    default: 'development',
   },
   r: {
     alias: 'region',
-    describe: 'region, defaults to us-east-1',
+    describe: 'region (e.g. us-east-1)',
+    demandOption: true,
     type: 'string',
-    default: 'us-east-1',
   },
   a: {
     alias: 'accountSid',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
@@ -19,8 +19,8 @@ import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
 import { fetch } from 'undici';
 import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
 
-export const command = 'list';
-export const describe = 'List the profile flags for the given account';
+export const command = 'delete';
+export const describe = 'Delete an existing profile flag for the given account';
 export const builder = {
   e: {
     alias: 'environment',
@@ -40,9 +40,15 @@ export const builder = {
     demandOption: true,
     type: 'string',
   },
+  i: {
+    alias: 'flagId',
+    describe: 'the id of the flag to delete',
+    demandOption: true,
+    type: 'number',
+  },
 };
 
-export const handler = async ({ region, environment, accountSid }) => {
+export const handler = async ({ region, environment, accountSid, flagId }) => {
   try {
     const timestamp = new Date().getTime();
     const assumeRoleParams = {
@@ -57,10 +63,14 @@ export const handler = async ({ region, environment, accountSid }) => {
       assumeRoleParams,
     });
 
-    const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/flags');
+    const url = getAdminV0URL(
+      internalResourcesUrl,
+      accountSid,
+      `/profiles/flags/${flagId}`,
+    );
 
     const response = await fetch(url, {
-      method: 'GET',
+      method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Basic ${authKey}`,
@@ -75,7 +85,7 @@ export const handler = async ({ region, environment, accountSid }) => {
     console.log(JSON.stringify(jsonResp, null, 2));
   } catch (err) {
     console.error(
-      `Failed to list profile flags for account ${accountSid} (${region} ${environment})`,
+      `Failed to delete profile flag ${flagId} for account ${accountSid} (${region} ${environment})`,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
@@ -20,7 +20,7 @@ import { fetch } from 'undici';
 import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
 
 export const command = 'delete';
-export const describe = 'Delete an existing profile flag for the given account';
+export const describe = 'Delete an existing profile flag';
 export const builder = {
   e: {
     alias: 'environment',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/delete.ts
@@ -24,15 +24,15 @@ export const describe = 'Delete an existing profile flag';
 export const builder = {
   e: {
     alias: 'environment',
-    describe: 'environment, defaults to development',
+    describe: 'environment (e.g. development, staging, production)',
+    demandOption: true,
     type: 'string',
-    default: 'development',
   },
   r: {
     alias: 'region',
-    describe: 'region, defaults to us-east-1',
+    describe: 'region (e.g. us-east-1)',
+    demandOption: true,
     type: 'string',
-    default: 'us-east-1',
   },
   a: {
     alias: 'accountSid',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
@@ -20,7 +20,7 @@ import { fetch } from 'undici';
 import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
 
 export const command = 'edit';
-export const describe = 'Edit an existing profile flag for the given account';
+export const describe = 'Edit an existing profile flag';
 export const builder = {
   e: {
     alias: 'environment',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
@@ -19,8 +19,8 @@ import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
 import { fetch } from 'undici';
 import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
 
-export const command = 'list';
-export const describe = 'List the profile flags for the given account';
+export const command = 'edit';
+export const describe = 'Edit an existing profile flag for the given account';
 export const builder = {
   e: {
     alias: 'environment',
@@ -40,9 +40,21 @@ export const builder = {
     demandOption: true,
     type: 'string',
   },
+  i: {
+    alias: 'flagId',
+    describe: 'the id of the flag to edit',
+    demandOption: true,
+    type: 'number',
+  },
+  n: {
+    alias: 'name',
+    describe: 'the new name for the flag',
+    demandOption: true,
+    type: 'string',
+  },
 };
 
-export const handler = async ({ region, environment, accountSid }) => {
+export const handler = async ({ region, environment, accountSid, flagId, name }) => {
   try {
     const timestamp = new Date().getTime();
     const assumeRoleParams = {
@@ -57,14 +69,19 @@ export const handler = async ({ region, environment, accountSid }) => {
       assumeRoleParams,
     });
 
-    const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/flags');
+    const url = getAdminV0URL(
+      internalResourcesUrl,
+      accountSid,
+      `/profiles/flags/${flagId}`,
+    );
 
     const response = await fetch(url, {
-      method: 'GET',
+      method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Basic ${authKey}`,
       },
+      body: JSON.stringify({ name }),
     });
 
     if (!response.ok) {
@@ -75,7 +92,7 @@ export const handler = async ({ region, environment, accountSid }) => {
     console.log(JSON.stringify(jsonResp, null, 2));
   } catch (err) {
     console.error(
-      `Failed to list profile flags for account ${accountSid} (${region} ${environment})`,
+      `Failed to edit profile flag ${flagId} for account ${accountSid} (${region} ${environment})`,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/edit.ts
@@ -24,15 +24,15 @@ export const describe = 'Edit an existing profile flag';
 export const builder = {
   e: {
     alias: 'environment',
-    describe: 'environment, defaults to development',
+    describe: 'environment (e.g. development, staging, production)',
+    demandOption: true,
     type: 'string',
-    default: 'development',
   },
   r: {
     alias: 'region',
-    describe: 'region, defaults to us-east-1',
+    describe: 'region (e.g. us-east-1)',
+    demandOption: true,
     type: 'string',
-    default: 'us-east-1',
   },
   a: {
     alias: 'accountSid',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { fetch } from 'undici';
+
+import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
+
+export const command = 'list';
+export const describe = 'List the profile flags for the given account';
+export const builder = {
+  e: {
+    alias: 'environment',
+    describe: 'environment, defaults to development',
+    type: 'string',
+    default: 'development',
+  },
+  r: {
+    alias: 'region',
+    describe: 'region, defaults to us-east-1',
+    type: 'string',
+    default: 'us-east-1',
+  },
+  a: {
+    alias: 'accountSid',
+    describe: 'account SID',
+    demandOption: true,
+    type: 'string',
+  },
+};
+export const handler = async ({ region, environment, accountSid }) => {
+  const timestamp = new Date().getTime();
+  const assumeRoleParams = {
+    RoleArn: 'arn:aws:iam::712893914485:role/admin-no-pii',
+    RoleSessionName: `es-reindex-${timestamp}`,
+  };
+
+  const { authKey, internalResourcesUrl } = await getHRMInternalEndpointAccess({
+    region,
+    environment,
+    staticKeyPattern,
+    assumeRoleParams,
+  });
+
+  const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/flags');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${authKey}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to submit request: ${response.statusText}`);
+  }
+
+  console.log(response.body);
+};

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -70,7 +70,5 @@ export const handler = async ({ region, environment, accountSid }) => {
     throw new Error(`Failed to submit request: ${response.statusText}`);
   }
 
-  for await (const chunk of response.body) {
-    process.stdout.write(chunk);
-  }
+  console.log(JSON.stringify(response.json(), null, 2));
 };

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -70,5 +70,6 @@ export const handler = async ({ region, environment, accountSid }) => {
     throw new Error(`Failed to submit request: ${response.statusText}`);
   }
 
-  console.log(JSON.stringify(response.json(), null, 2));
+  const jsonResp = await response.json();
+  console.log(JSON.stringify(jsonResp, null, 2));
 };

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -24,15 +24,15 @@ export const describe = 'List the profile flags for the given account';
 export const builder = {
   e: {
     alias: 'environment',
-    describe: 'environment, defaults to development',
+    describe: 'environment (e.g. development, staging, production)',
+    demandOption: true,
     type: 'string',
-    default: 'development',
   },
   r: {
     alias: 'region',
-    describe: 'region, defaults to us-east-1',
+    describe: 'region (e.g. us-east-1)',
+    demandOption: true,
     type: 'string',
-    default: 'us-east-1',
   },
   a: {
     alias: 'accountSid',

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -59,7 +59,7 @@ export const handler = async ({ region, environment, accountSid }) => {
   const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/flags');
 
   const response = await fetch(url, {
-    method: 'POST',
+    method: 'GET',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Basic ${authKey}`,

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/flags/list.ts
@@ -65,9 +65,12 @@ export const handler = async ({ region, environment, accountSid }) => {
       Authorization: `Basic ${authKey}`,
     },
   });
+
   if (!response.ok) {
     throw new Error(`Failed to submit request: ${response.statusText}`);
   }
 
-  console.log(response.body);
+  for await (const chunk of response.body) {
+    process.stdout.write(chunk);
+  }
 };

--- a/hrm-domain/hrm-service/scripts/hrmInternalConfig.ts
+++ b/hrm-domain/hrm-service/scripts/hrmInternalConfig.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { AccountSID } from '../../../packages/types';
+
+export const staticKeyPattern = /^STATIC_KEY_ADMIN_HRM=(?<key>.*)$/im;
+
+export const getAdminV0URL = (
+  internalResourcesUrl: URL,
+  accountSid: AccountSID,
+  path: string,
+) => new URL(`/admin/v0/accounts/${accountSid}${path}`, internalResourcesUrl);

--- a/hrm-domain/hrm-service/tsconfig.build.json
+++ b/hrm-domain/hrm-service/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "packages/elasticsearch-client" },
     { "path": "packages/twilio-client" },
     { "path": "packages/types" },
+    { "path": "packages/service-discovery" },
     { "path": "resources-domain/packages/resources-search-config" },
     { "path": "resources-domain/resources-service" },
     { "path": "hrm-domain/hrm-core" },

--- a/hrm-domain/hrm-service/tsconfig.json
+++ b/hrm-domain/hrm-service/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": false,
   },
 
-  "include": ["src/**/*.js", "src/**/*.json", "src/**/*.ts"]
+  "include": ["src/**/*.js", "src/**/*.json", "src/**/*.ts", "scripts/**/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
         "@tech-matters/http": "^1.0.0",
         "@tech-matters/profile-flags-cleanup": "^1.0.0",
         "@tech-matters/resources-service": "^1.0.0",
+        "@tech-matters/service-discovery": "^1.0.0",
         "@tech-matters/twilio-worker-auth": "^1.0.0",
         "@types/debug": "^4.1.8",
         "@types/express": "^4.17.13",
@@ -185,9 +186,9 @@
       "dev": true
     },
     "hrm-domain/hrm-service/node_modules/undici": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.5.0.tgz",
-      "integrity": "sha512-/MUmPb2ptTvp1j7lPvdMSofMdqPxcOhAaKZi4k55sqm6XMeKI3n1dZJ5cnD4gLjpt2l7CIlthR1IXM59xKhpxw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.1.tgz",
+      "integrity": "sha512-J0GaEp0ztu/grIE2Uq57AbK6TRb+bWbOlxu0POCzhFKA6LKbwSAev+hDQaQcgUUA9CPs8Ky+cauzTHnQrtAQEA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -5209,9 +5210,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1547.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1547.0.tgz",
-      "integrity": "sha512-jk7u3KtDZ5F20k2X6D2FhndpLGkt3ZuNfRU5crp+fI6B/GFj/S91GJDoZh/Yw3rW+CemY1sFmdFT8ReA2G8WkA==",
+      "version": "2.1446.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1446.0.tgz",
+      "integrity": "sha512-QaIyQz9csPSgujM+asHNWHh6uw1FDh+SxpUERLbePDYwqycQha/0BkOxTciGh/Jhp26tKMnHL7rwrYl37H6RYA==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -5222,7 +5223,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.6.2"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -14218,9 +14219,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -14383,11 +14384,10 @@
       }
     },
     "packages/service-discovery": {
-      "name": "@tech-matters/service-discovery",
       "version": "1.0.0",
       "license": "AGPL",
       "dependencies": {
-        "aws-sdk": "^2.1547.0"
+        "aws-sdk": "^2.1353.0"
       }
     },
     "packages/sns-client": {
@@ -17547,6 +17547,7 @@
         "@tech-matters/http": "^1.0.0",
         "@tech-matters/profile-flags-cleanup": "^1.0.0",
         "@tech-matters/resources-service": "^1.0.0",
+        "@tech-matters/service-discovery": "^1.0.0",
         "@tech-matters/testing": "^1.0.0",
         "@tech-matters/twilio-client": "^1.0.0",
         "@tech-matters/twilio-worker-auth": "^1.0.0",
@@ -17574,7 +17575,7 @@
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3",
         "umzug": "^3.0.0",
-        "undici": "*",
+        "undici": "^6.5.0",
         "util": "^0.12.2",
         "yargs": "^17.7.2"
       },
@@ -17586,9 +17587,9 @@
           "dev": true
         },
         "undici": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-6.5.0.tgz",
-          "integrity": "sha512-/MUmPb2ptTvp1j7lPvdMSofMdqPxcOhAaKZi4k55sqm6XMeKI3n1dZJ5cnD4gLjpt2l7CIlthR1IXM59xKhpxw==",
+          "version": "6.6.1",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.1.tgz",
+          "integrity": "sha512-J0GaEp0ztu/grIE2Uq57AbK6TRb+bWbOlxu0POCzhFKA6LKbwSAev+hDQaQcgUUA9CPs8Ky+cauzTHnQrtAQEA==",
           "dev": true,
           "requires": {
             "@fastify/busboy": "^2.0.0"
@@ -17749,7 +17750,7 @@
     "@tech-matters/service-discovery": {
       "version": "file:packages/service-discovery",
       "requires": {
-        "aws-sdk": "^2.1547.0"
+        "aws-sdk": "^2.1353.0"
       }
     },
     "@tech-matters/sns-client": {
@@ -18775,9 +18776,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1547.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1547.0.tgz",
-      "integrity": "sha512-jk7u3KtDZ5F20k2X6D2FhndpLGkt3ZuNfRU5crp+fI6B/GFj/S91GJDoZh/Yw3rW+CemY1sFmdFT8ReA2G8WkA==",
+      "version": "2.1446.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1446.0.tgz",
+      "integrity": "sha512-QaIyQz9csPSgujM+asHNWHh6uw1FDh+SxpUERLbePDYwqycQha/0BkOxTciGh/Jhp26tKMnHL7rwrYl37H6RYA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -18788,7 +18789,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.6.2"
+        "xml2js": "0.5.0"
       },
       "dependencies": {
         "punycode": {
@@ -25543,9 +25544,9 @@
       "requires": {}
     },
     "xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,9 @@
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3",
         "umzug": "^3.0.0",
-        "util": "^0.12.2"
+        "undici": "^6.5.0",
+        "util": "^0.12.2",
+        "yargs": "^17.7.2"
       }
     },
     "hrm-domain/hrm-service/node_modules/@types/node": {
@@ -181,6 +183,18 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
+    },
+    "hrm-domain/hrm-service/node_modules/undici": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.5.0.tgz",
+      "integrity": "sha512-/MUmPb2ptTvp1j7lPvdMSofMdqPxcOhAaKZi4k55sqm6XMeKI3n1dZJ5cnD4gLjpt2l7CIlthR1IXM59xKhpxw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
     },
     "hrm-domain/lambdas/contact-complete": {
       "name": "@tech-matters/hrm-jobs-contact-complete",
@@ -3886,6 +3900,10 @@
       "resolved": "packages/s3-client",
       "link": true
     },
+    "node_modules/@tech-matters/service-discovery": {
+      "resolved": "packages/service-discovery",
+      "link": true
+    },
     "node_modules/@tech-matters/sns-client": {
       "resolved": "packages/sns-client",
       "link": true
@@ -5191,9 +5209,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1446.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1446.0.tgz",
-      "integrity": "sha512-QaIyQz9csPSgujM+asHNWHh6uw1FDh+SxpUERLbePDYwqycQha/0BkOxTciGh/Jhp26tKMnHL7rwrYl37H6RYA==",
+      "version": "2.1547.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1547.0.tgz",
+      "integrity": "sha512-jk7u3KtDZ5F20k2X6D2FhndpLGkt3ZuNfRU5crp+fI6B/GFj/S91GJDoZh/Yw3rW+CemY1sFmdFT8ReA2G8WkA==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -5204,7 +5222,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "xml2js": "0.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -14200,9 +14218,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -14362,6 +14380,14 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.388.0",
         "@aws-sdk/s3-request-presigner": "^3.388.0"
+      }
+    },
+    "packages/service-discovery": {
+      "name": "@tech-matters/service-discovery",
+      "version": "1.0.0",
+      "license": "AGPL",
+      "dependencies": {
+        "aws-sdk": "^2.1547.0"
       }
     },
     "packages/sns-client": {
@@ -14538,6 +14564,7 @@
       "dependencies": {
         "@tech-matters/elasticsearch-client": "^1.0.0",
         "@tech-matters/resources-search-config": "^1.0.0",
+        "@tech-matters/service-discovery": "^1.0.0",
         "@tech-matters/sns-client": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
         "@tech-matters/twilio-worker-auth": "^1.0.0",
@@ -17547,7 +17574,9 @@
         "ts-node": "^10.7.0",
         "typescript": "^4.6.3",
         "umzug": "^3.0.0",
-        "util": "^0.12.2"
+        "undici": "*",
+        "util": "^0.12.2",
+        "yargs": "^17.7.2"
       },
       "dependencies": {
         "@types/node": {
@@ -17555,6 +17584,15 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
           "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
           "dev": true
+        },
+        "undici": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-6.5.0.tgz",
+          "integrity": "sha512-/MUmPb2ptTvp1j7lPvdMSofMdqPxcOhAaKZi4k55sqm6XMeKI3n1dZJ5cnD4gLjpt2l7CIlthR1IXM59xKhpxw==",
+          "dev": true,
+          "requires": {
+            "@fastify/busboy": "^2.0.0"
+          }
         }
       }
     },
@@ -17657,6 +17695,7 @@
       "requires": {
         "@tech-matters/elasticsearch-client": "^1.0.0",
         "@tech-matters/resources-search-config": "^1.0.0",
+        "@tech-matters/service-discovery": "^1.0.0",
         "@tech-matters/sns-client": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
         "@tech-matters/testing": "^1.0.0",
@@ -17705,6 +17744,12 @@
       "requires": {
         "@aws-sdk/client-s3": "^3.388.0",
         "@aws-sdk/s3-request-presigner": "^3.388.0"
+      }
+    },
+    "@tech-matters/service-discovery": {
+      "version": "file:packages/service-discovery",
+      "requires": {
+        "aws-sdk": "^2.1547.0"
       }
     },
     "@tech-matters/sns-client": {
@@ -18730,9 +18775,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1446.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1446.0.tgz",
-      "integrity": "sha512-QaIyQz9csPSgujM+asHNWHh6uw1FDh+SxpUERLbePDYwqycQha/0BkOxTciGh/Jhp26tKMnHL7rwrYl37H6RYA==",
+      "version": "2.1547.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1547.0.tgz",
+      "integrity": "sha512-jk7u3KtDZ5F20k2X6D2FhndpLGkt3ZuNfRU5crp+fI6B/GFj/S91GJDoZh/Yw3rW+CemY1sFmdFT8ReA2G8WkA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -18743,7 +18788,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "xml2js": "0.6.2"
       },
       "dependencies": {
         "punycode": {
@@ -25498,9 +25543,9 @@
       "requires": {}
     },
     "xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "wait-on": "^7.2.0"
   },
   "scripts": {
+    "admin-cli": "npx tsx hrm-domain/hrm-service/scripts/admin-cli.ts",
     "build": "tsc -b --verbose",
     "build-and-start": "run-s build start",
     "build-and-start:service": "run-s build start:service",

--- a/packages/service-discovery/getHRMInternalEndpointAccess.ts
+++ b/packages/service-discovery/getHRMInternalEndpointAccess.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+// TODO: needs to be converted to aws-sdk-v3
+import { ECS, EC2, S3, STS } from 'aws-sdk';
+
+/**
+ * Returns the private IP address of the first task defined under the cluster - serviceName service discovery registry
+ */
+const findTaskPrivateIp = async ({
+  region,
+  environment,
+  credentials,
+}: {
+  region: string;
+  environment: string;
+  credentials: { accessKeyId: string; secretAccessKey: string; sessionToken: string };
+}) => {
+  const ecs = new ECS({
+    credentials,
+    region,
+  });
+  const ec2 = new EC2({
+    credentials,
+    region,
+  });
+
+  const cluster = `${environment}-ecs-cluster`;
+  const serviceName = `${environment}-ecs-service`;
+
+  const tasks = await ecs.listTasks({ cluster, serviceName }).promise();
+  const taskArns = tasks.taskArns ?? [];
+  const describeParams = {
+    cluster: cluster,
+    tasks: taskArns,
+  };
+  const taskData = await ecs.describeTasks(describeParams).promise();
+  const task = taskData!.tasks![0];
+  if (!task) {
+    throw new Error(`No task found for service ${serviceName}`);
+  }
+
+  const networkInterfaceDetails = task.attachments![0].details!.find(
+    detail => detail.name === 'networkInterfaceId',
+  );
+
+  if (!networkInterfaceDetails) {
+    throw new Error(`Could not find network interface details for task ${task.taskArn}`);
+  }
+
+  const networkInterfaceId = networkInterfaceDetails.value ?? '';
+  const describeNetworkInterfacesParams = {
+    NetworkInterfaceIds: [networkInterfaceId],
+  };
+  const networkInterfaceDescription = await ec2
+    .describeNetworkInterfaces(describeNetworkInterfacesParams)
+    .promise();
+
+  if (!networkInterfaceDescription.NetworkInterfaces) {
+    throw new Error(`Could not find network interfaces with network interface IDid task`);
+  }
+
+  const networkInterface = networkInterfaceDescription.NetworkInterfaces[0];
+  const privateIpAddress = networkInterface.PrivateIpAddress;
+
+  if (!privateIpAddress) {
+    throw new Error(
+      `Could not find private IP address on network interface ${networkInterfaceId} for task`,
+    );
+  }
+  console.log('Found the resources service private IP:', privateIpAddress);
+
+  return privateIpAddress;
+};
+
+const getHrmEnvVar = async ({
+  region,
+  environment,
+  staticKeyPattern,
+  credentials,
+}: {
+  region: string;
+  environment: string;
+  staticKeyPattern: RegExp;
+  credentials: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+  };
+}) => {
+  const s3 = new S3({
+    credentials,
+    region,
+  });
+
+  const { Body } = await s3
+    .getObject({
+      Bucket: `tl-hrm-vars-${environment}${region === 'us-east-1' ? '' : `-${region}`}`,
+      Key: `${environment}.env`,
+    })
+    .promise();
+  if (!Body) {
+    throw new Error('Failed to load environment variables file from S3');
+  }
+
+  const authKey = Body.toString().match(staticKeyPattern)?.groups?.key;
+  if (!authKey) {
+    throw new Error(
+      `Found the HRM .env file but failed to find the auth key under a ${staticKeyPattern} entry`,
+    );
+  }
+
+  return authKey;
+};
+
+export const getHRMInternalEndpointAccess = async ({
+  region,
+  environment,
+  assumeRoleParams,
+  staticKeyPattern,
+}: {
+  region: string;
+  environment: string;
+  assumeRoleParams: {
+    RoleArn: string;
+    RoleSessionName: string;
+  };
+  staticKeyPattern: RegExp;
+}) => {
+  const sts = new STS();
+  const { Credentials } = await sts.assumeRole(assumeRoleParams).promise();
+  const credentials = {
+    accessKeyId: Credentials!.AccessKeyId,
+    secretAccessKey: Credentials!.SecretAccessKey,
+    sessionToken: Credentials!.SessionToken,
+  };
+
+  const privateIpAddress = await findTaskPrivateIp({
+    region,
+    environment,
+    credentials,
+  });
+
+  const internalResourcesUrl = new URL('http://localhost');
+  internalResourcesUrl!.hostname = privateIpAddress;
+  internalResourcesUrl!.port = '8081';
+
+  const authKey = await getHrmEnvVar({
+    region,
+    environment,
+    staticKeyPattern,
+    credentials,
+  });
+
+  return {
+    internalResourcesUrl,
+    authKey,
+  };
+};

--- a/packages/service-discovery/index.ts
+++ b/packages/service-discovery/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './getHRMInternalEndpointAccess';

--- a/packages/service-discovery/package.json
+++ b/packages/service-discovery/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@tech-matters/service-discovery",
+  "version": "1.0.0",
+  "description": "Shared library for HRM",
+  "author": "",
+  "license": "AGPL",
+  "main": "dist/index.js",
+  "types": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/techmatters/hrm.git"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/techmatters/hrm/issues"
+  },
+  "homepage": "https://github.com/techmatters/hrm#readme",
+  "dependencies": {
+    "aws-sdk": "^2.1547.0"
+  }
+}

--- a/packages/service-discovery/package.json
+++ b/packages/service-discovery/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/techmatters/hrm#readme",
   "dependencies": {
-    "aws-sdk": "^2.1547.0"
+    "aws-sdk": "^2.1353.0"
   }
 }

--- a/packages/service-discovery/tsconfig.json
+++ b/packages/service-discovery/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.packages-base.json",
+  "include": ["*.ts"],
+  "compilerOptions": {
+    "outDir": "./dist",
+  },
+}

--- a/resources-domain/resources-service/package.json
+++ b/resources-domain/resources-service/package.json
@@ -65,6 +65,7 @@
     "@tech-matters/ssm-cache": "^1.0.0",
     "@tech-matters/twilio-worker-auth": "^1.0.0",
     "@tech-matters/types": "^1.0.0",
+    "@tech-matters/service-discovery": "^1.0.0",
     "aws-sdk": "^2.1353.0",
     "date-fns": "^2.29.3",
     "dotenv": "^8.6.0",

--- a/resources-domain/resources-service/tsconfig.scripts.json
+++ b/resources-domain/resources-service/tsconfig.scripts.json
@@ -11,7 +11,4 @@
     "outDir": "./scripts-dist"
   },
   "include": ["src/**/*.ts","scripts/**/*.ts"],
-  "references": [
-    { "path": "packages/service-discovery" }
-  ]
 }

--- a/resources-domain/resources-service/tsconfig.scripts.json
+++ b/resources-domain/resources-service/tsconfig.scripts.json
@@ -11,4 +11,7 @@
     "outDir": "./scripts-dist"
   },
   "include": ["src/**/*.ts","scripts/**/*.ts"],
+  "references": [
+    { "path": "packages/service-discovery" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "packages/sqs-client" },
     { "path": "packages/twilio-client" },
     { "path": "packages/twilio-worker-auth" },
+    { "path": "packages/service-discovery" },
     { "path": "lambdas/packages/hrm-authentication" },
     { "path": "lambdas/job-complete" },
     { "path": "hrm-domain/lambdas/contact-complete" },


### PR DESCRIPTION
This PR is a continuation of https://github.com/techmatters/hrm/pull/546

## Description
This PR adds a script to expose an admin-cli that can be used to interact with the HRM internal endpoints.
This cli-like sxcript supports 4 different commands:
- `admin-cli profiles flags create`  Create a new profile flag
- `admin-cli profiles flags delete`  Delete an existing profile flag
- `admin-cli profiles flags edit`    Edit an existing profile flag
- `admin-cli profiles flags list`    List the profile flags for the given account

Each of the commands supports `--help` flag to inform the user what are the required and optional parameters, usage, description etc.

The cli script is intended to support resource-like scoping, to make it easier to extend it to further usage of this internal tool.

In order to run the scripts you need to be connected to the VPN corresponding to the target environment (e.g. if you want to run changes in EU, you need to be connected to that VPN, any other change requires you to be connected to the management VPN).
The commands can only be executed from within the devops instance. You may need to clone this repo if your user in the instance does not has it yet.

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added

### Verification steps
- Connect to the VPN, then ssh into the devops instance
- Clone the repo (git clone https://github.com/techmatters/hrm.git), enter into the folder (`cd hrm`) and install the depencencies (`npm ci`)
- 