### PR TITLE
feat: add updatedBy and createdBy columns to profiles tables [CHI-2603]

### DIFF
--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -128,12 +128,16 @@ const findS3StoredTranscriptPending = (
   return null;
 };
 
-const initProfile = async (conn, accountSid, contact) => {
+const initProfile = async (
+  conn,
+  accountSid: string,
+  contact: Pick<Contact, 'number'>,
+) => {
   if (!contact.number) return {};
 
   const profileResult = await getOrCreateProfileWithIdentifier(conn)(
-    contact.number,
     accountSid,
+    { identifier: contact.number },
     { user: { isSupervisor: false, roles: [], workerSid: systemUser } }, // fake the worker since makes more sense to keep the new "profile created by system"
   );
 

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -50,7 +50,7 @@ import {
 import { Profile, getOrCreateProfileWithIdentifier } from '../profile/profileService';
 import { deleteContactReferrals } from '../referral/referral-data-access';
 import { DatabaseUniqueConstraintViolationError, inferPostgresError } from '../sql';
-import { systemUser } from '@tech-matters/twilio-worker-auth/src/twilioWorkerAuthMiddleware';
+import { systemUser } from '@tech-matters/twilio-worker-auth';
 
 // Re export as is:
 export { Contact } from './contactDataAccess';

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -50,6 +50,7 @@ import {
 import { Profile, getOrCreateProfileWithIdentifier } from '../profile/profileService';
 import { deleteContactReferrals } from '../referral/referral-data-access';
 import { DatabaseUniqueConstraintViolationError, inferPostgresError } from '../sql';
+import { systemUser } from '@tech-matters/twilio-worker-auth/src/twilioWorkerAuthMiddleware';
 
 // Re export as is:
 export { Contact } from './contactDataAccess';
@@ -133,6 +134,7 @@ const initProfile = async (conn, accountSid, contact) => {
   const profileResult = await getOrCreateProfileWithIdentifier(conn)(
     contact.number,
     accountSid,
+    { user: { isSupervisor: false, roles: [], workerSid: systemUser } }, // fake the worker since makes more sense to keep the new "profile created by system"
   );
 
   if (isErr(profileResult)) {

--- a/hrm-domain/hrm-core/profile/profileService.ts
+++ b/hrm-domain/hrm-core/profile/profileService.ts
@@ -66,6 +66,7 @@ export const getOrCreateProfileWithIdentifier =
   async (
     identifier: string,
     accountSid: string,
+    { user }: { user: TwilioUser },
   ): Promise<TResult<'InternalServerError', profileDB.IdentifierWithProfiles>> => {
     try {
       if (!identifier) {
@@ -83,6 +84,7 @@ export const getOrCreateProfileWithIdentifier =
 
       return await profileDB.createIdentifierAndProfile(task)(accountSid, {
         identifier,
+        createdBy: user.workerSid,
       });
     } catch (err) {
       return newErr({

--- a/hrm-domain/hrm-core/profile/profileService.ts
+++ b/hrm-domain/hrm-core/profile/profileService.ts
@@ -189,6 +189,7 @@ export const getProfileFlagsByIdentifier = profileDB.getProfileFlagsByIdentifier
 export const createProfileFlag = async (
   accountSid: string,
   payload: NewProfileFlagRecord,
+  { user }: { user: TwilioUser },
 ): Promise<
   TResult<'InternalServerError' | 'InvalidParameterError', profileDB.ProfileFlag>
 > => {
@@ -211,7 +212,10 @@ export const createProfileFlag = async (
       });
     }
 
-    const pf = await profileDB.createProfileFlag(accountSid, { name });
+    const pf = await profileDB.createProfileFlag(accountSid, {
+      name,
+      createdBy: user.workerSid,
+    });
 
     return pf;
   } catch (err) {
@@ -228,6 +232,7 @@ export const updateProfileFlagById = async (
   payload: {
     name: string;
   },
+  { user }: { user: TwilioUser },
 ): Promise<
   TResult<'InternalServerError' | 'InvalidParameterError', profileDB.ProfileFlag>
 > => {
@@ -252,6 +257,7 @@ export const updateProfileFlagById = async (
     const profileFlag = await profileDB.updateProfileFlagById(accountSid, {
       id: flagId,
       name,
+      updatedBy: user.workerSid,
     });
 
     return profileFlag;

--- a/hrm-domain/hrm-core/profile/profileService.ts
+++ b/hrm-domain/hrm-core/profile/profileService.ts
@@ -62,7 +62,7 @@ export const getProfile =
     }
   };
 
-const createIdentifierAndProfile =
+export const createIdentifierAndProfile =
   (task?) =>
   async (
     accountSid: string,
@@ -82,7 +82,7 @@ const createIdentifierAndProfile =
           }),
         ]);
 
-        return Promise.all([
+        const [idWithProfiles] = await Promise.all([
           profileDB.associateProfileToIdentifier(t)(
             accountSid,
             newProfile.id,
@@ -93,7 +93,9 @@ const createIdentifierAndProfile =
             id: newProfile.id,
             updatedBy: user.workerSid,
           }),
-        ]).then(([idWithProfiles]) => idWithProfiles);
+        ]);
+
+        return idWithProfiles;
       });
     } catch (err) {
       return newErr({
@@ -114,12 +116,10 @@ export const getOrCreateProfileWithIdentifier =
       if (!identifier) {
         return newOk({ data: null });
       }
-
       const profileResult = await profileDB.getIdentifierWithProfiles(task)({
         accountSid,
         identifier,
       });
-
       if (isErr(profileResult) || profileResult.data) {
         return profileResult;
       }

--- a/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
@@ -16,7 +16,7 @@
 
 import { pgp } from '../../connection-pool';
 
-type NewRecordCommons = {
+export type NewRecordCommons = {
   accountSid: string;
   createdAt: Date;
   updatedAt: Date;

--- a/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
@@ -16,16 +16,22 @@
 
 import { pgp } from '../../connection-pool';
 
+type NewRecordCommons = {
+  accountSid: string;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: string;
+  updatedBy: string;
+};
+
 export type NewProfileRecord = {
   name: string | null;
 };
 
-export const insertProfileSql = (
-  profile: NewProfileRecord & { accountSid: string; createdAt: Date; updatedAt: Date },
-) => `
+export const insertProfileSql = (profile: NewProfileRecord & NewRecordCommons) => `
   ${pgp.helpers.insert(
     profile,
-    ['accountSid', 'name', 'createdAt', 'updatedAt'],
+    ['accountSid', 'name', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy'],
     'Profiles',
   )}
   RETURNING *
@@ -36,15 +42,11 @@ export type NewIdentifierRecord = {
 };
 
 export const insertIdentifierSql = (
-  identifier: NewIdentifierRecord & {
-    accountSid: string;
-    createdAt: Date;
-    updatedAt: Date;
-  },
+  identifier: NewIdentifierRecord & NewRecordCommons,
 ) => `
 ${pgp.helpers.insert(
   identifier,
-  ['accountSid', 'identifier', 'createdAt', 'updatedAt'],
+  ['accountSid', 'identifier', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy'],
   'Identifiers',
 )}
 RETURNING *

--- a/hrm-domain/hrm-core/profile/sql/profile-update.sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-update.sql.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { pgp } from '../../connection-pool';
+import type { NewProfileRecord, NewRecordCommons } from './profile-insert-sql';
+
+const VALID_PROFILE_UPDATE_FIELDS = ['name', 'updatedAt', 'updatedBy'];
+
+const updateColumnSet = new pgp.helpers.ColumnSet(
+  VALID_PROFILE_UPDATE_FIELDS.map(f => ({
+    name: f,
+    skip: val => !val.exists,
+  })),
+  { table: 'Profiles' },
+);
+
+export const updateProfileByIdSql = (
+  profile: Partial<NewProfileRecord> & Pick<NewRecordCommons, 'updatedAt' | 'updatedBy'>,
+) => {
+  const profileWithTimestamp = {
+    ...profile,
+    updatedAt: profile.updatedAt.toISOString(),
+  };
+
+  return `
+    ${pgp.helpers.update(profileWithTimestamp, updateColumnSet)}
+    WHERE "accountSid" = $<accountSid> AND "id" = $<profileId>
+    RETURNING *
+  `;
+};

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -28,6 +28,7 @@ import { omit } from 'lodash';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 import { newOk } from '@tech-matters/types';
 import * as profilesDB from '../../profile/profileDataAccess';
+import * as profilesService from '../../profile/profileService';
 import { NewContactRecord } from '../../contact/sql/contactInsertSql';
 import { ALWAYS_CAN } from '../mocks';
 import '@tech-matters/testing/expectToParseAsDate';
@@ -45,6 +46,7 @@ const getIdentifierWithProfilesSpy = jest
           accountSid: 'accountSid',
           createdAt: new Date(),
           updatedAt: new Date(),
+          createdBy: 'createdBy',
           profiles: [
             {
               id: 1,
@@ -54,6 +56,7 @@ const getIdentifierWithProfilesSpy = jest
               name: 'name',
               contactsCount: 0,
               casesCount: 0,
+              createdBy: 'createdBy',
             },
           ],
         },
@@ -147,7 +150,7 @@ describe('createContact', () => {
       () => async () => newOk({ data: null }),
     );
 
-    jest.spyOn(profilesDB, 'createIdentifierAndProfile').mockImplementationOnce(
+    jest.spyOn(profilesService, 'createIdentifierAndProfile').mockImplementationOnce(
       () => async () =>
         newOk({
           data: { id: 2, profiles: [{ id: 2 }] },

--- a/hrm-domain/hrm-service/migrations/20240220203743-alter-profiles-createdBy.js
+++ b/hrm-domain/hrm-service/migrations/20240220203743-alter-profiles-createdBy.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+'use strict';
+
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS public."Profiles"
+      ADD COLUMN "createdBy" text COLLATE pg_catalog."default",
+      ADD COLUMN "updatedBy" text COLLATE pg_catalog."default";
+    `);
+    await queryInterface.sequelize.query(`
+      UPDATE "Profiles" SET "createdBy" = 'system';
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Profiles"
+      ALTER COLUMN "createdBy" SET NOT NULL;    
+    `);
+    console.log(
+      '"createdBy" & "updatedBy" columns added to table "Profiles", populated with default value "system"',
+    );
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS public."Identifiers"
+      ADD COLUMN "createdBy" text COLLATE pg_catalog."default",
+      ADD COLUMN "updatedBy" text COLLATE pg_catalog."default";
+    `);
+    await queryInterface.sequelize.query(`
+      UPDATE "Identifiers" SET "createdBy" = 'system';
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Identifiers"
+      ALTER COLUMN "createdBy" SET NOT NULL;    
+    `);
+    console.log(
+      '"createdBy" & "updatedBy" columns added to table "Identifiers", populated with default value "system"',
+    );
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE IF EXISTS public."ProfileFlags"
+      ADD COLUMN "createdBy" text COLLATE pg_catalog."default",
+      ADD COLUMN "updatedBy" text COLLATE pg_catalog."default";
+    `);
+    await queryInterface.sequelize.query(`
+      UPDATE "ProfileFlags" SET "createdBy" = 'system';
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."ProfileFlags"
+      ALTER COLUMN "createdBy" SET NOT NULL;    
+    `);
+    console.log(
+      '"createdBy" & "updatedBy" columns added to table "ProfileFlags", populated with default value "system"',
+    );
+  },
+
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."ProfileFlags"
+      DROP COLUMN "createdBy",
+      DROP COLUMN "updatedBy";
+    `);
+    console.log('"createdBy" & "updatedBy" columns dropped from table "ProfileFlags"');
+
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Identifiers"
+      DROP COLUMN "createdBy",
+      DROP COLUMN "updatedBy";
+    `);
+    console.log('"createdBy" & "updatedBy" columns dropped from table "Identifiers"');
+
+    await queryInterface.sequelize.query(`
+    ALTER TABLE public."Profiles"
+    DROP COLUMN "createdBy",
+    DROP COLUMN "updatedBy";
+  `);
+    console.log('"createdBy" & "updatedBy" columns dropped from table "Profiles"');
+  },
+};

--- a/hrm-domain/hrm-service/service-tests/contacts.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contacts.test.ts
@@ -46,6 +46,7 @@ import * as csamReportApi from '@tech-matters/hrm-core/csam-report/csam-report';
 import { getRequest, getServer, headers, setRules, useOpenRules } from './server';
 import { twilioUser } from '@tech-matters/twilio-worker-auth';
 import * as profilesDB from '@tech-matters/hrm-core/profile/profileDataAccess';
+import * as profilesService from '@tech-matters/hrm-core/profile/profileService';
 
 import { isErr } from '@tech-matters/types';
 import {
@@ -333,9 +334,13 @@ describe('/contacts route', () => {
         number: 'identifier1234',
       };
 
-      const profileResult = await profilesDB.createIdentifierAndProfile()(accountSid, {
-        identifier: contact.number,
-      });
+      const profileResult = await profilesService.createIdentifierAndProfile()(
+        accountSid,
+        {
+          identifier: contact.number,
+        },
+        { user: { isSupervisor: false, roles: [], workerSid } },
+      );
 
       if (isErr(profileResult)) {
         expect(false).toBeTruthy();
@@ -348,7 +353,7 @@ describe('/contacts route', () => {
       const profileId = profileResult.data.profiles[0].id;
 
       const createIdentifierAndProfileSpy = jest.spyOn(
-        profilesDB,
+        profilesService,
         'createIdentifierAndProfile',
       );
 
@@ -379,7 +384,7 @@ describe('/contacts route', () => {
       };
 
       const createIdentifierAndProfileSpy = jest.spyOn(
-        profilesDB,
+        profilesService,
         'createIdentifierAndProfile',
       );
 
@@ -414,7 +419,7 @@ describe('/contacts route', () => {
         'getIdentifierWithProfiles',
       );
       const createIdentifierAndProfileSpy = jest.spyOn(
-        profilesDB,
+        profilesService,
         'createIdentifierAndProfile',
       );
 

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -232,14 +232,14 @@ describe('/profiles', () => {
           accounts.map(acc =>
             getOrCreateProfileWithIdentifier()(
               acc,
-              { identifier },
+              { identifier: { identifier }, profile: { name: null } },
               { user: { isSupervisor: false, roles: [], workerSid } },
             ),
           ),
         )
       )
         .map(result => result.unwrap())
-        .reduce((accum, curr) => ({ ...accum, [curr.accountSid]: curr }), {});
+        .reduce((accum, curr) => ({ ...accum, [curr.identifier.accountSid]: curr }), {});
       // Create one case for each
       createdCases = (
         await Promise.all(accounts.map(acc => caseApi.createCase(case1, acc, workerSid)))
@@ -329,9 +329,9 @@ describe('/profiles', () => {
       // Create an identifier
       createdProfile = await getOrCreateProfileWithIdentifier()(
         accountSid,
-        { identifier },
+        { identifier: { identifier }, profile: { name: null } },
         { user: { isSupervisor: false, roles: [], workerSid } },
-      ).then(result => result.unwrap());
+      ).then(result => result.unwrap().identifier);
     });
 
     afterAll(async () => {

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -238,8 +238,8 @@ describe('/profiles', () => {
           ),
         )
       )
-        .map(result => result.unwrap())
-        .reduce((accum, curr) => ({ ...accum, [curr.identifier.accountSid]: curr }), {});
+        .map(result => result.unwrap().identifier)
+        .reduce((accum, curr) => ({ ...accum, [curr.accountSid]: curr }), {});
       // Create one case for each
       createdCases = (
         await Promise.all(accounts.map(acc => caseApi.createCase(case1, acc, workerSid)))

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -73,7 +73,9 @@ describe('/profiles', () => {
       existingProfiles = (await profilesDB.listProfiles(accountSid, {}, {})).unwrap()
         .profiles;
       createdProfiles = await Promise.all(
-        profilesNames.map(name => profilesDB.createProfile()(accountSid, { name })),
+        profilesNames.map(name =>
+          profilesDB.createProfile()(accountSid, { name, createdBy: workerSid }),
+        ),
       );
       defaultFlags = await profilesDB
         .getProfileFlagsForAccount(accountSid)
@@ -227,7 +229,13 @@ describe('/profiles', () => {
       // Create same identifier for two diferent accounts
       createdProfiles = (
         await Promise.all(
-          accounts.map(acc => getOrCreateProfileWithIdentifier()(identifier, acc)),
+          accounts.map(acc =>
+            getOrCreateProfileWithIdentifier()(
+              acc,
+              { identifier },
+              { user: { isSupervisor: false, roles: [], workerSid } },
+            ),
+          ),
         )
       )
         .map(result => result.unwrap())
@@ -320,8 +328,9 @@ describe('/profiles', () => {
     beforeAll(async () => {
       // Create an identifier
       createdProfile = await getOrCreateProfileWithIdentifier()(
-        identifier,
         accountSid,
+        { identifier },
+        { user: { isSupervisor: false, roles: [], workerSid } },
       ).then(result => result.unwrap());
     });
 
@@ -853,12 +862,14 @@ describe('/profiles', () => {
         const customFlag = (
           await profilesDB.createProfileFlag(accountSid, {
             name: 'custom',
+            createdBy: workerSid,
           })
         ).unwrap();
 
         const customFlagForAnother = (
           await profilesDB.createProfileFlag('ANOTHER_ACCOUNT', {
             name: 'custom 2',
+            createdBy: workerSid,
           })
         ).unwrap();
 

--- a/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
@@ -20,8 +20,6 @@ import { db } from '@tech-matters/hrm-core/connection-pool';
 import { accountSid, workerSid } from '../mocks';
 import * as profileDB from '@tech-matters/hrm-core/profile/profileDataAccess';
 import { systemUser } from '@tech-matters/twilio-worker-auth';
-import isBefore from 'date-fns/isBefore';
-import parseISO from 'date-fns/fp/parseISO';
 
 let createdProfile: profileDB.Profile;
 let createdProfileFlag: profileDB.ProfileFlag;

--- a/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/scheduled-tasks/profileFlagsCleanup.test.ts
@@ -17,7 +17,7 @@
 import { cleanupProfileFlags } from '@tech-matters/profile-flags-cleanup';
 import { addDays, subDays } from 'date-fns';
 import { db } from '@tech-matters/hrm-core/connection-pool';
-import { accountSid } from '../mocks';
+import { accountSid, workerSid } from '../mocks';
 import * as profileDB from '@tech-matters/hrm-core/profile/profileDataAccess';
 
 let createdProfile: profileDB.Profile;
@@ -27,10 +27,12 @@ beforeAll(async () => {
   [createdProfile, createdProfileFlag] = await Promise.all([
     profileDB.createProfile()(accountSid, {
       name: 'TEST_PROFILE',
+      createdBy: workerSid,
     }),
     (
       await profileDB.createProfileFlag(accountSid, {
         name: 'TEST_PROFILE_FLAG',
+        createdBy: workerSid,
       })
     ).unwrap(),
   ]);

--- a/hrm-domain/scheduled-tasks/profile-flags-cleanup/package.json
+++ b/hrm-domain/scheduled-tasks/profile-flags-cleanup/package.json
@@ -13,6 +13,7 @@
     "@tech-matters/ssm-cache": "^1.0.0",
     "@tech-matters/twilio-client": "^1.0.0",
     "@tech-matters/types": "^1.0.0",
+    "@tech-matters/twilio-worker-auth": "^1.0.0",
     "date-fns": "^2.28.0"
   }
 }

--- a/packages/twilio-worker-auth/src/index.ts
+++ b/packages/twilio-worker-auth/src/index.ts
@@ -18,6 +18,7 @@ export {
   getAuthorizationMiddleware,
   adminAuthorizationMiddleware,
   staticKeyAuthorizationMiddleware,
+  systemUser,
 } from './twilioWorkerAuthMiddleware';
 export { addAccountSidMiddleware } from './addAccountSidMiddleware';
 export { twilioUser, TwilioUser } from './twilioUser';

--- a/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
+++ b/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
@@ -148,9 +148,9 @@ export const staticKeyAuthorizationMiddleware = async (
 };
 
 // TODO: do we want to diferentiate what is actually system vs admin?
-export const adminUser = 'system';
+export const systemUser = 'system';
 export const adminAuthorizationMiddleware =
   (keySuffix: string) => async (req: Request, res: Response, next: NextFunction) => {
-    if (authenticateWithStaticKey(req, keySuffix, adminUser)) return next();
+    if (authenticateWithStaticKey(req, keySuffix, systemUser)) return next();
     return unauthorized(res);
   };

--- a/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
+++ b/packages/twilio-worker-auth/src/twilioWorkerAuthMiddleware.ts
@@ -59,16 +59,17 @@ const defaultTokenLookup = (accountSid: string) =>
 
 const authenticateWithStaticKey = (
   req: Request,
-  loginId: string | undefined,
+  keySuffix: string,
+  userId: string | undefined,
 ): boolean => {
   if (!req.headers) return false;
   const {
     headers: { authorization },
   } = req;
 
-  if (loginId && authorization && authorization.startsWith('Basic')) {
+  if (keySuffix && authorization && authorization.startsWith('Basic')) {
     try {
-      const staticSecretKey = `STATIC_KEY_${loginId}`;
+      const staticSecretKey = `STATIC_KEY_${keySuffix}`;
       const staticSecret = process.env[staticSecretKey];
       const requestSecret = authorization.replace('Basic ', '');
 
@@ -78,7 +79,7 @@ const authenticateWithStaticKey = (
         crypto.timingSafeEqual(Buffer.from(requestSecret), Buffer.from(staticSecret));
 
       if (isStaticSecretValid) {
-        req.user = twilioUser(`account-${loginId}`, []);
+        req.user = twilioUser(`${userId}`, []);
         return true;
       }
     } catch (err) {
@@ -123,7 +124,7 @@ export const getAuthorizationMiddleware =
 
     if (
       canAccessResourceWithStaticKey(req.originalUrl, req.method) &&
-      authenticateWithStaticKey(req, accountSid)
+      authenticateWithStaticKey(req, accountSid, `account-${accountSid}`)
     )
       return next();
 
@@ -135,12 +136,21 @@ export const staticKeyAuthorizationMiddleware = async (
   res: Response,
   next: NextFunction,
 ) => {
-  if (authenticateWithStaticKey(req, req.accountSid)) return next();
+  if (!req.accountSid) {
+    throw new Error(
+      'staticKeyAuthorizationMiddleware invoked with invalid request, req.accountSid missing',
+    );
+  }
+
+  if (authenticateWithStaticKey(req, req.accountSid, `account-${req.accountSid}`))
+    return next();
   return unauthorized(res);
 };
 
+// TODO: do we want to diferentiate what is actually system vs admin?
+export const adminUser = 'system';
 export const adminAuthorizationMiddleware =
-  (adminLoginId: string) => async (req: Request, res: Response, next: NextFunction) => {
-    if (authenticateWithStaticKey(req, adminLoginId)) return next();
+  (keySuffix: string) => async (req: Request, res: Response, next: NextFunction) => {
+    if (authenticateWithStaticKey(req, keySuffix, adminUser)) return next();
     return unauthorized(res);
   };

--- a/packages/types/Result.ts
+++ b/packages/types/Result.ts
@@ -56,7 +56,6 @@ export const newErr = <TError extends string>({
 type SuccessResult<TData> = ResultBase & {
   status: 'success';
   data: TData;
-  statusCode: number;
   readonly unwrap: () => TData;
 };
 
@@ -67,12 +66,10 @@ type NewSuccessResultParms<TData> = {
 
 export const newOk = <TData>({
   data,
-  statusCode = 200,
 }: NewSuccessResultParms<TData>): SuccessResult<TData> => ({
   _tag: 'Result',
   status: 'success',
   data,
-  statusCode,
   unwrap: () => data,
 });
 


### PR DESCRIPTION
## Description
This PR:
- Adds `createdBy` and `updatedBy` columns to the profiles related tables.
- Triggers an update on profiles table when a profile flag is associated or disassociated.
- Triggers an update on profiles table when a profile is associated to an identifier.

`Profiles`
- after creation
  ![Screenshot from 2024-02-22 12-23-24](https://github.com/techmatters/hrm/assets/15805319/8d3c1d30-0a45-41ef-ab7d-55b4544058df)
- after associating a flag
  ![Screenshot from 2024-02-22 12-24-33](https://github.com/techmatters/hrm/assets/15805319/c83a21ff-ef39-4c01-8746-443756bda68e)

`ProfileSections`
- after creation
  ![Screenshot from 2024-02-22 12-26-06](https://github.com/techmatters/hrm/assets/15805319/c4134ede-6a07-4722-b667-fed92f7c61fd)
- after editing
  ![Screenshot from 2024-02-22 12-26-25](https://github.com/techmatters/hrm/assets/15805319/bbbc2e42-a98f-4338-8719-90d91536d256)

Same goes for flags and identifiers, but since those two can only be created/updated by system or Aselo staff, I'm skipping the screenshots.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2603)
- [x] New tests added

### Verification steps
Trust service tests or
- Run local server (hrm and Flex).
- Create a new contact from a profile that does not exists in your DB.
  - [ ] Confirm that the profile and the identifier are created under `system` user.
- Associate a new flag to the profile
  - [ ] Confirm that the profile captures the `updatedBy` matching the user who associated.
- Disssociate a flag from the profile
  - [ ] Confirm that the profile captures the `updatedBy` matching the user who disassociated.
- Create a new profile section
  - [ ] Confirm that the section captures the `createdBy` matching the user.
- Edit a new profile section
  - [ ] Confirm that the section captures the `updatedBy` matching the user.