### PR TITLE
refactor: move contacts and cases types to HrmTypes module

### DIFF
--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -29,29 +29,16 @@ import { Contact } from '../contact/contactDataAccess';
 import { DateFilter, OrderByDirectionType } from '../sql';
 import { TKConditionsSets } from '../permissions/rulesMap';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
-import { TwilioUserIdentifier, WorkerSID } from '@tech-matters/types';
+import { TwilioUserIdentifier } from '@tech-matters/types';
+import {
+  PrecalculatedCasePermissionConditions,
+  CaseRecordCommon,
+} from '@tech-matters/types/HrmTypes';
 import { CaseSectionRecord } from './caseSection/types';
 import { pick } from 'lodash';
 import { HrmAccountId } from '@tech-matters/types';
 
-export type PrecalculatedCasePermissionConditions = {
-  isCaseContactOwner: boolean; // Does the requesting user own any of the contacts currently connected to the case?
-};
-
-export type CaseRecordCommon = {
-  info: any;
-  helpline: string;
-  status: string;
-  twilioWorkerId: WorkerSID;
-  createdBy: TwilioUserIdentifier;
-  updatedBy: TwilioUserIdentifier;
-  accountSid: HrmAccountId;
-  createdAt: string;
-  updatedAt: string;
-  statusUpdatedAt?: string;
-  statusUpdatedBy?: string;
-  previousStatus?: string;
-};
+export { PrecalculatedCasePermissionConditions, CaseRecordCommon };
 
 // Exported for testing
 export const VALID_CASE_CREATE_FIELDS: (keyof CaseRecordCommon)[] = [

--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -23,7 +23,6 @@ import {
   CaseListConfiguration,
   CaseListFilters,
   CaseRecord,
-  CaseRecordCommon,
   CaseSearchCriteria,
   SearchQueryFunction,
   create,
@@ -35,76 +34,25 @@ import {
   updateCaseInfo,
 } from './caseDataAccess';
 import { randomUUID } from 'crypto';
-import type { Contact } from '../contact/contactDataAccess';
 import { InitializedCan } from '../permissions/initializeCanForRules';
 import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { bindApplyTransformations as bindApplyContactTransformations } from '../contact/contactService';
 import type { Profile } from '../profile/profileDataAccess';
 import type { PaginationQuery } from '../search';
 import { HrmAccountId, TResult, newErr, newOk } from '@tech-matters/types';
+import {
+  WELL_KNOWN_CASE_SECTION_NAMES,
+  CaseService,
+  CaseInfoSection,
+} from '@tech-matters/types/HrmTypes';
 import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import { CaseSectionRecord } from './caseSection/types';
 import { pick } from 'lodash';
 
+export { WELL_KNOWN_CASE_SECTION_NAMES, CaseService, CaseInfoSection };
+
 const CASE_OVERVIEW_PROPERTIES = ['summary', 'followUpDate', 'childIsAtRisk'] as const;
 type CaseOverviewProperties = (typeof CASE_OVERVIEW_PROPERTIES)[number];
-
-type CaseSection = Omit<CaseSectionRecord, 'accountSid' | 'sectionType' | 'caseId'>;
-
-type CaseInfoSection = {
-  id: string;
-  twilioWorkerId: string;
-  updatedAt?: string;
-  updatedBy?: string;
-} & Record<string, any>;
-
-const getSectionSpecificDataFromNotesOrReferrals = (
-  caseSection: CaseInfoSection,
-): Record<string, any> => {
-  const {
-    id,
-    twilioWorkerId,
-    createdAt,
-    updatedBy,
-    updatedAt,
-    accountSid,
-    ...sectionSpecificData
-  } = caseSection;
-  return sectionSpecificData;
-};
-
-export const WELL_KNOWN_CASE_SECTION_NAMES = {
-  households: { getSectionSpecificData: s => s.household, sectionTypeName: 'household' },
-  perpetrators: {
-    getSectionSpecificData: s => s.perpetrator,
-    sectionTypeName: 'perpetrator',
-  },
-  incidents: { getSectionSpecificData: s => s.incident, sectionTypeName: 'incident' },
-  counsellorNotes: {
-    getSectionSpecificData: getSectionSpecificDataFromNotesOrReferrals,
-    sectionTypeName: 'note',
-  },
-  referrals: {
-    getSectionSpecificData: getSectionSpecificDataFromNotesOrReferrals,
-    sectionTypeName: 'referral',
-  },
-  documents: { getSectionSpecificData: s => s.document, sectionTypeName: 'document' },
-} as const;
-
-type PrecalculatedPermissions = Record<'userOwnsContact', boolean>;
-
-type CaseSectionsMap = {
-  [k in (typeof WELL_KNOWN_CASE_SECTION_NAMES)[keyof typeof WELL_KNOWN_CASE_SECTION_NAMES]['sectionTypeName']]?: CaseSection[];
-};
-
-export type CaseService = CaseRecordCommon & {
-  id: number;
-  childName?: string;
-  categories: Record<string, string[]>;
-  precalculatedPermissions?: PrecalculatedPermissions;
-  connectedContacts?: Contact[];
-  sections: CaseSectionsMap;
-};
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;

--- a/hrm-domain/hrm-core/contact/contactDataAccess.ts
+++ b/hrm-domain/hrm-core/contact/contactDataAccess.ts
@@ -23,29 +23,17 @@ import {
   selectSingleContactByTaskId,
 } from './sql/contact-get-sql';
 import { INSERT_CONTACT_SQL, NewContactRecord } from './sql/contactInsertSql';
-import { ContactRawJson, ReferralWithoutContactId } from './contactJson';
+import { ContactRawJson } from './contactJson';
 import type { ITask } from 'pg-promise';
 import { txIfNotInOne } from '../sql';
-import { ConversationMedia } from '../conversation-media/conversation-media';
 import { TOUCH_CASE_SQL } from '../case/sql/caseUpdateSql';
 import { TKConditionsSets } from '../permissions/rulesMap';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { TwilioUserIdentifier, HrmAccountId } from '@tech-matters/types';
 
-export type ExistingContactRecord = {
-  id: number;
-  accountSid: HrmAccountId;
-  createdAt: string;
-  finalizedAt?: string;
-  updatedAt?: string;
-  updatedBy?: TwilioUserIdentifier;
-} & Partial<NewContactRecord>;
+import { ExistingContactRecord, Contact } from '@tech-matters/types/HrmTypes';
 
-export type Contact = ExistingContactRecord & {
-  csamReports: any[];
-  referrals?: ReferralWithoutContactId[];
-  conversationMedia?: ConversationMedia[];
-};
+export { ExistingContactRecord, Contact };
 
 export type SearchParameters = {
   helpline?: string;

--- a/hrm-domain/hrm-core/contact/contactJson.ts
+++ b/hrm-domain/hrm-core/contact/contactJson.ts
@@ -13,27 +13,5 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { Referral } from '../referral/referral-data-access';
 
-/**
- * This and contained types are copied from Flex
- */
-export type ContactRawJson = {
-  definitionVersion?: string;
-  callType: string;
-  childInformation: {
-    [key: string]: string | boolean;
-  };
-  callerInformation?: {
-    [key: string]: string | boolean;
-  };
-  categories: Record<string, string[]>;
-  caseInformation: {
-    [key: string]: string | boolean;
-  };
-  contactlessTask?: { [key: string]: string | boolean };
-  referrals?: Referral[];
-};
-
-// Represents a referral when part of a contact structure, so no contact ID
-export type ReferralWithoutContactId = Omit<Referral, 'contactId'>;
+export { ContactRawJson, ReferralWithoutContactId } from '@tech-matters/types/HrmTypes';

--- a/hrm-domain/hrm-core/contact/sql/contactInsertSql.ts
+++ b/hrm-domain/hrm-core/contact/sql/contactInsertSql.ts
@@ -14,27 +14,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { ContactRawJson } from '../contactJson';
 import { selectSingleContactByTaskId } from './contact-get-sql';
-import { TwilioUserIdentifier, WorkerSID } from '@tech-matters/types';
+import { NewContactRecord } from '@tech-matters/types/HrmTypes';
 
-export type NewContactRecord = {
-  rawJson: ContactRawJson;
-  queueName: string;
-  twilioWorkerId?: WorkerSID;
-  createdBy?: TwilioUserIdentifier;
-  helpline?: string;
-  number?: string;
-  channel?: string;
-  conversationDuration: number;
-  timeOfContact?: string;
-  taskId: string;
-  channelSid?: string;
-  serviceSid?: string;
-  caseId?: string;
-  profileId?: number;
-  identifierId?: number;
-};
+export { NewContactRecord };
 
 export const INSERT_CONTACT_SQL = `
   WITH existing AS (

--- a/hrm-domain/hrm-core/conversation-media/conversation-media-data-access.ts
+++ b/hrm-domain/hrm-core/conversation-media/conversation-media-data-access.ts
@@ -32,73 +32,33 @@ import {
 import { insertConversationMediaSql } from './sql/conversation-media-insert-sql';
 import { updateSpecificDataByIdSql } from './sql/conversation-media-update-sql';
 import { HrmAccountId } from '@tech-matters/types';
+import {
+  S3ContactMediaType,
+  S3StoredTranscript,
+  S3StoredRecording,
+  S3StoredConversationMedia,
+  ConversationMedia,
+  NewConversationMedia,
+  isTwilioStoredMedia,
+  isS3StoredTranscript,
+  isS3StoredTranscriptPending,
+  isS3StoredRecording,
+  isS3StoredConversationMedia,
+} from '@tech-matters/types/HrmTypes';
 
-/**
- *
- */
-type ConversationMediaCommons = {
-  id: number;
-  contactId: number;
-  accountSid: HrmAccountId;
-  createdAt: Date;
-  updatedAt: Date;
+export {
+  S3ContactMediaType,
+  S3StoredTranscript,
+  S3StoredRecording,
+  S3StoredConversationMedia,
+  ConversationMedia,
+  NewConversationMedia,
+  isTwilioStoredMedia,
+  isS3StoredTranscript,
+  isS3StoredTranscriptPending,
+  isS3StoredRecording,
+  isS3StoredConversationMedia,
 };
-
-export enum S3ContactMediaType {
-  RECORDING = 'recording',
-  TRANSCRIPT = 'transcript',
-}
-
-type NewTwilioStoredMedia = {
-  storeType: 'twilio';
-  storeTypeSpecificData: { reservationSid: string };
-};
-type TwilioStoredMedia = ConversationMediaCommons & NewTwilioStoredMedia;
-
-type NewS3StoredTranscript = {
-  storeType: 'S3';
-  storeTypeSpecificData: {
-    type: S3ContactMediaType.TRANSCRIPT;
-    location?: {
-      bucket: string;
-      key: string;
-    };
-  };
-};
-
-type NewS3StoredRecording = {
-  storeType: 'S3';
-  storeTypeSpecificData: {
-    type: S3ContactMediaType.RECORDING;
-    location?: {
-      bucket: string;
-      key: string;
-    };
-  };
-};
-export type S3StoredTranscript = ConversationMediaCommons & NewS3StoredTranscript;
-export type S3StoredRecording = ConversationMediaCommons & NewS3StoredRecording;
-export type S3StoredConversationMedia = S3StoredTranscript | S3StoredRecording;
-
-export type ConversationMedia = TwilioStoredMedia | S3StoredConversationMedia;
-
-export type NewConversationMedia =
-  | NewTwilioStoredMedia
-  | NewS3StoredTranscript
-  | NewS3StoredRecording;
-
-export const isTwilioStoredMedia = (m: ConversationMedia): m is TwilioStoredMedia =>
-  m.storeType === 'twilio';
-export const isS3StoredTranscript = (m: ConversationMedia): m is S3StoredTranscript =>
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  m.storeType === 'S3' && m.storeTypeSpecificData?.type === S3ContactMediaType.TRANSCRIPT;
-export const isS3StoredTranscriptPending = (m: ConversationMedia) =>
-  isS3StoredTranscript(m) && !m.storeTypeSpecificData?.location;
-export const isS3StoredRecording = (m: ConversationMedia): m is S3StoredRecording =>
-  m.storeType === 'S3' && m.storeTypeSpecificData?.type === S3ContactMediaType.RECORDING;
-export const isS3StoredConversationMedia = (
-  m: ConversationMedia,
-): m is S3StoredConversationMedia => isS3StoredTranscript(m) || isS3StoredRecording(m);
 
 export const create =
   (task?) =>

--- a/hrm-domain/hrm-core/referral/referral-data-access.ts
+++ b/hrm-domain/hrm-core/referral/referral-data-access.ts
@@ -14,6 +14,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { Referral } from '@tech-matters/types/HrmTypes';
+
 import { insertReferralSql } from './sql/referral-insert-sql';
 import {
   DatabaseForeignKeyViolationError,
@@ -49,12 +51,7 @@ export class OrphanedReferralError extends Error {
   }
 }
 
-export type Referral = {
-  contactId: string;
-  resourceId: string;
-  referredAt: string;
-  resourceName?: string;
-};
+export { Referral };
 
 export const createReferralRecord =
   (task?) =>

--- a/packages/types/HrmTypes/Case.ts
+++ b/packages/types/HrmTypes/Case.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { HrmAccountId, TwilioUserIdentifier, WorkerSID } from '..';
+import { CaseSectionRecord } from './CaseSection';
+import { Contact } from './Contact';
+
+type CaseSection = Omit<CaseSectionRecord, 'accountSid' | 'sectionType' | 'caseId'>;
+
+export type PrecalculatedCasePermissionConditions = {
+  isCaseContactOwner: boolean; // Does the requesting user own any of the contacts currently connected to the case?
+};
+
+export type CaseRecordCommon = {
+  info: any;
+  helpline: string;
+  status: string;
+  twilioWorkerId: WorkerSID;
+  createdBy: TwilioUserIdentifier;
+  updatedBy: TwilioUserIdentifier;
+  accountSid: HrmAccountId;
+  createdAt: string;
+  updatedAt: string;
+  statusUpdatedAt?: string;
+  statusUpdatedBy?: string;
+  previousStatus?: string;
+};
+
+export type CaseInfoSection = {
+  id: string;
+  twilioWorkerId: string;
+  updatedAt?: string;
+  updatedBy?: string;
+} & Record<string, any>;
+
+const getSectionSpecificDataFromNotesOrReferrals = (
+  caseSection: CaseInfoSection,
+): Record<string, any> => {
+  const {
+    id,
+    twilioWorkerId,
+    createdAt,
+    updatedBy,
+    updatedAt,
+    accountSid,
+    ...sectionSpecificData
+  } = caseSection;
+  return sectionSpecificData;
+};
+
+export const WELL_KNOWN_CASE_SECTION_NAMES = {
+  households: { getSectionSpecificData: s => s.household, sectionTypeName: 'household' },
+  perpetrators: {
+    getSectionSpecificData: s => s.perpetrator,
+    sectionTypeName: 'perpetrator',
+  },
+  incidents: { getSectionSpecificData: s => s.incident, sectionTypeName: 'incident' },
+  counsellorNotes: {
+    getSectionSpecificData: getSectionSpecificDataFromNotesOrReferrals,
+    sectionTypeName: 'note',
+  },
+  referrals: {
+    getSectionSpecificData: getSectionSpecificDataFromNotesOrReferrals,
+    sectionTypeName: 'referral',
+  },
+  documents: { getSectionSpecificData: s => s.document, sectionTypeName: 'document' },
+} as const;
+
+type PrecalculatedPermissions = Record<'userOwnsContact', boolean>;
+
+type CaseSectionsMap = {
+  [k in (typeof WELL_KNOWN_CASE_SECTION_NAMES)[keyof typeof WELL_KNOWN_CASE_SECTION_NAMES]['sectionTypeName']]?: CaseSection[];
+};
+
+export type CaseService = CaseRecordCommon & {
+  id: number;
+  childName?: string;
+  categories: Record<string, string[]>;
+  precalculatedPermissions?: PrecalculatedPermissions;
+  connectedContacts?: Contact[];
+  sections: CaseSectionsMap;
+};

--- a/packages/types/HrmTypes/CaseSection.ts
+++ b/packages/types/HrmTypes/CaseSection.ts
@@ -13,16 +13,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { CaseSectionRecord, CaseSection } from '@tech-matters/types/HrmTypes';
 
-export { CaseSectionRecord, CaseSection };
+import { HrmAccountId } from '..';
 
-export type CaseSectionUpdate = Omit<
-  CaseSection,
-  'sectionId' | 'createdBy' | 'createdAt' | 'eventTimestamp' | 'sectionType'
-> & {
-  eventTimestamp?: string;
+export type CaseSectionRecord = {
+  caseId: number;
+  sectionType: string;
+  sectionId: string;
+  sectionTypeSpecificData: Record<string, any>;
+  accountSid: HrmAccountId;
+  createdAt: string;
+  createdBy: string;
+  updatedAt?: string;
+  updatedBy?: string;
+  eventTimestamp: string;
 };
-export type NewCaseSection = Omit<CaseSectionUpdate, 'updatedAt' | 'updatedBy'> & {
-  sectionId?: string;
-};
+
+export type CaseSection = Omit<CaseSectionRecord, 'accountSid' | 'caseId'>;

--- a/packages/types/HrmTypes/Contact.ts
+++ b/packages/types/HrmTypes/Contact.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+import { HrmAccountId, TwilioUserIdentifier, WorkerSID } from '..';
+import { ConversationMedia } from './ConversationMedia';
+import { Referral } from './Referral';
+
+/**
+ * This and contained types are copied from Flex
+ */
+export type ContactRawJson = {
+  definitionVersion?: string;
+  callType: string;
+  childInformation: {
+    [key: string]: string | boolean;
+  };
+  callerInformation?: {
+    [key: string]: string | boolean;
+  };
+  categories: Record<string, string[]>;
+  caseInformation: {
+    [key: string]: string | boolean;
+  };
+  contactlessTask?: { [key: string]: string | boolean };
+  referrals?: Referral[];
+};
+
+// Represents a referral when part of a contact structure, so no contact ID
+export type ReferralWithoutContactId = Omit<Referral, 'contactId'>;
+
+export type NewContactRecord = {
+  rawJson: ContactRawJson;
+  queueName: string;
+  twilioWorkerId?: WorkerSID;
+  createdBy?: TwilioUserIdentifier;
+  helpline?: string;
+  number?: string;
+  channel?: string;
+  conversationDuration: number;
+  timeOfContact?: string;
+  taskId: string;
+  channelSid?: string;
+  serviceSid?: string;
+  caseId?: string;
+  profileId?: number;
+  identifierId?: number;
+};
+
+export type ExistingContactRecord = {
+  id: number;
+  accountSid: HrmAccountId;
+  createdAt: string;
+  finalizedAt?: string;
+  updatedAt?: string;
+  updatedBy?: TwilioUserIdentifier;
+} & Partial<NewContactRecord>;
+
+export type Contact = ExistingContactRecord & {
+  csamReports: any[];
+  referrals?: ReferralWithoutContactId[];
+  conversationMedia?: ConversationMedia[];
+};

--- a/packages/types/HrmTypes/ConversationMedia.ts
+++ b/packages/types/HrmTypes/ConversationMedia.ts
@@ -1,0 +1,65 @@
+import { HrmAccountId } from '../HrmAccountId';
+
+type ConversationMediaCommons = {
+  id: number;
+  contactId: number;
+  accountSid: HrmAccountId;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export enum S3ContactMediaType {
+  RECORDING = 'recording',
+  TRANSCRIPT = 'transcript',
+}
+
+type NewTwilioStoredMedia = {
+  storeType: 'twilio';
+  storeTypeSpecificData: { reservationSid: string };
+};
+type TwilioStoredMedia = ConversationMediaCommons & NewTwilioStoredMedia;
+
+type NewS3StoredTranscript = {
+  storeType: 'S3';
+  storeTypeSpecificData: {
+    type: S3ContactMediaType.TRANSCRIPT;
+    location?: {
+      bucket: string;
+      key: string;
+    };
+  };
+};
+
+type NewS3StoredRecording = {
+  storeType: 'S3';
+  storeTypeSpecificData: {
+    type: S3ContactMediaType.RECORDING;
+    location?: {
+      bucket: string;
+      key: string;
+    };
+  };
+};
+export type S3StoredTranscript = ConversationMediaCommons & NewS3StoredTranscript;
+export type S3StoredRecording = ConversationMediaCommons & NewS3StoredRecording;
+export type S3StoredConversationMedia = S3StoredTranscript | S3StoredRecording;
+
+export type ConversationMedia = TwilioStoredMedia | S3StoredConversationMedia;
+
+export type NewConversationMedia =
+  | NewTwilioStoredMedia
+  | NewS3StoredTranscript
+  | NewS3StoredRecording;
+
+export const isTwilioStoredMedia = (m: ConversationMedia): m is TwilioStoredMedia =>
+  m.storeType === 'twilio';
+export const isS3StoredTranscript = (m: ConversationMedia): m is S3StoredTranscript =>
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  m.storeType === 'S3' && m.storeTypeSpecificData?.type === S3ContactMediaType.TRANSCRIPT;
+export const isS3StoredTranscriptPending = (m: ConversationMedia) =>
+  isS3StoredTranscript(m) && !m.storeTypeSpecificData?.location;
+export const isS3StoredRecording = (m: ConversationMedia): m is S3StoredRecording =>
+  m.storeType === 'S3' && m.storeTypeSpecificData?.type === S3ContactMediaType.RECORDING;
+export const isS3StoredConversationMedia = (
+  m: ConversationMedia,
+): m is S3StoredConversationMedia => isS3StoredTranscript(m) || isS3StoredRecording(m);

--- a/packages/types/HrmTypes/Referral.ts
+++ b/packages/types/HrmTypes/Referral.ts
@@ -13,16 +13,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { CaseSectionRecord, CaseSection } from '@tech-matters/types/HrmTypes';
 
-export { CaseSectionRecord, CaseSection };
-
-export type CaseSectionUpdate = Omit<
-  CaseSection,
-  'sectionId' | 'createdBy' | 'createdAt' | 'eventTimestamp' | 'sectionType'
-> & {
-  eventTimestamp?: string;
-};
-export type NewCaseSection = Omit<CaseSectionUpdate, 'updatedAt' | 'updatedBy'> & {
-  sectionId?: string;
+export type Referral = {
+  contactId: string;
+  resourceId: string;
+  referredAt: string;
+  resourceName?: string;
 };

--- a/packages/types/HrmTypes/index.ts
+++ b/packages/types/HrmTypes/index.ts
@@ -13,16 +13,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { CaseSectionRecord, CaseSection } from '@tech-matters/types/HrmTypes';
 
-export { CaseSectionRecord, CaseSection };
-
-export type CaseSectionUpdate = Omit<
-  CaseSection,
-  'sectionId' | 'createdBy' | 'createdAt' | 'eventTimestamp' | 'sectionType'
-> & {
-  eventTimestamp?: string;
-};
-export type NewCaseSection = Omit<CaseSectionUpdate, 'updatedAt' | 'updatedBy'> & {
-  sectionId?: string;
-};
+export * from './Contact';
+export * from './Referral';
+export * from './ConversationMedia';
+export * from './Case';
+export * from './CaseSection';


### PR DESCRIPTION
This PR is needed a prior step for https://github.com/techmatters/hrm/pull/634

## Description
This PR moves all types related to the root entities `Contact` and `Case` to a new module, `HrmTypes` under `@tech-matters/types` package. The reason for this is so we can share this types between `hrm-core` and different microservices (like the upcoming [search-index-consumer](https://github.com/techmatters/hrm/pull/634) function), so that we can have properly typed messages being exchanged between the different services. 

Disclaimer: I've tried avoiding this, as I thought that keeping the types in the `hrm-core` code would be better. This does not works since `hrm-core` will then need to be a dependency for the packages that want to use this types (like `hrm-search-config` elasticsearch config or the indexer itself), causing the builds to fail in several ways. I don't think having the types defined apart from the actual code is bad anyways. The types are re-exported from where they lived originally to avoid changing `hrm-core` as much as possible. Same work will be needed around the `Profile` types when the time comes, but for now trying to keep this as small as possible.


### Checklist
- [ ] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P