### PR TITLE
refactor: move "touch case" logic to service layer [CHI-2661]

### DIFF
--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -46,6 +46,8 @@ import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import { CaseSectionRecord } from './caseSection/types';
 import { pick } from 'lodash';
 
+export { touchCase } from './caseDataAccess';
+
 const CASE_OVERVIEW_PROPERTIES = ['summary', 'followUpDate', 'childIsAtRisk'] as const;
 type CaseOverviewProperties = (typeof CASE_OVERVIEW_PROPERTIES)[number];
 

--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -38,7 +38,7 @@ import { randomUUID } from 'crypto';
 import type { Contact } from '../contact/contactDataAccess';
 import { InitializedCan } from '../permissions/initializeCanForRules';
 import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
-import { bindApplyTransformations as bindApplyContactTransformations } from '../contact/contactService';
+import { bindApplyTransformations as bindApplyContactTransformations } from '../contact/bindApplyTransformations';
 import type { Profile } from '../profile/profileDataAccess';
 import type { PaginationQuery } from '../search';
 import { TResult, newErr, newOk } from '@tech-matters/types';

--- a/hrm-domain/hrm-core/contact/bindApplyTransformations.ts
+++ b/hrm-domain/hrm-core/contact/bindApplyTransformations.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { isS3StoredTranscript } from '../conversation-media/conversation-media';
+import { actionsMaps } from '../permissions';
+import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
+import type { InitializedCan } from '../permissions/initializeCanForRules';
+import type { Contact } from './contactDataAccess';
+
+const filterExternalTranscripts = (contact: Contact): Contact => {
+  const { conversationMedia, ...rest } = contact;
+  const filteredConversationMedia = (conversationMedia ?? []).filter(
+    m => !isS3StoredTranscript(m),
+  );
+
+  return {
+    ...rest,
+    conversationMedia: filteredConversationMedia,
+  };
+};
+
+type PermissionsBasedTransformation = {
+  action: (typeof actionsMaps)['contact'][keyof (typeof actionsMaps)['contact']];
+  transformation: (contact: Contact) => Contact;
+};
+
+const permissionsBasedTransformations: PermissionsBasedTransformation[] = [
+  {
+    action: actionsMaps.contact.VIEW_EXTERNAL_TRANSCRIPT,
+    transformation: filterExternalTranscripts,
+  },
+];
+
+export const bindApplyTransformations =
+  (can: InitializedCan, user: TwilioUser) =>
+  (contact: Contact): Contact =>
+    permissionsBasedTransformations.reduce(
+      (transformed, { action, transformation }) =>
+        !can(user, action, contact) ? transformation(transformed) : transformed,
+      contact,
+    );

--- a/hrm-domain/hrm-core/contact/contactDataAccess.ts
+++ b/hrm-domain/hrm-core/contact/contactDataAccess.ts
@@ -27,7 +27,6 @@ import { ContactRawJson, ReferralWithoutContactId } from './contactJson';
 import type { ITask } from 'pg-promise';
 import { txIfNotInOne } from '../sql';
 import { ConversationMedia } from '../conversation-media/conversation-media';
-import { TOUCH_CASE_SQL } from '../case/sql/caseUpdateSql';
 import { TKConditionsSets } from '../permissions/rulesMap';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 
@@ -230,15 +229,12 @@ export const connectToCase =
     updatedBy: string,
   ): Promise<Contact | undefined> => {
     return txIfNotInOne(task, async connection => {
-      const [[updatedContact]]: Contact[][] = await connection.multi<Contact>(
-        [UPDATE_CASEID_BY_ID, TOUCH_CASE_SQL].join(';\n'),
-        {
-          accountSid,
-          contactId,
-          caseId,
-          updatedBy,
-        },
-      );
+      const updatedContact: Contact = await connection.one<Contact>(UPDATE_CASEID_BY_ID, {
+        accountSid,
+        contactId,
+        caseId,
+        updatedBy,
+      });
       return updatedContact;
     });
   };


### PR DESCRIPTION
## Description
This PR just moves the logic of bumping a case `updatedBy` when connected to contact, from contact data access to contact service, exposing a case service for that matter. Also removes some circular dependency that arose because of this changes.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2661)
- [ ] New tests added
- [ ] Feature flags / configuration added

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P