### PR TITLE
feat: Add client data to existing AWS exports [CHI-2495]

### DIFF
--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -30,7 +30,7 @@ import {
 import { DELETE_BY_ID } from './sql/case-delete-sql';
 import { selectSingleCaseByIdSql } from './sql/caseGetSql';
 import { Contact } from '../contact/contactDataAccess';
-import { OrderByDirectionType } from '../sql';
+import { DateFilter, OrderByDirectionType } from '../sql';
 import { TKConditionsSets } from '../permissions/rulesMap';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { AccountSID } from '@tech-matters/types';
@@ -95,17 +95,6 @@ export type CaseSearchCriteria = {
   contactNumber?: string;
   firstName?: string;
   lastName?: string;
-};
-
-export const enum DateExistsCondition {
-  MUST_EXIST = 'MUST_EXIST',
-  MUST_NOT_EXIST = 'MUST_NOT_EXIST',
-}
-
-export type DateFilter = {
-  from?: string;
-  to?: string;
-  exists?: DateExistsCondition;
 };
 
 export type CategoryFilter = {

--- a/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
+++ b/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
@@ -15,8 +15,9 @@
  */
 
 import { pgp } from '../../connection-pool';
+import { DateExistsCondition, DateFilter } from '../../sql';
 import { SELECT_CASE_SECTIONS } from './case-sections-sql';
-import { CaseListFilters, DateExistsCondition, DateFilter } from '../caseDataAccess';
+import { CaseListFilters } from '../caseDataAccess';
 import { selectCoalesceCsamReportsByContactId } from '../../csam-report/sql/csam-report-get-sql';
 import { selectCoalesceReferralsByContactId } from '../../referral/sql/referral-get-sql';
 import { selectCoalesceConversationMediasByContactId } from '../../conversation-media/sql/conversation-media-get-sql';

--- a/hrm-domain/hrm-core/profile/profileDataAccess.ts
+++ b/hrm-domain/hrm-core/profile/profileDataAccess.ts
@@ -273,7 +273,7 @@ export const listProfiles = async (
         accountSid,
         limit,
         offset,
-        profileFlagIds: filters?.profileFlagIds,
+        ...filters,
       });
 
       const totalCount: number = result.length ? result[0].totalCount : 0;

--- a/hrm-domain/hrm-core/sql.ts
+++ b/hrm-domain/hrm-core/sql.ts
@@ -23,6 +23,17 @@ export const OrderByDirection = {
   descending: 'DESC',
 } as const;
 
+export const enum DateExistsCondition {
+  MUST_EXIST = 'MUST_EXIST',
+  MUST_NOT_EXIST = 'MUST_NOT_EXIST',
+}
+
+export type DateFilter = {
+  from?: string;
+  to?: string;
+  exists?: DateExistsCondition;
+};
+
 export type OrderByDirectionType =
   (typeof OrderByDirection)[keyof typeof OrderByDirection];
 

--- a/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
@@ -21,10 +21,9 @@ import each from 'jest-each';
 import * as caseApi from '@tech-matters/hrm-core/case/caseService';
 import { CaseService, getCase } from '@tech-matters/hrm-core/case/caseService';
 import * as caseDb from '@tech-matters/hrm-core/case/caseDataAccess';
-import {
-  CaseListFilters,
-  DateExistsCondition,
-} from '@tech-matters/hrm-core/case/caseDataAccess';
+import { CaseListFilters } from '@tech-matters/hrm-core/case/caseDataAccess';
+import { DateExistsCondition } from '@tech-matters/hrm-core/sql';
+
 import { db } from '@tech-matters/hrm-core/connection-pool';
 import {
   fillNameAndPhone,

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/index.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/index.ts
@@ -20,6 +20,7 @@ import isValid from 'date-fns/isValid';
 import { applyContextConfigOverrides } from './context';
 import { pullCases } from './pull-cases';
 import { pullContacts } from './pull-contacts';
+import { pullProfiles } from './pull-profiles';
 
 const isNullUndefinedOrEmptyString = (value: string | null | undefined) =>
   value === null || value === undefined || value === '';
@@ -63,5 +64,9 @@ export const pullData = async (
     ? getDateRangeForPast12Hours()
     : getDateRangeFromArgs(startDateISO, endDateISO);
   applyContextConfigOverrides({ shortCodeOverride: hlShortCode });
-  await Promise.all([pullCases(startDate, endDate), pullContacts(startDate, endDate)]);
+  await Promise.all([
+    pullCases(startDate, endDate),
+    pullContacts(startDate, endDate),
+    pullProfiles(startDate, endDate),
+  ]);
 };

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
@@ -187,9 +187,9 @@ export const pullProfiles = async (startDate: Date, endDate: Date) => {
     });
 
     await Promise.all(uploadPromises);
-    console.log(`>> ${shortCode} ${hrmEnv} Cases were pulled successfully!`);
+    console.log(`>> ${shortCode} ${hrmEnv} Profiles were pulled successfully!`);
   } catch (err) {
-    console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Cases`);
+    console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Profiles`);
     console.error(err);
     // TODO: Should throw an error?
   }

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import format from 'date-fns/format';
+import formatISO from 'date-fns/formatISO';
+// import { putS3Object } from '@tech-matters/s3-client';
+import * as profileApi from '@tech-matters/hrm-core/profile/profileService';
+import { getCasesByProfileId } from '@tech-matters/hrm-core/case/caseService';
+import {
+  Contact,
+  getContactsByProfileId,
+} from '@tech-matters/hrm-core/contact/contactService';
+import type {
+  ProfileFlag,
+  ProfileSection,
+  ProfileWithRelationships,
+} from '@tech-matters/hrm-core/profile/profileDataAccess';
+
+import { getContext, maxPermissions } from './context';
+import { autoPaginate } from './auto-paginate';
+import { parseISO } from 'date-fns';
+import { CaseRecord } from '@tech-matters/hrm-core/case/caseDataAccess';
+
+const getSearchParams = (startDate: Date, endDate: Date) => ({
+  filters: {
+    updatedAt: {
+      from: formatISO(startDate),
+      to: formatISO(endDate),
+    },
+  },
+});
+
+const getProfileSectionsForProfile = (p: ProfileWithRelationships) =>
+  p.profileSections.reduce<Promise<ProfileSection[]>>(
+    async (prevPromise, { id: sectionId }) => {
+      const accum = await prevPromise;
+      const section = (
+        await profileApi.getProfileSectionById(p.accountSid, {
+          profileId: p.id,
+          sectionId,
+        })
+      ).unwrap();
+
+      return [...accum, section];
+    },
+    Promise.resolve([]),
+  );
+
+export const pullCases = async (startDate: Date, endDate: Date) => {
+  const { accountSid, bucket, hrmEnv, shortCode } = await getContext();
+
+  try {
+    const { filters } = getSearchParams(startDate, endDate);
+
+    const populatedProfiles = await autoPaginate(async ({ limit, offset }) => {
+      const profileFlagsR = await profileApi.getProfileFlags(accountSid);
+      const profileFlags = profileFlagsR
+        .unwrap()
+        .reduce<{ [id: ProfileFlag['id']]: ProfileFlag }>(
+          (acc, curr) => ({
+            ...acc,
+            [curr.id]: curr,
+          }),
+          {},
+        );
+
+      const { count, profiles } = (
+        await profileApi.listProfiles(
+          accountSid,
+          { limit: limit.toString(), offset: offset.toString() },
+          { filters },
+          // {filters: {profileFlagIds}},
+        )
+      ).unwrap();
+
+      const profilesWithFlags = profiles.map(p => {
+        return {
+          ...p,
+          // destructuring on pf as it include validUntil
+          profileFlags: p.profileFlags.map(pf => ({ ...pf, ...profileFlags[pf.id] })),
+        };
+      });
+
+      const profilesWithSections = await profilesWithFlags.reduce<
+        Promise<
+          (Omit<ProfileWithRelationships, 'profileFlags' | 'profileSections'> & {
+            profileFlags: ProfileFlag[];
+            profileSections: ProfileSection[];
+          })[]
+        >
+      >(async (prevPromise, profile) => {
+        const acc = await prevPromise;
+        const profileSections = await getProfileSectionsForProfile(profile);
+        return [...acc, { ...profile, profileSections }];
+      }, Promise.resolve([]));
+
+      const profilesWithContacts = await profilesWithSections.reduce<
+        Promise<
+          (Omit<ProfileWithRelationships, 'profileFlags' | 'profileSections'> & {
+            profileFlags: ProfileFlag[];
+            profileSections: ProfileSection[];
+            contactIds: Contact['id'][];
+          })[]
+        >
+      >(async (prevPromise, profile) => {
+        const acc = await prevPromise;
+        const contactIds = await autoPaginate(async ({ limit: l, offset: o }) => {
+          const result = await getContactsByProfileId(
+            accountSid,
+            profile.id,
+            { limit: l.toString(), offset: o.toString() },
+            maxPermissions,
+          );
+
+          const { contacts, count: contactsCount } = result.unwrap();
+
+          return {
+            count: contactsCount,
+            records: contacts.map(c => c.id),
+          };
+        });
+
+        return [...acc, { ...profile, contactIds }];
+      }, Promise.resolve([]));
+
+      const profilesWithCases = await profilesWithContacts.reduce<
+        Promise<
+          (Omit<ProfileWithRelationships, 'profileFlags' | 'profileSections'> & {
+            profileFlags: ProfileFlag[];
+            profileSections: ProfileSection[];
+            contactIds: Contact['id'][];
+            caseIds: CaseRecord['id'][];
+          })[]
+        >
+      >(async (prevPromise, profile) => {
+        const acc = await prevPromise;
+        const caseIds = await autoPaginate(async ({ limit: l, offset: o }) => {
+          const result = await getCasesByProfileId(
+            accountSid,
+            profile.id,
+            { limit: l.toString(), offset: o.toString() },
+            maxPermissions,
+          );
+
+          const { cases, count: casesCount } = result.unwrap();
+
+          return {
+            count: casesCount,
+            records: cases.map(c => c.id),
+          };
+        });
+
+        return [...acc, { ...profile, caseIds }];
+      }, Promise.resolve([]));
+
+      return {
+        records: profilesWithCases,
+        count: count,
+      };
+    });
+
+    console.log(
+      '>>>>>>>>>>>>>>',
+      JSON.stringify(
+        populatedProfiles.filter(p => p.caseIds.length || p.contactIds.length),
+        null,
+        2,
+      ),
+    );
+
+    // const uploadPromises = populatedProfiles.map(profile => {
+    //   /*
+    //   Inner type is slightly wrong. The instance object actually has:
+    //   1) 'totalCount' property, which I think is wrong, so I'm deleting it
+    // */
+    //   delete (profile as any).totalCount;
+    //   const date = format(parseISO(profile.updatedAt.toISOString()), 'yyyy/MM/dd');
+    //   const key = `hrm-data/${date}/profiles/${profile.id}.json`;
+    //   const body = JSON.stringify(profile);
+    //   const params = { bucket, key, body };
+
+    //   return putS3Object(params);
+    // });
+
+    // await Promise.all(uploadPromises);
+    console.log(`>> ${shortCode} ${hrmEnv} Cases were pulled successfully!`);
+  } catch (err) {
+    console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Cases`);
+    console.error(err);
+    // TODO: Should throw an error?
+  }
+};
+
+pullCases(new Date('2024-03-07T20:13:56.854Z'), new Date());

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/index.test.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/index.test.ts
@@ -21,9 +21,11 @@ import parseISO from 'date-fns/parseISO';
 import { pullData } from '../../index';
 import * as pullContactsModule from '../../pull-contacts';
 import * as pullCasesModule from '../../pull-cases';
+import * as pullProfilesModule from '../../pull-profiles';
 
 jest.mock('../../pull-contacts');
 jest.mock('../../pull-cases');
+jest.mock('../../pull-profiles');
 
 const getParamsFromSpy = (spy: jest.SpyInstance) => ({
   startDate: spy.mock.calls[0][0],
@@ -53,6 +55,7 @@ describe('KHP Data Pull - Params', () => {
   test('When no params, it should default to the last 12h', async () => {
     const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
     const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+    const pullProfilesSpy = jest.spyOn(pullProfilesModule, 'pullProfiles');
 
     const expectedEndDate = new Date();
     const expectedStartDate = subHours(expectedEndDate, 12);
@@ -65,6 +68,7 @@ describe('KHP Data Pull - Params', () => {
 
     assertSpyHasBeenCalledWithRouhly(pullContactsSpy, expectedStartDate, expectedEndDate);
     assertSpyHasBeenCalledWithRouhly(pullCasesSpy, expectedStartDate, expectedEndDate);
+    assertSpyHasBeenCalledWithRouhly(pullProfilesSpy, expectedStartDate, expectedEndDate);
   });
 
   test('Valid start-date and end-date', async () => {
@@ -73,6 +77,7 @@ describe('KHP Data Pull - Params', () => {
 
     const startDateISO = '2023-05-01T10:00:00+0000';
     const endDateISO = '2023-05-30T18:00:00+0000';
+    const pullProfilesSpy = jest.spyOn(pullProfilesModule, 'pullProfiles');
 
     await pullData(startDateISO, endDateISO, undefined);
 
@@ -84,11 +89,16 @@ describe('KHP Data Pull - Params', () => {
       parseISO(startDateISO),
       parseISO(endDateISO),
     );
+    expect(pullProfilesSpy).toHaveBeenCalledWith(
+      parseISO(startDateISO),
+      parseISO(endDateISO),
+    );
   });
 
   test('No end-date should default to now', async () => {
     const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
     const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+    const pullProfilesSpy = jest.spyOn(pullProfilesModule, 'pullProfiles');
 
     const startDateISO = '2023-05-01T10:00:00+0000';
     const now = new Date();
@@ -97,11 +107,13 @@ describe('KHP Data Pull - Params', () => {
 
     assertSpyHasBeenCalledWithRouhly(pullContactsSpy, parseISO(startDateISO), now);
     assertSpyHasBeenCalledWithRouhly(pullCasesSpy, parseISO(startDateISO), now);
+    assertSpyHasBeenCalledWithRouhly(pullProfilesSpy, parseISO(startDateISO), now);
   });
 
   test('Ivalid date should throw', async () => {
     const pullContactsSpy = jest.spyOn(pullContactsModule, 'pullContacts');
     const pullCasesSpy = jest.spyOn(pullCasesModule, 'pullCases');
+    const pullProfilesSpy = jest.spyOn(pullProfilesModule, 'pullProfiles');
 
     const startDateISO = '9999INVALID';
 
@@ -109,5 +121,6 @@ describe('KHP Data Pull - Params', () => {
 
     expect(pullContactsSpy).not.toHaveBeenCalled();
     expect(pullCasesSpy).not.toHaveBeenCalled();
+    expect(pullProfilesSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
This PR is the result of a pairing session with @mmythily.

This PR adds a script to export profiles in our scheduled data exports.
- Adds filters based on `createdAt` and `updatedAt` columns of the `Profiles` table to list profiles services.
- Adds a script that pulls the profiles from the DB and uploads to `hrm-data/${date}/profiles/${profile.id}.json` in the corresponding docs bucket.
  This script is reusing all the existing profiles services to avoid creating a gigantic SQL query, as I (Gian) think this is easier to maintain in sync with potential future changes - gigantic 1-use-case-queries have a history of falling out of sync. [A draft PR using the single query approach has been started by Mythily here](https://github.com/techmatters/hrm/pull/588), in case we think this approach is wrong.
  The script to pull the profiles use a lot of synchronous sub-queries to avoid capturing all the connections of the DB connections pool.

@stephenhand I've opened this PR against the `-rc` branch, thinking that this was required as part of the next deployment. If it's not, and we need to merge this against master, https://github.com/techmatters/hrm/pull/586 will cause a few merge conflicts >.<

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2495)
- [ ] New tests added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
