### PR TITLE
[Fix] List Modica as a chat channel on the backend

### DIFF
--- a/hrm-domain/hrm-core/contact/channelTypes.ts
+++ b/hrm-domain/hrm-core/contact/channelTypes.ts
@@ -25,6 +25,7 @@ export const channelTypes = {
   twitter: 'twitter',
   instagram: 'instagram',
   line: 'line',
+  modica: 'modica',
   default: 'default',
 } as const;
 
@@ -36,6 +37,7 @@ export const chatChannels = [
   channelTypes.twitter,
   channelTypes.instagram,
   channelTypes.line,
+  channelTypes.modica,
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Description
This is needed in order to have Modica pending transcripts in S3.
The code expects all chat channels to be listed at `chatChannel` const.

P.S.: I'm not sure what scenario results in a pending transcript. When I test Flex, I can see the Transcripts just fine.

For reference, see the code blocks below:

```
export const isChatChannel = (channel: string) => chatChannels.includes(channel as any);
```

```
const findS3StoredTranscriptPending = (
  contact: Contact,
  conversationMedia: ConversationMedia[],
) => {
  if (enableCreateContactJobsFlag && isChatChannel(contact.channel)) {
    return conversationMedia.find(isS3StoredTranscriptPending);
  }

  return null;
};
```

```
    // if pertinent, create retrieve-transcript job
    const pendingTranscript = findS3StoredTranscriptPending(
      contact,
      createdConversationMedia,
    );
    if (pendingTranscript) {
      await createContactJob(conn)({
        jobType: ContactJobType.RETRIEVE_CONTACT_TRANSCRIPT,
        resource: contact,
        additionalPayload: { conversationMediaId: pendingTranscript.id },
      });
    }
```
