### PR TITLE
Fix profiles date string type to ensure data exports on profiles work

### DIFF
--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
@@ -75,7 +75,9 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
 
   try {
     await Promise.all(uploadPromises);
-    console.log(`>> ${shortCode} ${hrmEnv} Cases were pulled successfully!`);
+    console.log(
+      `>> ${shortCode} ${hrmEnv} ${casesWithContactIdOnly.length} Cases were pulled successfully!`,
+    );
   } catch (err) {
     console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Cases`);
     console.error(err);

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-contacts.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-contacts.ts
@@ -61,7 +61,9 @@ export const pullContacts = async (startDate: Date, endDate: Date) => {
 
   try {
     await Promise.all(uploadPromises);
-    console.log(`>> ${shortCode} ${hrmEnv} Contacts were pulled successfully!`);
+    console.log(
+      `>> ${shortCode} ${hrmEnv} ${contacts.length} Contacts were pulled successfully!`,
+    );
   } catch (err) {
     console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Contacts`);
     console.error(err);

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
@@ -178,7 +178,10 @@ export const pullProfiles = async (startDate: Date, endDate: Date) => {
       1) 'totalCount' property, which I think is wrong, so I'm deleting it
     */
       delete (profile as any).totalCount;
-      const date = format(parseISO(profile.updatedAt.toISOString()), 'yyyy/MM/dd');
+      const date = format(
+        parseISO(profile.updatedAt.toString() ?? profile.createdAt.toString()),
+        'yyyy/MM/dd',
+      );
       const key = `hrm-data/${date}/profiles/${profile.id}.json`;
       const body = JSON.stringify(profile);
       const params = { bucket, key, body };
@@ -187,7 +190,9 @@ export const pullProfiles = async (startDate: Date, endDate: Date) => {
     });
 
     await Promise.all(uploadPromises);
-    console.log(`>> ${shortCode} ${hrmEnv} Profiles were pulled successfully!`);
+    console.log(
+      `>> ${shortCode} ${hrmEnv} ${populatedProfiles.length} Profiles were pulled successfully!`,
+    );
   } catch (err) {
     console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Profiles`);
     console.error(err);


### PR DESCRIPTION
## Description

- @nickhurlburt and I were able to debug and realized that the date string for `updatedAt` for a profile was not useful for matching (it was an ISO string), and hence returning 0 profiles even though just a line earlier outside of the try block the profiles were being returned. 
- I also added the count of entities to the success data pull runs for better readability in logs related to data pulls. 

(seemingly unrelated unit test is failing, hence this PR is still in draft)

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P