### PR TITLE
CHI-2726: Added a 'hasContacts' computed flag to enable banner display logic on profiles

### DIFF
--- a/hrm-domain/hrm-core/profile/profileDataAccess.ts
+++ b/hrm-domain/hrm-core/profile/profileDataAccess.ts
@@ -91,6 +91,7 @@ export type ProfileWithRelationships = Profile & {
     sectionType: ProfileSection['sectionType'];
     id: ProfileSection['id'];
   }[];
+  hasContacts: boolean;
 };
 
 type IdentifierParams =

--- a/hrm-domain/hrm-core/profile/profileService.ts
+++ b/hrm-domain/hrm-core/profile/profileService.ts
@@ -34,8 +34,8 @@ import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import type { NewProfileSectionRecord } from './sql/profile-sections-sql';
 import type { NewProfileFlagRecord } from './sql/profile-flags-sql';
 import type { NewIdentifierRecord, NewProfileRecord } from './sql/profile-insert-sql';
-import { ITask } from 'pg-promise';
-import { HrmAccountId } from '@tech-matters/types/dist';
+import type { ITask } from 'pg-promise';
+import type { HrmAccountId } from '@tech-matters/types';
 
 export {
   Identifier,


### PR DESCRIPTION
 ## Description

This flag ignored permissions and is set to true if the profile has contacts attached, whether the user has permission to see them or not.

This is a hack to enable banner display logic on the front end. Remove when limited view permissions are added, as this logic can be driven off limited view permissions once those are present.

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Automated tests

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P