### PR TITLE
CHI-2559: Return full first contacts with cases

### DIFF
--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -301,18 +301,6 @@ const mapEssentialData =
 
     const { summary, followUpDate, definitionVersion } = info;
 
-    const firstChildRawJson = connectedContacts[0]?.rawJson;
-    const { firstName, lastName } = firstChildRawJson?.childInformation ?? {};
-
-    const firstChildEssentialData = {
-      rawJson: {
-        childInformation: {
-          firstName,
-          lastName,
-        },
-      },
-    };
-
     const infoEssentialData = {
       summary,
       followUpDate,
@@ -322,7 +310,7 @@ const mapEssentialData =
     return {
       id,
       status,
-      connectedContacts: connectedContacts.length > 0 ? [firstChildEssentialData] : [],
+      connectedContacts: connectedContacts.slice(0, 1),
       twilioWorkerId,
       categories,
       createdAt,

--- a/hrm-domain/hrm-service/src/defaultConfiguration.ts
+++ b/hrm-domain/hrm-service/src/defaultConfiguration.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 switch (process.env.NODE_ENV) {
   case 'development': {
     if (!process.env.INCLUDE_ERROR_IN_RESPONSE) {

--- a/hrm-domain/hrm-service/src/defaultConfiguration.ts
+++ b/hrm-domain/hrm-service/src/defaultConfiguration.ts
@@ -1,0 +1,8 @@
+switch (process.env.NODE_ENV) {
+  case 'development': {
+    if (!process.env.INCLUDE_ERROR_IN_RESPONSE) {
+      console.log('INCLUDE_ERROR_IN_RESPONSE not set, setting to true');
+      process.env.INCLUDE_ERROR_IN_RESPONSE = 'true';
+    }
+  }
+}

--- a/hrm-domain/hrm-service/src/www.ts
+++ b/hrm-domain/hrm-service/src/www.ts
@@ -16,7 +16,7 @@
  */
 
 import express from 'express';
-
+import './defaultConfiguration';
 /**
  * Module dependencies.
  */
@@ -40,7 +40,7 @@ const debug = debugFactory('hrm:server');
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+  const port = parseInt(val, 10);
 
   if (isNaN(port)) {
     // named pipe
@@ -62,7 +62,7 @@ const appWithResourcesService = configureResourcesService({
 });
 const app = configureDefaultPostMiddlewares(
   appWithResourcesService,
-  Boolean(process.env.INCLUDE_ERROR_IN_RESPONSE),
+  process.env.INCLUDE_ERROR_IN_RESPONSE?.toString()?.toLowerCase() === 'true',
 );
 
 const internalAppWithoutServices = configureDefaultPreMiddlewares(express());
@@ -74,7 +74,7 @@ const internalAppWithResourcesService = configureInternalResourcesService({
 });
 const internalApp = configureDefaultPostMiddlewares(
   internalAppWithResourcesService,
-  Boolean(process.env.INCLUDE_ERROR_IN_RESPONSE),
+  process.env.INCLUDE_ERROR_IN_RESPONSE?.toString()?.toLowerCase() === 'true',
 );
 /**
  * Create HTTP server.
@@ -104,7 +104,7 @@ function onError(error) {
     throw error;
   }
 
-  var bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
+  const bind = typeof port === 'string' ? 'Pipe ' + port : 'Port ' + port;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
@@ -126,8 +126,8 @@ function onError(error) {
  */
 
 const onListening = listenServer => () => {
-  var addr = listenServer.address();
-  var bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
+  const addr = listenServer.address();
+  const bind = typeof addr === 'string' ? 'pipe ' + addr : 'port ' + addr.port;
   debug('Listening on ' + bind);
   console.log('Log listening on ' + bind);
 };

--- a/packages/http/webServerConfiguration.ts
+++ b/packages/http/webServerConfiguration.ts
@@ -32,7 +32,7 @@ export const configureDefaultPostMiddlewares = (
   includeErrorInResponse: boolean,
 ) => {
   webServer.use((req, res, next) => {
-    next(createError(404));
+    next(createError(404, `No handler configured for url: ${req.url}`));
   });
   const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     console.log(err);


### PR DESCRIPTION
## Description

There were too many gotchas in Flex to make it worth cutting down the contact, it would just be too much of a PITA for the benefit, so now the full first contact record (i.e. the stuff directly on the record, not the associated stuff) will be returned

Also, the SQL has been updated to only return a single contact with the case from the DB when only essential data is specified. This will cut down on unnecessary DB reads

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Automated tests continue to pass

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P