### PR TITLE
CHI-2620: Add 'HRM account ID' concept to API 

### DIFF
--- a/hrm-domain/hrm-core/case/canPerformCaseAction.ts
+++ b/hrm-domain/hrm-core/case/canPerformCaseAction.ts
@@ -34,9 +34,9 @@ export const canPerformCaseAction = (
 ) =>
   asyncHandler(async (req, res, next) => {
     if (!req.isAuthorized()) {
-      const { accountSid, user, can } = req;
+      const { hrmAccountId, user, can } = req;
       const id = getCaseIdFromRequest(req);
-      const caseObj = await getCase(id, accountSid, {
+      const caseObj = await getCase(id, hrmAccountId, {
         can,
         user,
         permissions: OPEN_VIEW_CONTACT_PERMISSIONS,

--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -30,14 +30,14 @@ import { getCaseTimeline } from './caseSection/caseSectionService';
 const casesRouter = SafeRouter();
 casesRouter.put('/:id/status', canUpdateCaseStatus, async (req, res) => {
   const {
-    accountSid,
+    hrmAccountId,
     user,
     body: { status },
     can,
     permissions,
   } = req;
   const { id } = req.params;
-  const updatedCase = await caseApi.updateCaseStatus(id, status, accountSid, {
+  const updatedCase = await caseApi.updateCaseStatus(id, status, hrmAccountId, {
     can,
     user,
     permissions,
@@ -50,7 +50,7 @@ casesRouter.put('/:id/status', canUpdateCaseStatus, async (req, res) => {
 
 casesRouter.put('/:id/overview', canEditCaseOverview, async (req, res) => {
   const {
-    accountSid,
+    hrmAccountId,
     user: { workerSid },
     body,
   } = req;
@@ -66,7 +66,7 @@ casesRouter.put('/:id/overview', canEditCaseOverview, async (req, res) => {
       `Invalid followUpDate provided: ${followUpDate} - must be a valid ISO 8601 date string`,
     );
   }
-  const updatedCase = await caseApi.updateCaseOverview(accountSid, id, body, workerSid);
+  const updatedCase = await caseApi.updateCaseOverview(hrmAccountId, id, body, workerSid);
   if (!updatedCase) {
     throw createError(404);
   }

--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -74,11 +74,11 @@ casesRouter.put('/:id/overview', canEditCaseOverview, async (req, res) => {
 });
 
 casesRouter.get('/:id/timeline', canViewCase, async (req, res) => {
-  const { accountSid, params, query } = req;
+  const { hrmAccountId, params, query } = req;
   const { id: caseId } = params;
   const { sectionTypes, includeContacts, limit, offset } = query;
   const timeline = await getCaseTimeline(
-    accountSid,
+    hrmAccountId,
     req,
     parseInt(caseId),
     (sectionTypes ?? 'note,referral').split(','),
@@ -91,9 +91,9 @@ casesRouter.get('/:id/timeline', canViewCase, async (req, res) => {
 casesRouter.expressRouter.use('/:caseId/sections', caseSectionRoutesV0);
 
 casesRouter.delete('/:id', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
   const { id } = req.params;
-  const deleted = await casesDb.deleteById(id, accountSid);
+  const deleted = await casesDb.deleteById(id, hrmAccountId);
   if (!deleted) {
     throw createError(404);
   }
@@ -112,7 +112,7 @@ casesRouter.delete('/:id', publicEndpoint, async (req, res) => {
  * @returns {CaseSearchReturn} - List of cases
  */
 casesRouter.get('/', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
   const {
     sortDirection,
     sortBy,
@@ -126,7 +126,7 @@ casesRouter.get('/', publicEndpoint, async (req, res) => {
   const onlyEssentialData = Boolean(onlyEssentialDataParam);
 
   const cases = await caseApi.searchCases(
-    accountSid,
+    hrmAccountId,
     { sortDirection, sortBy, limit, offset },
     searchCriteria,
     { filters: { includeOrphans: false }, closedCases, counselor, helpline },
@@ -137,20 +137,20 @@ casesRouter.get('/', publicEndpoint, async (req, res) => {
 });
 
 casesRouter.post('/', publicEndpoint, async (req, res) => {
-  const { accountSid, user } = req;
-  const createdCase = await caseApi.createCase(req.body, accountSid, user.workerSid);
+  const { hrmAccountId, user } = req;
+  const createdCase = await caseApi.createCase(req.body, hrmAccountId, user.workerSid);
 
   res.json(createdCase);
 });
 
 casesRouter.get('/:id', canViewCase, async (req, res) => {
-  const { accountSid, permissions, can, user } = req;
+  const { hrmAccountId, permissions, can, user } = req;
   const { id } = req.params;
   const onlyEssentialData = Boolean(req.query.onlyEssentialData);
 
   const caseFromDB = await caseApi.getCase(
     id,
-    accountSid,
+    hrmAccountId,
     {
       can,
       user,
@@ -167,7 +167,7 @@ casesRouter.get('/:id', canViewCase, async (req, res) => {
 });
 
 casesRouter.post('/search', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
   const {
     closedCases,
     counselor,
@@ -178,7 +178,7 @@ casesRouter.post('/search', publicEndpoint, async (req, res) => {
   } = req.body || {};
 
   const searchResults = await caseApi.searchCases(
-    accountSid,
+    hrmAccountId,
     req.query || {},
     searchCriteria,
     { closedCases, counselor, helpline, filters },

--- a/hrm-domain/hrm-core/case/caseSection/caseSectionRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseSection/caseSectionRoutesV0.ts
@@ -72,11 +72,11 @@ caseSectionsRouter.get(
   canViewCaseSection,
   async (req: Request, res) => {
     const {
-      accountSid,
+      hrmAccountId,
       params: { caseId, sectionType, sectionId },
     } = req;
 
-    const section = await getCaseSection(accountSid, caseId, sectionType, sectionId);
+    const section = await getCaseSection(hrmAccountId, caseId, sectionType, sectionId);
     if (!section) {
       throw createError(404);
     }
@@ -86,12 +86,12 @@ caseSectionsRouter.get(
 
 caseSectionsRouter.post('/:sectionType', canAddCaseSection, async (req, res) => {
   const {
-    accountSid,
+    hrmAccountId,
     user,
     params: { caseId, sectionType },
   } = req;
   const createdCase = await createCaseSection(
-    accountSid,
+    hrmAccountId,
     caseId,
     sectionType,
     req.body,
@@ -106,12 +106,12 @@ caseSectionsRouter.put(
   canEditCaseSection,
   async (req, res) => {
     const {
-      accountSid,
+      hrmAccountId,
       user,
       params: { caseId, sectionType, sectionId },
     } = req;
     const updatedSection = await replaceCaseSection(
-      accountSid,
+      hrmAccountId,
       caseId,
       sectionType,
       sectionId,
@@ -130,13 +130,19 @@ caseSectionsRouter.delete(
   canEditCaseSection,
   async (req, res) => {
     const {
-      accountSid,
+      hrmAccountId,
       user,
       params: { caseId, sectionType, sectionId },
     } = req;
-    const deleted = await deleteCaseSection(accountSid, caseId, sectionType, sectionId, {
-      user,
-    });
+    const deleted = await deleteCaseSection(
+      hrmAccountId,
+      caseId,
+      sectionType,
+      sectionId,
+      {
+        user,
+      },
+    );
     if (!deleted) {
       throw createError(404);
     }

--- a/hrm-domain/hrm-core/contact/canPerformContactAction.ts
+++ b/hrm-domain/hrm-core/contact/canPerformContactAction.ts
@@ -42,11 +42,11 @@ const canPerformActionOnContact = (
 ) =>
   asyncHandler(async (req, res, next) => {
     if (!req.isAuthorized()) {
-      const { accountSid, user, can, body, query } = req;
+      const { accountSid, hrmAccountId, user, can, body, query } = req;
       const { contactId } = req.params;
 
       try {
-        const contactObj = await getContactById(accountSid, contactId, req);
+        const contactObj = await getContactById(hrmAccountId, contactId, req);
         if (!contactObj) {
           // This is a dirty hack that relies on the catch block in the try/catch below to return a 404
           throw new Error('contact not found');
@@ -140,10 +140,10 @@ export const canPerformViewContactAction = canPerformActionOnContact(
 
 const canRemoveFromCase = async (
   originalCaseId: string,
-  { can, user, accountSid, permissions },
+  { can, user, hrmAccountId, permissions },
 ): Promise<boolean> => {
   if (originalCaseId) {
-    const originalCaseObj = await getCase(parseInt(originalCaseId), accountSid, {
+    const originalCaseObj = await getCase(parseInt(originalCaseId), hrmAccountId, {
       can,
       user,
       permissions,
@@ -158,14 +158,14 @@ const canConnectContact = canPerformActionOnContact(
   actionsMaps.contact.ADD_CONTACT_TO_CASE,
   async (
     { caseId: originalCaseId }: Contact,
-    { can, user, accountSid, body: { caseId: targetCaseId }, permissions },
+    { can, user, hrmAccountId, body: { caseId: targetCaseId }, permissions },
   ) => {
     if (
-      !(await canRemoveFromCase(originalCaseId, { can, user, accountSid, permissions }))
+      !(await canRemoveFromCase(originalCaseId, { can, user, hrmAccountId, permissions }))
     ) {
       return false;
     }
-    const targetCaseObj = await getCase(parseInt(targetCaseId), accountSid, {
+    const targetCaseObj = await getCase(parseInt(targetCaseId), hrmAccountId, {
       can,
       user,
       permissions,

--- a/hrm-domain/hrm-core/contact/contactRoutesV0.ts
+++ b/hrm-domain/hrm-core/contact/contactRoutesV0.ts
@@ -45,8 +45,8 @@ const contactsRouter = SafeRouter();
  * @returns {Contact} - Created contact
  */
 contactsRouter.post('/', publicEndpoint, async (req, res) => {
-  const { accountSid, user } = req;
-  const contact = await createContact(accountSid, user.workerSid, req.body, {
+  const { hrmAccountId, user } = req;
+  const contact = await createContact(hrmAccountId, user.workerSid, req.body, {
     can: req.can,
     user,
   });
@@ -54,8 +54,8 @@ contactsRouter.post('/', publicEndpoint, async (req, res) => {
 });
 
 contactsRouter.get('/byTaskSid/:taskSid', publicEndpoint, async (req, res) => {
-  const { accountSid, user, can } = req;
-  const contact = await getContactByTaskId(accountSid, req.params.taskSid, {
+  const { hrmAccountId, user, can } = req;
+  const contact = await getContactByTaskId(hrmAccountId, req.params.taskSid, {
     can: req.can,
     user,
   });
@@ -69,11 +69,11 @@ contactsRouter.put(
   '/:contactId/connectToCase',
   canChangeContactConnection,
   async (req, res) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { contactId } = req.params;
     const { caseId } = req.body;
     try {
-      const updatedContact = await connectContactToCase(accountSid, contactId, caseId, {
+      const updatedContact = await connectContactToCase(hrmAccountId, contactId, caseId, {
         can: req.can,
         user,
       });
@@ -93,11 +93,11 @@ contactsRouter.delete(
   '/:contactId/connectToCase',
   canDisconnectContact,
   async (req, res) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { contactId } = req.params;
 
     try {
-      const deleteContact = await connectContactToCase(accountSid, contactId, null, {
+      const deleteContact = await connectContactToCase(hrmAccountId, contactId, null, {
         can: req.can,
         user,
       });
@@ -114,9 +114,9 @@ contactsRouter.delete(
 );
 
 contactsRouter.post('/search', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
 
-  const searchResults = await searchContacts(accountSid, req.body, req.query, {
+  const searchResults = await searchContacts(hrmAccountId, req.body, req.query, {
     can: req.can,
     user: req.user,
     permissions: req.permissions,
@@ -138,12 +138,12 @@ contactsRouter.patch(
   validatePatchPayload,
   canPerformEditContactAction,
   async (req, res) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { contactId } = req.params;
     const finalize = req.query.finalize === 'true'; // Default to false for backwards compatibility
     try {
       const contact = await patchContact(
-        accountSid,
+        hrmAccountId,
         user.workerSid,
         finalize,
         contactId,
@@ -163,14 +163,19 @@ contactsRouter.patch(
 );
 
 contactsRouter.post('/:contactId/conversationMedia', publicEndpoint, async (req, res) => {
-  const { accountSid, user } = req;
+  const { hrmAccountId, user } = req;
   const { contactId } = req.params;
 
   try {
-    const contact = await addConversationMediaToContact(accountSid, contactId, req.body, {
-      can: req.can,
-      user,
-    });
+    const contact = await addConversationMediaToContact(
+      hrmAccountId,
+      contactId,
+      req.body,
+      {
+        can: req.can,
+        user,
+      },
+    );
     res.json(contact);
   } catch (err) {
     if (err.message.toLowerCase().includes('contact not found')) {
@@ -181,8 +186,8 @@ contactsRouter.post('/:contactId/conversationMedia', publicEndpoint, async (req,
 
 // WARNING: this endpoint MUST be the last one in this router, because it will be used if none of the above regex matches the path
 contactsRouter.get('/:contactId', canPerformViewContactAction, async (req, res) => {
-  const { accountSid, can, user } = req;
-  const contact = await getContactById(accountSid, req.params.contactId, {
+  const { hrmAccountId, can, user } = req;
+  const contact = await getContactById(hrmAccountId, req.params.contactId, {
     can: req.can,
     user,
   });

--- a/hrm-domain/hrm-core/csam-report/csam-report-routes-v0.ts
+++ b/hrm-domain/hrm-core/csam-report/csam-report-routes-v0.ts
@@ -25,8 +25,8 @@ const csamReportRouter = SafeRouter();
 csamReportRouter.post(
   '/',
   publicEndpoint,
-  async (req: Request & { accountSid: string }, res: Response) => {
-    const { accountSid } = req;
+  async (req: Request & { hrmAccountId: string }, res: Response) => {
+    const { hrmAccountId } = req;
 
     const { contactId, csamReportId, twilioWorkerId, reportType } = req.body;
 
@@ -47,7 +47,7 @@ csamReportRouter.post(
 
     const createdCSAMReport = await createCSAMReport(
       { contactId, csamReportId, twilioWorkerId, reportType },
-      accountSid,
+      hrmAccountId,
     );
     res.json(createdCSAMReport);
   },
@@ -56,11 +56,11 @@ csamReportRouter.post(
 csamReportRouter.post(
   '/:reportId(\\d+)/acknowledge',
   publicEndpoint,
-  async (req: Request & { accountSid: string }, res: Response) => {
-    const { accountSid } = req;
+  async (req: Request & { hrmAccountId: string }, res: Response) => {
+    const { hrmAccountId } = req;
     const reportId = parseInt(req.params.reportId, 10);
 
-    const acknowledgedReport = await acknowledgeCsamReport(reportId, accountSid);
+    const acknowledgedReport = await acknowledgeCsamReport(reportId, hrmAccountId);
 
     if (!acknowledgedReport) {
       throw createError(404, `Report with id ${reportId} not found`);

--- a/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
+++ b/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
@@ -30,9 +30,9 @@ postSurveysRouter.post(
   '/',
   publicEndpoint,
   async (req: Request<NewPostSurvey>, res: Response<PostSurvey>) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
 
-    const createdPostSurvey = await createPostSurvey(accountSid, req.body);
+    const createdPostSurvey = await createPostSurvey(hrmAccountId, req.body);
     res.json(createdPostSurvey);
   },
 );
@@ -56,10 +56,10 @@ postSurveysRouter.get(
   '/contactTaskId/:id',
   canViewPostSurvey,
   async (req: Request, res: Response) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
     const { id } = req.params;
 
-    const postSurveys = await getPostSurveysByContactTaskId(accountSid, id);
+    const postSurveys = await getPostSurveysByContactTaskId(hrmAccountId, id);
     res.json(postSurveys);
   },
 );

--- a/hrm-domain/hrm-core/profile/adminProfileRoutesV0.ts
+++ b/hrm-domain/hrm-core/profile/adminProfileRoutesV0.ts
@@ -26,11 +26,11 @@ adminProfilesRouter.post(
   '/identifiers',
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { identifier, name } = req.body;
 
     const result = await profileController.createProfileWithIdentifierOrError(
-      accountSid,
+      hrmAccountId,
       { identifier: { identifier }, profile: { name } },
       { user },
     );
@@ -49,9 +49,9 @@ adminProfilesRouter.post(
 );
 
 adminProfilesRouter.get('/flags', publicEndpoint, async (req: Request, res: Response) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
 
-  const result = await profileController.getProfileFlags(accountSid);
+  const result = await profileController.getProfileFlags(hrmAccountId);
 
   res.json(result);
 });
@@ -61,11 +61,11 @@ adminProfilesRouter.post(
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { accountSid, user } = req;
+      const { hrmAccountId, user } = req;
       const { name } = req.body;
 
       const result = await profileController.createProfileFlag(
-        accountSid,
+        hrmAccountId,
         { name },
         { user },
       );
@@ -86,12 +86,12 @@ adminProfilesRouter.patch(
   '/flags/:flagId',
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { flagId } = req.params;
     const { name } = req.body;
 
     const result = await profileController.updateProfileFlagById(
-      accountSid,
+      hrmAccountId,
       parseInt(flagId, 10),
       {
         name,
@@ -117,12 +117,12 @@ adminProfilesRouter.delete(
   '/flags/:flagId',
   publicEndpoint,
   async (req: Request, res: Response) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
     const { flagId } = req.params;
 
     const result = await profileController.deleteProfileFlagById(
       parseInt(flagId, 10),
-      accountSid,
+      hrmAccountId,
     );
 
     res.json(result);

--- a/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
+++ b/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
@@ -24,19 +24,19 @@ import type { InitializedCan } from '../permissions/initializeCanForRules';
 import type { ActionsForTK } from '../permissions/actions';
 
 export const canPerformActionOnProfile = async ({
-  accountSid,
+  hrmAccountId,
   action,
   can,
   profileId,
   user,
 }: {
   action: ActionsForTK<'profile'>;
-  accountSid: string;
+  hrmAccountId: string;
   can: InitializedCan;
   profileId: Profile['id'];
   user: TwilioUser;
 }) => {
-  const result = await getProfileById()(accountSid, profileId);
+  const result = await getProfileById()(hrmAccountId, profileId);
 
   const isAllowed = can(user, action, result);
 
@@ -46,18 +46,18 @@ export const canPerformActionOnProfile = async ({
 export const canPerformActionOnProfileMiddleware = (
   action: ActionsForTK<'profile'>,
   parseRequest: (req: RequestWithPermissions) => {
-    accountSid: string;
+    hrmAccountId: string;
     can: InitializedCan;
     profileId: Profile['id'];
     user: TwilioUser;
   },
 ) =>
   asyncHandler(async (req, _res, next) => {
-    const { accountSid, can, profileId, user } = parseRequest(req);
+    const { hrmAccountId, can, profileId, user } = parseRequest(req);
 
     const result = await canPerformActionOnProfile({
       action,
-      accountSid,
+      hrmAccountId,
       can,
       profileId,
       user,
@@ -79,7 +79,7 @@ export const canPerformActionOnProfileMiddleware = (
   });
 
 export const canPerformActionOnProfileSection = async ({
-  accountSid,
+  hrmAccountId,
   action,
   can,
   profileId,
@@ -87,7 +87,7 @@ export const canPerformActionOnProfileSection = async ({
   user,
 }: {
   action: ActionsForTK<'profileSection'>;
-  accountSid: string;
+  hrmAccountId: string;
   can: InitializedCan;
   profileId: Profile['id'];
   sectionId: ProfileSection['id'] | null;
@@ -98,7 +98,7 @@ export const canPerformActionOnProfileSection = async ({
     return newOk({ data: { isAllowed } });
   }
 
-  const result = await getProfileSectionById(accountSid, { profileId, sectionId });
+  const result = await getProfileSectionById(hrmAccountId, { profileId, sectionId });
 
   if (!result) {
     return newErr({
@@ -115,7 +115,7 @@ export const canPerformActionOnProfileSection = async ({
 export const canPerformActionOnProfileSectionMiddleware = (
   action: ActionsForTK<'profileSection'>,
   parseRequest: (req: RequestWithPermissions) => {
-    accountSid: string;
+    hrmAccountId: string;
     can: InitializedCan;
     profileId: Profile['id'];
     sectionId: ProfileSection['id'] | null;
@@ -123,10 +123,10 @@ export const canPerformActionOnProfileSectionMiddleware = (
   },
 ) =>
   asyncHandler(async (req, _res, next) => {
-    const { accountSid, can, profileId, sectionId, user } = parseRequest(req);
+    const { hrmAccountId, can, profileId, sectionId, user } = parseRequest(req);
 
     const result = await canPerformActionOnProfileSection({
-      accountSid,
+      hrmAccountId,
       action,
       can,
       profileId,

--- a/hrm-domain/hrm-core/profile/profileRoutesV0.ts
+++ b/hrm-domain/hrm-core/profile/profileRoutesV0.ts
@@ -41,7 +41,7 @@ const profilesRouter = SafeRouter();
  * @param {profileController.SearchParameters['filters']['profileFlagIds']} req.query.profileFlagIds
  */
 profilesRouter.get('/', publicEndpoint, async (req: Request, res: Response) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
   const {
     sortDirection,
     sortBy,
@@ -62,7 +62,7 @@ profilesRouter.get('/', publicEndpoint, async (req: Request, res: Response) => {
   };
 
   const result = await profileController.listProfiles(
-    accountSid,
+    hrmAccountId,
     { sortDirection, sortBy, limit, offset },
     { filters },
   );
@@ -74,11 +74,11 @@ profilesRouter.get(
   '/identifier/:identifier',
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
     const { identifier } = req.params;
 
     const result = await profileController.getIdentifierByIdentifier(
-      accountSid,
+      hrmAccountId,
       identifier,
     );
 
@@ -91,11 +91,11 @@ profilesRouter.get(
 );
 
 profilesRouter.get('/identifier/:identifier/flags', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
+  const { hrmAccountId } = req;
   const { identifier } = req.params;
 
   const result = await profileController.getProfileFlagsByIdentifier(
-    accountSid,
+    hrmAccountId,
     identifier,
   );
 
@@ -111,11 +111,11 @@ profilesRouter.get(
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { accountSid } = req;
+      const { hrmAccountId } = req;
       const { profileId } = req.params;
 
       const result = await getContactsByProfileId(
-        accountSid,
+        hrmAccountId,
         parseInt(profileId, 10),
         req.query,
         {
@@ -141,11 +141,11 @@ profilesRouter.get(
   publicEndpoint,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { accountSid, can, user, permissions } = req;
+      const { hrmAccountId, can, user, permissions } = req;
       const { profileId } = req.params;
 
       const result = await getCasesByProfileId(
-        accountSid,
+        hrmAccountId,
         parseInt(profileId, 10),
         req.query,
         { can, user, permissions },
@@ -172,7 +172,7 @@ profilesRouter.get('/flags', publicEndpoint, async (req, res) => {
 const canAssociate = canPerformActionOnProfileMiddleware(
   actionsMaps.profile.FLAG_PROFILE,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     user: req.user,
@@ -182,7 +182,7 @@ profilesRouter.post(
   '/:profileId/flags/:profileFlagId',
   canAssociate,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { profileId, profileFlagId } = req.params;
     const { validUntil } = req.body;
 
@@ -197,7 +197,7 @@ profilesRouter.post(
     }
 
     const result = await profileController.associateProfileToProfileFlag(
-      accountSid,
+      hrmAccountId,
       {
         profileId: parseInt(profileId),
         profileFlagId: parseInt(profileFlagId),
@@ -226,7 +226,7 @@ profilesRouter.post(
 const canDisassociate = canPerformActionOnProfileMiddleware(
   actionsMaps.profile.UNFLAG_PROFILE,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     user: req.user,
@@ -236,11 +236,11 @@ profilesRouter.delete(
   '/:profileId/flags/:profileFlagId',
   canDisassociate,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user, params } = req;
+    const { hrmAccountId, user, params } = req;
     const { profileId, profileFlagId } = params;
 
     const result = await profileController.disassociateProfileFromProfileFlag(
-      accountSid,
+      hrmAccountId,
       {
         profileId: parseInt(profileId, 10),
         profileFlagId: parseInt(profileFlagId, 10),
@@ -264,7 +264,7 @@ profilesRouter.delete(
 const canCreateProfileSection = canPerformActionOnProfileSectionMiddleware(
   actionsMaps.profileSection.CREATE_PROFILE_SECTION,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     sectionId: null,
@@ -275,12 +275,12 @@ profilesRouter.post(
   '/:profileId/sections',
   canCreateProfileSection,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { profileId } = req.params;
     const { content, sectionType } = req.body;
 
     const result = await profileController.createProfileSection(
-      accountSid,
+      hrmAccountId,
       { content, profileId: parseInt(profileId, 10), sectionType },
       { user },
     );
@@ -299,7 +299,7 @@ profilesRouter.post(
 const canEditProfileSection = canPerformActionOnProfileSectionMiddleware(
   actionsMaps.profileSection.EDIT_PROFILE_SECTION,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     sectionId: parseInt(req.params.sectionId, 10),
@@ -310,12 +310,12 @@ profilesRouter.patch(
   '/:profileId/sections/:sectionId',
   canEditProfileSection,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid, user } = req;
+    const { hrmAccountId, user } = req;
     const { profileId, sectionId } = req.params;
     const { content } = req.body;
 
     const result = await profileController.updateProfileSectionById(
-      accountSid,
+      hrmAccountId,
       {
         profileId: parseInt(profileId, 10),
         sectionId: parseInt(sectionId, 10),
@@ -335,7 +335,7 @@ profilesRouter.patch(
 const canViewProfileSection = canPerformActionOnProfileSectionMiddleware(
   actionsMaps.profileSection.VIEW_PROFILE_SECTION,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     sectionId: parseInt(req.params.sectionId, 10),
@@ -346,10 +346,10 @@ profilesRouter.get(
   '/:profileId/sections/:sectionId',
   canViewProfileSection,
   async (req: Request, res: Response) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
     const { profileId, sectionId } = req.params;
 
-    const result = await profileController.getProfileSectionById(accountSid, {
+    const result = await profileController.getProfileSectionById(hrmAccountId, {
       profileId: parseInt(profileId, 10),
       sectionId: parseInt(sectionId, 10),
     });
@@ -365,7 +365,7 @@ profilesRouter.get(
 const canViewProfile = canPerformActionOnProfileMiddleware(
   actionsMaps.profile.VIEW_PROFILE,
   req => ({
-    accountSid: req.accountSid,
+    hrmAccountId: req.hrmAccountId,
     can: req.can,
     profileId: parseInt(req.params.profileId, 10),
     user: req.user,
@@ -376,11 +376,11 @@ profilesRouter.get(
   '/:profileId',
   canViewProfile,
   async (req: Request, res: Response, next: NextFunction) => {
-    const { accountSid } = req;
+    const { hrmAccountId } = req;
     const { profileId } = req.params;
 
     const result = await profileController.getProfile()(
-      accountSid,
+      hrmAccountId,
       parseInt(profileId, 10),
     );
 

--- a/hrm-domain/hrm-core/profile/profileRoutesV0.ts
+++ b/hrm-domain/hrm-core/profile/profileRoutesV0.ts
@@ -163,8 +163,8 @@ profilesRouter.get(
 );
 
 profilesRouter.get('/flags', publicEndpoint, async (req, res) => {
-  const { accountSid } = req;
-  const result = await profileController.getProfileFlags(accountSid);
+  const { hrmAccountId } = req;
+  const result = await profileController.getProfileFlags(hrmAccountId);
 
   res.json(result);
 });

--- a/hrm-domain/hrm-core/referral/referral-routes-v0.ts
+++ b/hrm-domain/hrm-core/referral/referral-routes-v0.ts
@@ -32,12 +32,12 @@ export default () => {
     '/',
     publicEndpoint,
     async (req: Request<unknown, Referral, Referral>, res: Response) => {
-      const { accountSid, body } = req;
+      const { hrmAccountId, body } = req;
       if (!body.resourceId || !body.contactId || !isValid(parseISO(body.referredAt))) {
         throw createError(400, 'Required referral property not present');
       }
       try {
-        res.json(await createReferral()(accountSid, body));
+        res.json(await createReferral()(hrmAccountId, body));
       } catch (err) {
         if (err instanceof DuplicateReferralError) {
           throw createError(400, err.message);

--- a/hrm-domain/hrm-core/unit-tests/contact/canPerformContactAction.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/canPerformContactAction.test.ts
@@ -59,6 +59,7 @@ beforeEach(() => {
     can: jest.fn(),
     user: { workerSid: 'worker1' },
     accountSid: 'account1',
+    hrmAccountId: 'account1',
     body: {},
   };
   next.mockClear();
@@ -185,7 +186,7 @@ describe('canPerformEditContactAction', () => {
       new ContactBuilder().withFinalizedAt(BASELINE_DATE).build(),
     );
     await canPerformEditContactAction(req, {}, next);
-    expect(mockGetContactById).toHaveBeenCalledWith(req.accountSid, 'contact1', req);
+    expect(mockGetContactById).toHaveBeenCalledWith(req.hrmAccountId, 'contact1', req);
   });
 
   describe('finalized contact', function () {

--- a/hrm-domain/hrm-core/unit-tests/referrals/referrals-routes-v0.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/referrals/referrals-routes-v0.test.ts
@@ -78,7 +78,8 @@ describe('POST /search', () => {
       {
         body: validReferral,
         accountSid: 'AC1',
-      } as Request<Referral>,
+        hrmAccountId: 'AC1',
+      } as any,
       response,
     );
     expect(innerCreateReferral).toHaveBeenCalledWith('AC1', validReferral);
@@ -91,7 +92,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, referredAt: hourAgo.toString() },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {
@@ -107,7 +109,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, referredAt: undefined },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {
@@ -123,7 +126,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, contactId: undefined },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {
@@ -139,7 +143,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, resourceId: undefined },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {
@@ -158,7 +163,8 @@ describe('POST /search', () => {
       {
         body: rest,
         accountSid: 'AC1',
-      } as Request<Referral>,
+        hrmAccountId: 'AC1',
+      } as any,
       response,
     );
     expect(innerCreateReferral).toHaveBeenCalledWith('AC1', rest);
@@ -176,7 +182,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, resource: undefined },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {
@@ -198,7 +205,8 @@ describe('POST /search', () => {
         {
           body: { ...validReferral, resource: undefined },
           accountSid: 'AC1',
-        } as Request<Referral>,
+          hrmAccountId: 'AC1',
+        } as any,
         response,
       );
     } catch (err) {

--- a/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
@@ -1203,6 +1203,14 @@ describe('/cases route', () => {
                   ),
               expectedTotalCount: 7,
             },
+            {
+              description:
+                'should return empty set if different HRM sub account specified',
+              searchRoute: `/v0/accounts/${accounts[0]}-other/cases/search`,
+              sampleConfig: SIMPLE_SAMPLE_CONFIG,
+              expectedCasesAndContacts: () => [],
+              expectedTotalCount: 0,
+            },
           ];
 
           let createdCasesAndContacts: CaseWithContact[];
@@ -1215,7 +1223,7 @@ describe('/cases route', () => {
             });
           });
 
-          each(testCases.filter((tc, idx) => idx === 8)).test(
+          each(testCases).test(
             '$description',
             async ({
               sampleConfig,

--- a/packages/twilio-worker-auth/package.json
+++ b/packages/twilio-worker-auth/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tech-matters/http": "^1.0.0",
+    "@tech-matters/types": "^1.0.0",
     "twilio-flex-token-validator": "^1.5.6"
   },
   "devDependencies": {

--- a/packages/twilio-worker-auth/src/addAccountSidMiddleware.ts
+++ b/packages/twilio-worker-auth/src/addAccountSidMiddleware.ts
@@ -16,11 +16,13 @@
 
 import './index';
 import type { Request, Response, NextFunction } from 'express';
+import { AccountSID } from '@tech-matters/types';
 
 declare global {
   namespace Express {
     export interface Request {
-      accountSid?: string;
+      accountSid?: AccountSID;
+      hrmAccountId?: string;
     }
   }
 }
@@ -33,6 +35,8 @@ export const addAccountSidMiddleware = (
   res: Response,
   next: NextFunction,
 ) => {
-  req.accountSid = req.params.accountSid;
+  const [twilioAccountSid] = req.params.accountSid.split('-');
+  req.accountSid = twilioAccountSid as AccountSID;
+  req.hrmAccountId = req.params.accountSid;
   return next();
 };


### PR DESCRIPTION
## Description

Currently a HRM account can be the same as the Twilio Account SID, or can be the Twilio Account SID or ${TwilioAccountSID}-{qualifier}

The URL used with HRM is now the HRM account ID, not the Twilio Account SID. Authentication & permissions are still looked up against the base twilio account, but data saved with no qualifier cannot be read by a client using a qualifier, or vice versa. Essentially it creates a sandboxed 'sub account' in the HRM DB for each qualifier, where the data is separate.

This concept could be extended in the future to support full multi-tenanting of HRM data in the future - although this would need linking to either Okta or Twilio user identities, so we could enforce which 'HRM tenant' of the account the user is a member of. At the moment, any user can theoretically use any sub account they like, which is fine for the current use case of sandboxing off test data

With a little more work we could even support the opposite model, where multiple Twilio accounts feed the same HRM account

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [x] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P