### PR TITLE
Test Case Merging permissions

### DIFF
--- a/hrm-domain/hrm-core/permission-rules/demo.json
+++ b/hrm-domain/hrm-core/permission-rules/demo.json
@@ -25,7 +25,7 @@
   "viewExternalTranscript": [["everyone"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
-  "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [["isSupervisor"]],
   
   "viewPostSurvey": [["isSupervisor"]]
 }

--- a/hrm-domain/hrm-core/permission-rules/ph.json
+++ b/hrm-domain/hrm-core/permission-rules/ph.json
@@ -25,7 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
-  "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [["isOwner"]],
 
   "viewPostSurvey": [["isSupervisor"]]
 }

--- a/hrm-domain/hrm-core/permission-rules/za.json
+++ b/hrm-domain/hrm-core/permission-rules/za.json
@@ -25,7 +25,7 @@
   "viewExternalTranscript": [["isSupervisor"]],
   "viewRecording": [],
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
-  "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
+  "removeContactFromCase": [["isOwner"]],
 
   "viewPostSurvey": [["isSupervisor"]]
 }


### PR DESCRIPTION
## Description
<!--
Temporary changes to staging accounts to test Case Merging permissions framework.

I changed:
ca.json, nz.json -> to our new default to test with their config
demo.json -> AS Dev, Stg, "removeContactFromCase": [["isSupervisor"]], so no counsellors can remove from case even if they created the contact
za.json -> removed ‘isCaseOpen’ so we should be able to remove from closed cases
ph.json ->   "removeContactFromCase": [["isOwner"]] …. So supervisors cannot remove from contact

-->

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
