### PR TITLE
feat: Add endpoint to manually create client profiles [CHI-2565]

### DIFF
--- a/hrm-domain/hrm-core/profile/adminProfileRoutesV0.ts
+++ b/hrm-domain/hrm-core/profile/adminProfileRoutesV0.ts
@@ -21,6 +21,34 @@ import createError from 'http-errors';
 
 const adminProfilesRouter = SafeRouter();
 
+adminProfilesRouter.post('/identifiers', publicEndpoint, async (req, res, next) => {
+  try {
+    const { accountSid } = req;
+    const { identifier, name } = req.body;
+
+    const result = await profileController.createProfileWithIdentifier()(
+      identifier,
+      accountSid,
+      name,
+    );
+
+    if (isErr(result)) {
+      return next(
+        mapHTTPError(result, {
+          InvalidParameterError: 400,
+          IdentifierExistsError: 409,
+          InternalServerError: 500,
+        }),
+      );
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    console.error(err);
+    return next(createError(500, err.message));
+  }
+});
+
 adminProfilesRouter.get('/flags', publicEndpoint, async (req, res, next) => {
   try {
     const { accountSid } = req;

--- a/hrm-domain/hrm-core/profile/profileDataAccess.ts
+++ b/hrm-domain/hrm-core/profile/profileDataAccess.ts
@@ -203,13 +203,13 @@ export const createIdentifierAndProfile =
   (task?) =>
   async (
     accountSid: string,
-    payload: NewIdentifierRecord,
+    payload: { identifier: NewIdentifierRecord; profile: NewProfileRecord },
   ): Promise<TResult<'InternalServerError', IdentifierWithProfiles>> => {
     try {
       return await txIfNotInOne(task, async t => {
         const [newIdentifier, newProfile] = await Promise.all([
-          createIdentifier(t)(accountSid, payload),
-          createProfile(t)(accountSid, { name: null }),
+          createIdentifier(t)(accountSid, payload.identifier),
+          createProfile(t)(accountSid, { name: payload.profile?.name || null }),
         ]);
 
         return associateProfileToIdentifier(t)(

--- a/hrm-domain/hrm-service/scripts/README.md
+++ b/hrm-domain/hrm-service/scripts/README.md
@@ -15,6 +15,8 @@ This is composition of different scripts that will allow to perform actions agai
 ```bash
 admin-cli
 ├── profiles
+| ├── identifiers
+|   ├── create:       # Create a new identifier and associate a profile to it
 | ├── flags
 |   ├── list:         # List the profile flags for the given account
 |   ├── create:       # Create a new profile flag

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/identifiers.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/identifiers.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const command = 'identifiers <command>';
+export const desc = 'admin endpoints for profile identifiers';
+export const builder = function (yargs) {
+  return yargs.commandDir('identifiers', {
+    exclude: /^(index|_)/, // Exclude files starting with 'index' or '_'
+    extensions: ['ts'],
+  });
+  // .commandDir('common_cmds'); add more
+};
+// export const handler = function (argv) {};

--- a/hrm-domain/hrm-service/scripts/admin-commands/profiles/identifiers/create.ts
+++ b/hrm-domain/hrm-service/scripts/admin-commands/profiles/identifiers/create.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { getHRMInternalEndpointAccess } from '@tech-matters/service-discovery';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { fetch } from 'undici';
+import { getAdminV0URL, staticKeyPattern } from '../../../hrmInternalConfig';
+
+export const command = 'create';
+export const describe =
+  'Create an identifier (if not exists) and a new profile associated to it';
+export const builder = {
+  e: {
+    alias: 'environment',
+    describe: 'environment (e.g. development, staging, production)',
+    demandOption: true,
+    type: 'string',
+  },
+  r: {
+    alias: 'region',
+    describe: 'region (e.g. us-east-1)',
+    demandOption: true,
+    type: 'string',
+  },
+  a: {
+    alias: 'accountSid',
+    describe: 'account SID',
+    demandOption: true,
+    type: 'string',
+  },
+  i: {
+    alias: 'identifier',
+    describe: 'the identifier',
+    demandOption: true,
+    type: 'string',
+  },
+  n: {
+    alias: 'name',
+    describe: 'the name for the new profile',
+    demandOption: false,
+    type: 'string',
+  },
+};
+
+export const handler = async ({ region, environment, accountSid, identifier, name }) => {
+  try {
+    const timestamp = new Date().getTime();
+    const assumeRoleParams = {
+      RoleArn: 'arn:aws:iam::712893914485:role/admin-no-pii',
+      RoleSessionName: `hrm-admin-cli-${timestamp}`,
+    };
+
+    const { authKey, internalResourcesUrl } = await getHRMInternalEndpointAccess({
+      region,
+      environment,
+      staticKeyPattern,
+      assumeRoleParams,
+    });
+
+    const url = getAdminV0URL(internalResourcesUrl, accountSid, '/profiles/identifiers');
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${authKey}`,
+      },
+      body: JSON.stringify({ identifier, name }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to submit request: ${response.statusText}`);
+    }
+
+    const jsonResp = await response.json();
+    console.log(JSON.stringify(jsonResp, null, 2));
+  } catch (err) {
+    console.error(
+      `Failed to create identifier ${identifier} account ${accountSid} (${region} ${environment})`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+};

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -334,7 +334,8 @@ describe('/contacts route', () => {
       };
 
       const profileResult = await profilesDB.createIdentifierAndProfile()(accountSid, {
-        identifier: contact.number,
+        identifier: { identifier: contact.number },
+        profile: { name: null },
       });
 
       if (isErr(profileResult)) {

--- a/packages/service-discovery/getHRMInternalEndpointAccess.ts
+++ b/packages/service-discovery/getHRMInternalEndpointAccess.ts
@@ -165,6 +165,9 @@ export const getHRMInternalEndpointAccess = async ({
     credentials,
   });
 
+  const callerID = await sts.getCallerIdentity().promise();
+  console.log(callerID)
+
   return {
     internalResourcesUrl,
     authKey,

--- a/packages/service-discovery/getHRMInternalEndpointAccess.ts
+++ b/packages/service-discovery/getHRMInternalEndpointAccess.ts
@@ -165,9 +165,6 @@ export const getHRMInternalEndpointAccess = async ({
     credentials,
   });
 
-  const callerID = await sts.getCallerIdentity().promise();
-  console.log(callerID)
-
   return {
     internalResourcesUrl,
     authKey,


### PR DESCRIPTION
## Description
This PR 
- Creates a new admin endpoint, /profiles/identifiers/ which accepts a POST operation. This endpoint 
  - Expects an `identifier` to be provided in the request body, and optionally a `name`.
  - Creates a new new identifier record (if not exists) with `identifier` and associates it to a new profile. The profile will be named after `name` property, if provided.
- Expose the above endpoint via `admin-cli profiles identifiers create` command.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2565)
- [ ] New tests added

### Verification steps
- Confirm that this code is deloyed to Aselo Development.
- Connect to the VPN and SSH into the devops instance.
- `cd` and checkout the repo in this branch.
- run `npm run admin-cli profiles identifiers create -- -a=ACd8a2e89748318adf6ddff7df6948deaf -r=us-east-1 -e=development -i=<some identifier> -n=<some example name>` and confirm that the profile is properly creted.
- Retry above and confirm it fails this time, due to the identifier already existing in the DB.