### PR TITLE
Bug fix: Case count returns accurate number to look up all contact related cases- not just distinct

### DIFF
--- a/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
@@ -100,7 +100,7 @@ export const getProfilesByIdentifierSql = `
   SELECT
     profiles.id AS id,
     profiles.name AS name,
-    CAST(COUNT(DISTINCT CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS INTEGER) AS "casesCount",
+    CAST(COUNT(CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS INTEGER) AS "casesCount",
     CAST(COUNT(CASE WHEN "Contacts"."profileId" IS NOT NULL THEN 1 END) AS INTEGER) AS "contactsCount"
   FROM "Identifiers" ids
   LEFT JOIN "ProfilesToIdentifiers" p2i ON ids.id = p2i."identifierId"


### PR DESCRIPTION
## Description
- This PR fixes a bug in the sql query for `identifierByIdentifer` which was returning only partial count. 

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
- Check front end, particular compare the case count between the yellow banner and the cases count in the tab when viewing records

