### PR TITLE
Enable “view profiles” for all helplines not using profiles

### DIFF
--- a/hrm-domain/hrm-core/permission-rules/br.json
+++ b/hrm-domain/hrm-core/permission-rules/br.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/ca.json
+++ b/hrm-domain/hrm-core/permission-rules/ca.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/cl.json
+++ b/hrm-domain/hrm-core/permission-rules/cl.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["everyone"]],
   "removeContactFromCase": [["everyone"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/co.json
+++ b/hrm-domain/hrm-core/permission-rules/co.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/e2e.json
+++ b/hrm-domain/hrm-core/permission-rules/e2e.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/et.json
+++ b/hrm-domain/hrm-core/permission-rules/et.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/hu.json
+++ b/hrm-domain/hrm-core/permission-rules/hu.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/in.json
+++ b/hrm-domain/hrm-core/permission-rules/in.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/jm.json
+++ b/hrm-domain/hrm-core/permission-rules/jm.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/mt.json
+++ b/hrm-domain/hrm-core/permission-rules/mt.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/mw.json
+++ b/hrm-domain/hrm-core/permission-rules/mw.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
  
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/ph.json
+++ b/hrm-domain/hrm-core/permission-rules/ph.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/pl.json
+++ b/hrm-domain/hrm-core/permission-rules/pl.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/ro.json
+++ b/hrm-domain/hrm-core/permission-rules/ro.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/sg.json
+++ b/hrm-domain/hrm-core/permission-rules/sg.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
   
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/th.json
+++ b/hrm-domain/hrm-core/permission-rules/th.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/uk.json
+++ b/hrm-domain/hrm-core/permission-rules/uk.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/za.json
+++ b/hrm-domain/hrm-core/permission-rules/za.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/zm.json
+++ b/hrm-domain/hrm-core/permission-rules/zm.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],

--- a/hrm-domain/hrm-core/permission-rules/zw.json
+++ b/hrm-domain/hrm-core/permission-rules/zw.json
@@ -25,7 +25,7 @@
   "addContactToCase": [["isSupervisor"], ["isOwner"]],
   "removeContactFromCase": [["isSupervisor"], ["isOwner"]],
 
-  "viewProfile": [],
+  "viewProfile": [["everyone"]],
   "flagProfile": [],
   "unflagProfile": [],
   "createProfileSection": [],


### PR DESCRIPTION
## Description
- Follow this slack thread for more context: https://tech-matters.slack.com/archives/C04TWSG2420/p1711055807359569?thread_ts=1711050800.071239&cid=C04TWSG2420
- In short, this is a fix that triggers the frontend to retry when hitting the `/profiles/{id}` endpoint because of a loader for helplines that do not have the profiles feature flag turned on. This is a safe hotfix to patch the recent release. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P