### PR TITLE
chore: publish pending index-search jobs on write/update ops for contacts [CHI-2724]

### DIFF
--- a/hrm-domain/hrm-core/contact-job/contact-job-complete.ts
+++ b/hrm-domain/hrm-core/contact-job/contact-job-complete.ts
@@ -20,6 +20,7 @@ import {
   completeContactJob,
   getContactJobById,
 } from './contact-job-data-access';
+import { updateConversationMediaData } from '../contact/contactService';
 import { ContactJobAttemptResult, ContactJobType } from '@tech-matters/types';
 import {
   ContactJobCompleteProcessorError,
@@ -41,7 +42,6 @@ import type {
 import {
   ConversationMedia,
   getConversationMediaById,
-  updateConversationMediaData,
 } from '../conversation-media/conversation-media';
 
 export const processCompletedRetrieveContactTranscript = async (
@@ -59,7 +59,7 @@ export const processCompletedRetrieveContactTranscript = async (
     location: completedJob.attemptPayload,
   };
 
-  return updateConversationMediaData(
+  return updateConversationMediaData(completedJob.contactId)(
     completedJob.accountSid,
     completedJob.conversationMediaId,
     storeTypeSpecificData,

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -59,6 +59,7 @@ import {
   isS3StoredTranscript,
   isS3StoredTranscriptPending,
   NewConversationMedia,
+  updateConversationMediaSpecificData,
 } from '../conversation-media/conversation-media';
 import { Profile, getOrCreateProfileWithIdentifier } from '../profile/profileService';
 import { deleteContactReferrals } from '../referral/referral-data-access';
@@ -463,3 +464,25 @@ export const getContactsByProfileId = async (
     });
   }
 };
+
+/**
+ * wrapper around updateSpecificData that also triggers a re-index operation when the conversation media gets updated (e.g. when transcript is exported)
+ */
+export const updateConversationMediaData =
+  (contactId: Contact['id']) =>
+  async (
+    ...[accountSid, id, storeTypeSpecificData]: Parameters<
+      typeof updateConversationMediaSpecificData
+    >
+  ): ReturnType<typeof updateConversationMediaSpecificData> => {
+    const result = await updateConversationMediaSpecificData(
+      accountSid,
+      id,
+      storeTypeSpecificData,
+    );
+
+    // trigger index operation but don't await for it
+    indexContactInSearchIndex({ accountSid, contactId });
+
+    return result;
+  };

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -175,7 +175,7 @@ const initProfile = async (
   });
 };
 
-const doOPContactInSearchIndex =
+const doContactInSearchIndexOP =
   (operation: IndexMessage['operation']) =>
   async ({
     accountSid,
@@ -189,8 +189,8 @@ const doOPContactInSearchIndex =
     await publishContactToSearchIndex({ accountSid, contact, operation });
   };
 
-export const indexContactInSearchIndex = doOPContactInSearchIndex('index');
-const removeContactInSearchIndex = doOPContactInSearchIndex('remove');
+export const indexContactInSearchIndex = doContactInSearchIndexOP('index');
+const removeContactInSearchIndex = doContactInSearchIndexOP('remove');
 
 // Creates a contact with all its related records within a single transaction
 export const createContact = async (

--- a/hrm-domain/hrm-core/contact/sql/contact-get-sql.ts
+++ b/hrm-domain/hrm-core/contact/sql/contact-get-sql.ts
@@ -21,6 +21,9 @@ import { selectCoalesceReferralsByContactId } from '../../referral/sql/referral-
 const ID_WHERE_CLAUSE = `WHERE c."accountSid" = $<accountSid> AND c."id" = $<contactId>`;
 const TASKID_WHERE_CLAUSE = `WHERE c."accountSid" = $<accountSid> AND c."taskId" = $<taskId>`;
 
+/**
+ * Note: this query is also used to index Contact records in ES. If the JOINs are ever removed from this query, make sure that the JOINs are preserved for the ES dedicated one
+ */
 export const selectContactsWithRelations = (table: string) => `
         SELECT c.*, reports."csamReports", joinedReferrals."referrals", media."conversationMedia"
         FROM "${table}" c 

--- a/hrm-domain/hrm-core/conversation-media/conversation-media-data-access.ts
+++ b/hrm-domain/hrm-core/conversation-media/conversation-media-data-access.ts
@@ -116,6 +116,9 @@ export const getByContactId = async (
     }),
   );
 
+/**
+ * NOTE: This function should not be used, but via the wrapper exposed from contact service. This is because otherwise, no contact re-index will be triggered.
+ */
 export const updateSpecificData = async (
   accountSid: HrmAccountId,
   id: ConversationMedia['id'],

--- a/hrm-domain/hrm-core/conversation-media/conversation-media.ts
+++ b/hrm-domain/hrm-core/conversation-media/conversation-media.ts
@@ -26,5 +26,5 @@ export {
   create as createConversationMedia,
   getById as getConversationMediaById,
   getByContactId as getConversationMediaByContactId,
-  updateSpecificData as updateConversationMediaData,
+  updateSpecificData as updateConversationMediaSpecificData,
 } from './conversation-media-data-access';

--- a/hrm-domain/hrm-core/jobs/search/publishToSearchIndex.ts
+++ b/hrm-domain/hrm-core/jobs/search/publishToSearchIndex.ts
@@ -26,6 +26,7 @@ const PENDING_INDEX_QUEUE_SSM_PATH = `/${process.env.NODE_ENV}/${
 
 const publishToSearchIndex = async (message: IndexMessage) => {
   try {
+    console.log('>>>> publishToSearchIndex invoked with message: ', message);
     const queueUrl = await getSsmParameter(PENDING_INDEX_QUEUE_SSM_PATH);
 
     return await sendSqsMessage({

--- a/hrm-domain/hrm-core/jobs/search/publishToSearchIndex.ts
+++ b/hrm-domain/hrm-core/jobs/search/publishToSearchIndex.ts
@@ -24,14 +24,24 @@ const PENDING_INDEX_QUEUE_SSM_PATH = `/${process.env.NODE_ENV}/${
   process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION
 }/sqs/jobs/hrm-search-index/queue-url-consumer`;
 
-const publishToSearchIndex = async (message: IndexMessage) => {
+const publishToSearchIndex = async ({
+  message,
+  messageGroupId,
+}: {
+  message: IndexMessage;
+  messageGroupId: string;
+}) => {
   try {
-    console.log('>>>> publishToSearchIndex invoked with message: ', message);
+    console.log(
+      '>>>> publishToSearchIndex invoked with message: ',
+      JSON.stringify(message),
+    );
     const queueUrl = await getSsmParameter(PENDING_INDEX_QUEUE_SSM_PATH);
 
     return await sendSqsMessage({
       queueUrl,
       message: JSON.stringify(message),
+      messageGroupId,
     });
   } catch (err) {
     console.error(
@@ -49,7 +59,11 @@ export const publishContactToSearchIndex = async ({
   accountSid: AccountSID;
   contact: Contact;
   operation: IndexMessage['operation'];
-}) => publishToSearchIndex({ accountSid, type: 'contact', contact, operation });
+}) =>
+  publishToSearchIndex({
+    message: { accountSid, type: 'contact', contact, operation },
+    messageGroupId: `${accountSid}-contact-${contact.id}`,
+  });
 
 export const publishCaseToSearchIndex = async ({
   accountSid,
@@ -59,4 +73,8 @@ export const publishCaseToSearchIndex = async ({
   accountSid: AccountSID;
   case: CaseService;
   operation: IndexMessage['operation'];
-}) => publishToSearchIndex({ accountSid, type: 'case', case: caseObj, operation });
+}) =>
+  publishToSearchIndex({
+    message: { accountSid, type: 'case', case: caseObj, operation },
+    messageGroupId: `${accountSid}-case-${caseObj.id}`,
+  });

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -145,6 +145,7 @@ describe('createContact', () => {
       identifierId: 1,
     });
 
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -173,6 +174,7 @@ describe('createContact', () => {
       identifierId: 2,
     });
 
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -207,6 +209,7 @@ describe('createContact', () => {
       identifierId: undefined,
     });
 
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -228,6 +231,7 @@ describe('createContact', () => {
       identifierId: 1,
     });
 
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -250,6 +254,7 @@ describe('createContact', () => {
       identifierId: 1,
     });
 
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 });
@@ -266,6 +271,8 @@ describe('connectContactToCase', () => {
       '4321',
       ALWAYS_CAN.user.workerSid,
     );
+
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(result).toStrictEqual(mockContact);
   });
 
@@ -276,6 +283,7 @@ describe('connectContactToCase', () => {
     expect(
       connectContactToCase(accountSid, '1234', '4321', ALWAYS_CAN),
     ).rejects.toThrow();
+    expect(publishToSearchIndexSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -310,6 +318,8 @@ describe('patchContact', () => {
       samplePatch,
       ALWAYS_CAN,
     );
+
+    expect(publishToSearchIndexSpy).toHaveBeenCalled();
     expect(result).toStrictEqual(mockContact);
     expect(patchSpy).toHaveBeenCalledWith(accountSid, '1234', true, {
       updatedBy: contactPatcherSid,
@@ -333,6 +343,8 @@ describe('patchContact', () => {
     const patchSpy = jest.fn();
     jest.spyOn(contactDb, 'patch').mockReturnValue(patchSpy);
     patchSpy.mockResolvedValue(undefined);
+
+    expect(publishToSearchIndexSpy).not.toHaveBeenCalled();
     expect(
       patchContact(accountSid, contactPatcherSid, true, '1234', samplePatch, ALWAYS_CAN),
     ).rejects.toThrow();

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -34,6 +34,11 @@ import { ALWAYS_CAN, OPEN_CONTACT_ACTION_CONDITIONS } from '../mocks';
 import '@tech-matters/testing/expectToParseAsDate';
 import { openPermissions } from '../../permissions/json-permissions';
 import { RulesFile, TKConditionsSets } from '../../permissions/rulesMap';
+import * as publishToSearchIndex from '../../jobs/search/publishToSearchIndex';
+
+const publishToSearchIndexSpy = jest
+  .spyOn(publishToSearchIndex, 'publishContactToSearchIndex')
+  .mockImplementation(async () => Promise.resolve('Ok') as any);
 
 const accountSid = 'AC-accountSid';
 const workerSid = 'WK-WORKER_SID';

--- a/hrm-domain/hrm-service/Dockerfile
+++ b/hrm-domain/hrm-service/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache rsync \
     && npx tsc -b tsconfig.build.json \
     && cp -r hrm-domain/hrm-service/* /home/node/ \
     && mkdir -p /home/node/hrm-domain/ \
+    && cp -r hrm-domain/packages /home/node/hrm-domain/packages \
     && cp -r hrm-domain/hrm-core /home/node/hrm-domain/hrm-core \
     && cp -r hrm-domain/scheduled-tasks /home/node/hrm-domain/scheduled-tasks \
     && cp -r packages /home/node/ \

--- a/hrm-domain/hrm-service/service-tests/contact-job/contactJobCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/contactJobCleanup.test.ts
@@ -24,12 +24,10 @@ import {
   mockSuccessfulTwilioAuthentication,
 } from '@tech-matters/testing';
 import { createContactJob } from '@tech-matters/hrm-core/contact-job/contact-job-data-access';
-import {
-  isS3StoredTranscriptPending,
-  updateConversationMediaData,
-} from '@tech-matters/hrm-core/conversation-media/conversation-media';
+import { isS3StoredTranscriptPending } from '@tech-matters/hrm-core/conversation-media/conversation-media';
 import { S3ContactMediaType } from '@tech-matters/hrm-core/conversation-media/conversation-media';
 import { getById as getContactById } from '@tech-matters/hrm-core/contact/contactDataAccess';
+import { updateConversationMediaData } from '@tech-matters/hrm-core/contact/contactService';
 import * as cleanupContactJobsApi from '@tech-matters/contact-job-cleanup';
 import {
   completeContactJob,
@@ -206,7 +204,7 @@ describe('cleanupContactJobs', () => {
 
     job = await completeContactJob({ id: job.id, completionPayload });
     job = await backDateJob(job.id);
-    await updateConversationMediaData(
+    await updateConversationMediaData(contact.id)(
       accountSid,
       job.additionalPayload.conversationMediaId,
       completionPayload,

--- a/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
@@ -515,7 +515,7 @@ describe('complete retrieve-transcript job type', () => {
       // );
 
       const updateConversationMediaSpy = jest.spyOn(
-        conversationMediaApi,
+        contactApi,
         'updateConversationMediaData',
       );
 

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -23,13 +23,13 @@ import {
 import { CreateIndexConvertedDocument } from '@tech-matters/elasticsearch-client';
 import { IndexPayload, IndexPayloadCase, IndexPayloadContact } from './payload';
 
-const filterEmpty = <T extends CaseDocument | ContactDocument>(doc: T): T =>
+const filterUndefined = <T extends CaseDocument | ContactDocument>(doc: T): T =>
   Object.entries(doc).reduce((accum, [key, value]) => {
-    if (value) {
-      return { ...accum, [key]: value };
+    if (value === undefined) {
+      return accum;
     }
 
-    return accum;
+    return { ...accum, [key]: value };
   }, {} as T);
 
 export const convertContactToContactDocument = ({
@@ -71,7 +71,7 @@ export const convertContactToContactDocument = ({
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };
 
-  return filterEmpty(contactDocument);
+  return filterUndefined(contactDocument);
 };
 
 const convertCaseToCaseDocument = ({
@@ -130,7 +130,7 @@ const convertCaseToCaseDocument = ({
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };
 
-  return filterEmpty(caseDocument);
+  return filterUndefined(caseDocument);
 };
 
 const convertToContactIndexDocument = (payload: IndexPayload) => {


### PR DESCRIPTION
## Description
This PR makes usage of the SQS client introduced in https://github.com/techmatters/hrm/pull/644 to publish contacts after creation/updates operations performed.

Some considerations:
- There's not error handling in the calls to `publishContactToSearchIndex`, as it being a wrapper around `publishToSearchIndex` function, "swallows" any error/rejection and `console.error`s them. We'll, in a future PR, improve that logging as a mean to be used for monitoring. Currently we have no plans to "retry" failed messages, but we could do so if we find this erroring more often than expected (should not be the case).
- We don't use the publish function directly, instead we use two wrapper around it: `indexContactInSearchIndex` and `removeContactInSearchIndex`, as they will retrieve the contact from the DB before sending the payload. This is to avoid rewriting queries that do not return the latest version of a contact when the service itself does not needs it, and instead we defer to slightly less performing process to send the "to-index" messages (this is not a critical performance-sensitive operation anyways).
- In most cases, we don't `await` for the SQS payload to be sent, to avoid slowing unnecessarily down the users' requests.
- The only time we send a `remove` operation message is when a contact is disconnected from it's parent case, in order to keep the results as relevant as possible. In this scenario, we do `await` for the message to be delivered, as if we don't, the update on the contact will prevent us from knowing which was the parent case before (we could do some SQL tricks or use the audits table for this purpose, but I think is reasonable to keep this one exception simpler at the cost of a slightly slower "disconnect case-contact" operation). 

TODO:
- [ ] Add service tests
- [ ] Add localstack and test the integratio nend to end?

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2724)
- [x] New tests added
- [ ] Feature flags / configuration added

### Verification steps
- Make sure that the latest version of `search-index-consumer` lambda is deployed to development.
- Deploy this code to HRM development.
- Create and/or modify a few contacts, add them to cases, remove them from cases.
- Confirm by looking at `/aws/lambda/development-hrm-search-index-consumer` cloudwatch logs that the messages are being processed by the lambda consumer.
- Go to ElasticSearch console, and confirm by querying `development-us-east-1-hrm-shared` node that the contacts/cases are properly indexed.
  - `GET /acd8a2e89748318adf6ddff7df6948deaf-hrm-contacts/_search`
  - `GET /acd8a2e89748318adf6ddff7df6948deaf-hrm-cases/_search`


### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P