### PR TITLE
fix: Fix "Standardize phone number identifiers" migration [CHI-2673]

### DIFF
--- a/hrm-domain/hrm-core/profile/profileService.ts
+++ b/hrm-domain/hrm-core/profile/profileService.ts
@@ -43,8 +43,6 @@ export {
   SearchParameters,
 } from './profileDataAccess';
 
-const sanitizeIdentifier = (i: string) => i.replace(' ', '');
-
 export const getProfile =
   (task?) =>
   async (
@@ -69,7 +67,7 @@ export const createIdentifierAndProfile =
     return txIfNotInOne(task, async t => {
       try {
         const newIdentifier = await profileDB.createIdentifier(t)(accountSid, {
-          identifier: sanitizeIdentifier(identifier.identifier),
+          identifier: identifier.identifier,
           createdBy: user.workerSid,
         });
         const newProfile = await profileDB.createProfile(t)(accountSid, {
@@ -116,7 +114,7 @@ export const getOrCreateProfileWithIdentifier =
 
     const profileResult = await profileDB.getIdentifierWithProfiles(task)({
       accountSid,
-      identifier: sanitizeIdentifier(identifier.identifier),
+      identifier: identifier.identifier,
     });
 
     if (profileResult) {
@@ -185,7 +183,7 @@ export const getIdentifierByIdentifier = async (
 ): Promise<profileDB.IdentifierWithProfiles> =>
   profileDB.getIdentifierWithProfiles()({
     accountSid,
-    identifier: sanitizeIdentifier(identifier),
+    identifier: identifier,
   });
 
 export const listProfiles = profileDB.listProfiles;

--- a/hrm-domain/hrm-service/migrations/20240329215610-sanitize-identifiers-remove-blank-spaces.js
+++ b/hrm-domain/hrm-service/migrations/20240329215610-sanitize-identifiers-remove-blank-spaces.js
@@ -19,17 +19,52 @@
 module.exports = {
   up: async queryInterface => {
     await queryInterface.sequelize.query(`
-    DO $$
-      DECLARE idx public."Identifiers";
-    BEGIN
-      -- For each identifier in Identifier with spaces
-      FOR idx IN (SELECT * FROM "Identifiers" WHERE "identifier" LIKE '% %') LOOP
-        -- Remove any blank spaces that the identifiers might have
-        UPDATE "Identifiers" SET "identifier" = replace(idx."identifier", ' ', '') WHERE id = idx.id;
-      END LOOP;
-    END$$
+      -- Fix the contacts for the conflicting records
+      UPDATE "Contacts" SET "profileId" = sanitized."targetProfile", "identifierId" = sanitized."targetId" 
+      FROM (
+        --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+        SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile" 
+          FROM "Identifiers" "main" 
+          INNER JOIN (
+            SELECT "accountSid", replace("identifier", ' ', '') AS "sanitized", MIN("id") AS "targetId" FROM "Identifiers" GROUP BY "accountSid", replace("identifier", ' ', '') HAVING COUNT(*) > 1
+          ) "grouped" ON replace("main"."identifier", ' ', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+          INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
+          ORDER BY replace("identifier", ' ', '')
+      ) AS sanitized WHERE "identifierId" = sanitized."conflictId" AND "identifierId" != sanitized."targetId"
     `);
-    console.log('Sequence "Profiles_id_seq" created');
+    console.log('Contacts fixed');
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Contacts" SET "profileId" = sanitized."targetProfile", "identifierId" = sanitized."targetId" 
+      FROM (
+        --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+        SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile" 
+          FROM "Identifiers" "main" 
+          INNER JOIN (
+            SELECT "accountSid", replace("identifier", ' ', '') AS "sanitized", MIN("id") AS "targetId" FROM "Identifiers" GROUP BY "accountSid", replace("identifier", ' ', '') HAVING COUNT(*) > 1
+          ) "grouped" ON replace("main"."identifier", ' ', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+          INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
+          ORDER BY replace("identifier", ' ', '')
+      ) AS sanitized WHERE "identifierId" = sanitized."conflictId" AND "identifierId" != sanitized."targetId"
+    `);
+    console.log('Conflicting profiles deleted');
+
+    await queryInterface.sequelize.query(`
+      DELETE FROM "Identifiers" WHERE "id" IN (
+        SELECT "idx"."id" AS "conflictIdentifierId"
+        FROM (
+          --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+          SELECT "main"."id" AS "conflictId", "grouped"."targetId"
+            FROM "Identifiers" "main" 
+            INNER JOIN (
+              SELECT "accountSid", replace("identifier", ' ', '') AS "sanitized", MIN("id") AS "targetId" FROM "Identifiers" GROUP BY "accountSid", replace("identifier", ' ', '') HAVING COUNT(*) > 1
+            ) "grouped" ON replace("main"."identifier", ' ', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+            ORDER BY replace("identifier", ' ', '')
+        ) AS "sanitized"
+        INNER JOIN "Identifiers" "idx" ON "idx"."id" = "sanitized"."conflictId" AND "idx"."id" != "sanitized"."targetId"
+      )
+    `);
+    console.log('Conflicting identifiers deleted');
   },
 
   down: async () => {},


### PR DESCRIPTION
## Description
This PR attempts to fix the (broken) migration merged in https://github.com/techmatters/hrm/pull/613.
The migration, initially, didn't contemplated "conflicts" on identifiers - that is, if `1234` and `12 34` are both identifiers stored in the DB, the migration fails to run.

This screenshots intend to show what are the effects of the whole migration
- Before migration, see the "conflicting identifiers"
  ![Screenshot from 2024-04-09 17-24-39](https://github.com/techmatters/hrm/assets/15805319/062a6d51-ce7a-4242-8d67-7564efd35afe)
- See which contacts are related to the above identifiers
  ![Screenshot from 2024-04-09 17-25-48](https://github.com/techmatters/hrm/assets/15805319/5c3d214c-1fa9-4d11-b7a0-378ae9c484c7)
- Run the queries, one by one (note how many records are updated/deleted on each step)
  ![Screenshot from 2024-04-09 17-27-34](https://github.com/techmatters/hrm/assets/15805319/b1d9943e-d520-473d-8b4e-179d307934fa)
  ![Screenshot from 2024-04-09 17-29-14](https://github.com/techmatters/hrm/assets/15805319/1f362c6b-eb87-4daa-bed1-9fefb30c3410)
  ![Screenshot from 2024-04-09 17-29-28](https://github.com/techmatters/hrm/assets/15805319/3d039c9d-61f4-46a4-87c8-4f5f5b18a145)
  ![Screenshot from 2024-04-09 17-30-19](https://github.com/techmatters/hrm/assets/15805319/c3d33a75-1c49-4ecd-a276-022ae5a349a6)

After all this queries, there are no identifiers with blank spaces in my local DB, neither any "conflicting identifiers".

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2673)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P