### PR TITLE
refactor: Remove case/contact "joined" ids from data pulls [CHI-2661]

### DIFF
--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
@@ -51,15 +51,7 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
     };
   });
 
-  const mapContactsToId = (contacts: Required<{ id: number }>[]) =>
-    contacts.map(contact => contact.id);
-
-  const casesWithContactIdOnly = cases.map(cas => ({
-    ...cas,
-    connectedContacts: mapContactsToId(cas?.connectedContacts ?? []),
-  }));
-
-  const uploadPromises = casesWithContactIdOnly.map(cas => {
+  const uploadPromises = cases.map(cas => {
     /*
       Case type is slightly wrong. The instance object actually has:
       1) 'totalCount' property, which I think is wrong, so I'm deleting it
@@ -76,7 +68,7 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
   try {
     await Promise.all(uploadPromises);
     console.log(
-      `>> ${shortCode} ${hrmEnv} ${casesWithContactIdOnly.length} Cases were pulled successfully!`,
+      `>> ${shortCode} ${hrmEnv} ${cases.length} Cases were pulled successfully!`,
     );
   } catch (err) {
     console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Cases`);

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-cases.ts
@@ -51,7 +51,15 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
     };
   });
 
-  const uploadPromises = cases.map(cas => {
+  const mapContactsToId = (contacts: Required<{ id: number }>[]) =>
+    contacts.map(contact => contact.id);
+
+  const casesWithContactIdOnly = cases.map(cas => ({
+    ...cas,
+    connectedContacts: mapContactsToId(cas?.connectedContacts ?? []),
+  }));
+
+  const uploadPromises = casesWithContactIdOnly.map(cas => {
     /*
       Case type is slightly wrong. The instance object actually has:
       1) 'totalCount' property, which I think is wrong, so I'm deleting it
@@ -67,9 +75,7 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
 
   try {
     await Promise.all(uploadPromises);
-    console.log(
-      `>> ${shortCode} ${hrmEnv} ${cases.length} Cases were pulled successfully!`,
-    );
+    console.log(`>> ${shortCode} ${hrmEnv} Cases were pulled successfully!`);
   } catch (err) {
     console.error(`>> Error in ${shortCode} ${hrmEnv} Data Pull: Cases`);
     console.error(err);

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
@@ -71,7 +71,6 @@ export const pullProfiles = async (startDate: Date, endDate: Date) => {
         accountSid,
         { limit: limit.toString(), offset: offset.toString() },
         { filters },
-        // {filters: {profileFlagIds}},
       );
 
       const profilesWithFlags = profiles.map(p => {

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pull-profiles.ts
@@ -18,21 +18,15 @@ import format from 'date-fns/format';
 import formatISO from 'date-fns/formatISO';
 import { putS3Object } from '@tech-matters/s3-client';
 import * as profileApi from '@tech-matters/hrm-core/profile/profileService';
-import { getCasesByProfileId } from '@tech-matters/hrm-core/case/caseService';
-import {
-  Contact,
-  getContactsByProfileId,
-} from '@tech-matters/hrm-core/contact/contactService';
 import type {
   ProfileFlag,
   ProfileSection,
   ProfileWithRelationships,
 } from '@tech-matters/hrm-core/profile/profileDataAccess';
 
-import { getContext, maxPermissions } from './context';
+import { getContext } from './context';
 import { autoPaginate } from './auto-paginate';
 import { parseISO } from 'date-fns';
-import { CaseRecord } from '@tech-matters/hrm-core/case/caseDataAccess';
 
 const getSearchParams = (startDate: Date, endDate: Date) => ({
   filters: {
@@ -107,67 +101,8 @@ export const pullProfiles = async (startDate: Date, endDate: Date) => {
         return [...acc, { ...profile, profileSections }];
       }, Promise.resolve([]));
 
-      const profilesWithContacts = await profilesWithSections.reduce<
-        Promise<
-          (Omit<ProfileWithRelationships, 'profileFlags' | 'profileSections'> & {
-            profileFlags: ProfileFlag[];
-            profileSections: ProfileSection[];
-            contactIds: Contact['id'][];
-          })[]
-        >
-      >(async (prevPromise, profile) => {
-        const acc = await prevPromise;
-        const contactIds = await autoPaginate(async ({ limit: l, offset: o }) => {
-          const result = await getContactsByProfileId(
-            accountSid,
-            profile.id,
-            { limit: l.toString(), offset: o.toString() },
-            maxPermissions,
-          );
-
-          const { contacts, count: contactsCount } = result.unwrap();
-
-          return {
-            count: contactsCount,
-            records: contacts.map(c => c.id),
-          };
-        });
-
-        return [...acc, { ...profile, contactIds }];
-      }, Promise.resolve([]));
-
-      const profilesWithCases = await profilesWithContacts.reduce<
-        Promise<
-          (Omit<ProfileWithRelationships, 'profileFlags' | 'profileSections'> & {
-            profileFlags: ProfileFlag[];
-            profileSections: ProfileSection[];
-            contactIds: Contact['id'][];
-            caseIds: CaseRecord['id'][];
-          })[]
-        >
-      >(async (prevPromise, profile) => {
-        const acc = await prevPromise;
-        const caseIds = await autoPaginate(async ({ limit: l, offset: o }) => {
-          const result = await getCasesByProfileId(
-            accountSid,
-            profile.id,
-            { limit: l.toString(), offset: o.toString() },
-            maxPermissions,
-          );
-
-          const { cases, count: casesCount } = result.unwrap();
-
-          return {
-            count: casesCount,
-            records: cases.map(c => c.id),
-          };
-        });
-
-        return [...acc, { ...profile, caseIds }];
-      }, Promise.resolve([]));
-
       return {
-        records: profilesWithCases,
+        records: profilesWithSections,
         count: count,
       };
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13855,9 +13855,9 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -25274,9 +25274,9 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }


### PR DESCRIPTION
REVIEW ONLY AFTER https://github.com/techmatters/hrm/pull/606 IS MERGED.

## Description
This PR removes the following relationships between entities in the data pulls:
- Profile <> Contacts: this can be instead queried using the contact records.
- Profile <> Cases: this can be instead queried using the contact records -> case records.
- ~Case <> Contacts: this can be instead queried using the contact records.~

The purpose of this cleanup is to remove relationships that may fall out of sync. The contact will always be the source of truth, and if any change takes place on a contact record, it will trigger a re-export, keeping the data updated.



### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2661)
- [ ] New tests added
- [ ] Feature flags / configuration added

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P