### PR TITLE
refactor: remove contacts and case counts from profiles services

### DIFF
--- a/hrm-domain/hrm-core/profile/profileDataAccess.ts
+++ b/hrm-domain/hrm-core/profile/profileDataAccess.ts
@@ -62,14 +62,7 @@ type RecordCommons = {
 
 export type Identifier = NewIdentifierRecord & RecordCommons;
 
-export type ProfileCounts = {
-  contactsCount: number;
-  casesCount: number;
-};
-
-export type ProfileWithCounts = Profile & ProfileCounts;
-
-export type IdentifierWithProfiles = Identifier & { profiles: ProfileWithCounts[] };
+export type IdentifierWithProfiles = Identifier & { profiles: Profile[] };
 
 type ProfileFlagAssociation = {
   id: ProfileFlag['id'];
@@ -77,7 +70,7 @@ type ProfileFlagAssociation = {
 };
 
 export type ProfileWithRelationships = Profile &
-  ProfileCounts & {
+  Profile & {
     identifiers: Identifier[];
     profileFlags: ProfileFlagAssociation[];
     profileSections: {

--- a/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
@@ -41,16 +41,6 @@ export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
     LEFT JOIN "Identifiers" identifiers ON identifiers.id = p2i."identifierId" AND identifiers."accountSid" = p2i."accountSid"
     GROUP BY p2i."profileId"
   ),
-  
-  ContactCaseCounts AS (
-    SELECT
-        "Contacts"."profileId",
-        COUNT(*) as "contactsCount",
-        COUNT(DISTINCT "Contacts"."caseId") as "casesCount"
-    FROM TargetProfiles profile
-	  LEFT JOIN "Contacts" ON "Contacts"."profileId" = profile.id AND "Contacts"."accountSid" = profile."accountSid"
-    GROUP BY "Contacts"."profileId"
-  ),
 
   RelatedProfileFlags AS (
     SELECT
@@ -74,14 +64,11 @@ export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
   SELECT
     tp.*,
     COALESCE(ri.identifiers, '[]'::jsonb) as identifiers,
-    COALESCE(ccc."contactsCount"::int, 0) as "contactsCount",
-    COALESCE(ccc."casesCount"::int, 0) as "casesCount",
     COALESCE(rpf."profileFlags", '[]'::jsonb) as "profileFlags",
     COALESCE(rps."profileSections", '[]'::jsonb) as "profileSections"
   FROM TargetProfiles tp
   LEFT JOIN "Profiles" profiles ON profiles.id = tp.id AND profiles."accountSid" = tp."accountSid" -- join on profiles so Postgres will use the indexes
   LEFT JOIN RelatedIdentifiers ri ON profiles.id = ri."profileId"
-  LEFT JOIN ContactCaseCounts ccc ON profiles.id = ccc."profileId"
   LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"
   LEFT JOIN RelatedProfileSections rps ON profiles.id = rps."profileId"
 `;
@@ -99,13 +86,10 @@ export const getIdentifierSql = `
 export const getProfilesByIdentifierSql = `
   SELECT
     profiles.id AS id,
-    profiles.name AS name,
-    CAST(COUNT(CASE WHEN "Contacts"."caseId" IS NOT NULL THEN "Contacts"."profileId" END) AS INTEGER) AS "casesCount",
-    CAST(COUNT(CASE WHEN "Contacts"."profileId" IS NOT NULL THEN 1 END) AS INTEGER) AS "contactsCount"
+    profiles.name AS name
   FROM "Identifiers" ids
   LEFT JOIN "ProfilesToIdentifiers" p2i ON ids.id = p2i."identifierId"
   LEFT JOIN "Profiles" profiles ON profiles.id = p2i."profileId"
-  LEFT JOIN "Contacts" ON "Contacts"."profileId" = profiles.id
   ${WHERE_IDENTIFIER_CLAUSE}
   GROUP BY profiles.id, profiles.name;
 `;


### PR DESCRIPTION
## Description
This PR removes the contacts and cases `COUNT`s from the profiles services (data access and SQL queries as well), in order to separate the concerns.
The motivation to do this is the Jira ticket linked below, where we continue to find discrepancies between the "counts" being shown in profiles/identifiers vs what is actually retrieved when the user tries to access the Contacts and Cases tabs from the UI.

The discrepancies are explained by the changes in Contacts and Cases permissions. Before this PR:
  - When we fetch Contacts and Cases lists, we do so using the "search"/"list" logic exposed via Contacs and Cases services respectively. This services account for very customizable (and for the last few months, fast changing) permissions filters which might "hide" records from the payload being sent back to the user.
  - When we fetch Profiles and Identifiers we do so via the Profiles services which are querying on the Contacts and Cases tables to add the COUNT to the payload. This queries on Contacts and Cases, since directly embedded in the SQL queries for Profiles, do not account for all the permissions filters introduced in Contacts and Cases, hence they might return a count that is greater than what the user can actually see.
This bug has been present since we introduced Profiles ([see this](https://github.com/techmatters/hrm/blame/4a03aac478d4d5824ea01ace60a5c6b6fa1bc03b/hrm-domain/hrm-core/profile/profileDataAccess.ts#L65)). In an attempt to save round-trips to the DB we re-used the same query, not having in mind that permissions will soon affect the way we count the results of "list views" (i.e. ignoring "list permissiosn").
 
To solve the above described issue, we could:
- Replicate the permissions based filters in the Profiles queries regarding Contacts and Cases. This is an awful idea since it will be very hard to maintain in sync.
- Remove the indirections to Contacts and Cases in the queries related to Profiles, and add the COUNTs at the Profile service by calling Contacts and Cases services respectively. This will always be in sync since.
- Change the way the UI works regarding this:
  1. Fetch the Identifiers/Profiles.
  2. Fetch the Contacts and Cases COUNTs based on the Profiles ids returned from above.
  This is also maintained always in sync, but imposes a more strict separation of concerns between the services of our different entities in the backend, which in turns means the service drives how we implement UI and not the other way around.

After a small talk with Steve we both agreed moving towards the 3rd option.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2624)
- [ ] New tests added

### Verification steps
See PR linked at the top.