### PR TITLE
CHI-2769: Wrap the create contact call in a result type so it is handled correctly

### DIFF
--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -208,16 +208,19 @@ export const createContact = async (
         profileId,
         identifierId,
       };
-
+      const contactCreateResult = await create(conn)(accountSid, completeNewContact);
+      if (isErr(contactCreateResult)) {
+        return contactCreateResult;
+      }
       // create contact record (may return an existing one cause idempotence)
-      const { contact } = await create(conn)(accountSid, completeNewContact);
+      const { contact } = contactCreateResult.data;
       contact.referrals = [];
       contact.csamReports = [];
       contact.conversationMedia = [];
 
       const applyTransformations = bindApplyTransformations(can, user);
 
-      return newOk({ data: applyTransformations(contact) });
+      return newOkFromData(applyTransformations(contact));
     });
     if (isOk(result)) {
       return result.data;

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -64,7 +64,6 @@ import { Profile, getOrCreateProfileWithIdentifier } from '../profile/profileSer
 import { deleteContactReferrals } from '../referral/referral-data-access';
 import {
   DatabaseErrorResult,
-  inferPostgresErrorResult,
   isDatabaseUniqueConstraintViolationErrorResult,
 } from '../sql';
 import { systemUser } from '@tech-matters/twilio-worker-auth';
@@ -227,19 +226,18 @@ export const createContact = async (
     }
     // This operation can fail with a unique constraint violation if a contact with the same ID is being created concurrently
     // It should only every need to retry once, but we'll do it 3 times just in case
-    const postgresErrorResult = inferPostgresErrorResult(result.rawError);
     if (
-      isDatabaseUniqueConstraintViolationErrorResult(postgresErrorResult) &&
-      (postgresErrorResult.constraint === 'Contacts_taskId_accountSid_idx' ||
-        postgresErrorResult.constraint === 'Identifiers_identifier_accountSid')
+      isDatabaseUniqueConstraintViolationErrorResult(result) &&
+      (result.constraint === 'Contacts_taskId_accountSid_idx' ||
+        result.constraint === 'Identifiers_identifier_accountSid')
     ) {
       if (retries === 1) {
         console.log(
-          `Retrying createContact due to '${postgresErrorResult.constraint}' data constraint conflict - it should use the existing resource next attempt (retry #${retries})`,
+          `Retrying createContact due to '${result.constraint}' data constraint conflict - it should use the existing resource next attempt (retry #${retries})`,
         );
       } else {
         console.warn(
-          `Retrying createContact due to '${postgresErrorResult.constraint}' data constraint conflict  - it shouldn't have taken more than 1 retry to return the existing contact with this taskId but we are on retry #${retries} :-/`,
+          `Retrying createContact due to '${result.constraint}' data constraint conflict  - it shouldn't have taken more than 1 retry to return the existing contact with this taskId but we are on retry #${retries} :-/`,
         );
       }
     } else {

--- a/hrm-domain/hrm-core/unit-tests/contact/contactDataAccess.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactDataAccess.test.ts
@@ -21,6 +21,7 @@ import { ContactBuilder } from './contact-builder';
 import { NewContactRecord } from '../../contact/sql/contactInsertSql';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { OPEN_CONTACT_ACTION_CONDITIONS } from '../mocks';
+import { newOkFromData } from '@tech-matters/types';
 
 let conn: pgPromise.ITask<unknown>;
 
@@ -75,8 +76,11 @@ describe('create', () => {
     });
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({
-      contact: returnedContact,
-      isNewRecord: false,
+      ...newOkFromData({
+        contact: returnedContact,
+        isNewRecord: false,
+      }),
+      unwrap: expect.any(Function),
     });
   });
 
@@ -95,8 +99,11 @@ describe('create', () => {
     });
     const { isNewRecord, ...returnedContact } = returnValue;
     expect(created).toStrictEqual({
-      contact: returnedContact,
-      isNewRecord: true,
+      ...newOkFromData({
+        contact: returnedContact,
+        isNewRecord: true,
+      }),
+      unwrap: expect.any(Function),
     });
   });
 });

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -26,7 +26,7 @@ import {
 import { ContactBuilder } from './contact-builder';
 import { omit } from 'lodash';
 import { newTwilioUser } from '@tech-matters/twilio-worker-auth';
-import { newOk } from '@tech-matters/types';
+import { newOk, newOkFromData } from '@tech-matters/types';
 import * as profilesDB from '../../profile/profileDataAccess';
 import * as profilesService from '../../profile/profileService';
 import { NewContactRecord } from '../../contact/sql/contactInsertSql';
@@ -118,7 +118,8 @@ describe('createContact', () => {
   } = {}) => {
     const createContactMock = jest.fn(
       contactMockReturn ||
-        (() => Promise.resolve({ contact: mockContact, isNewRecord: true })),
+        (() =>
+          Promise.resolve(newOkFromData({ contact: mockContact, isNewRecord: true }))),
     );
     jest.spyOn(contactDb, 'create').mockReturnValue(createContactMock);
 

--- a/hrm-domain/hrm-service/Dockerfile
+++ b/hrm-domain/hrm-service/Dockerfile
@@ -36,6 +36,7 @@ RUN apk add --no-cache rsync \
     && cp -r hrm-domain/hrm-service/* /home/node/ \
     && mkdir -p /home/node/hrm-domain/ \
     && cp -r hrm-domain/hrm-core /home/node/hrm-domain/hrm-core \
+    && cp -r hrm-domain/packages /home/node/hrm-domain/packages \
     && cp -r hrm-domain/scheduled-tasks /home/node/hrm-domain/scheduled-tasks \
     && cp -r packages /home/node/ \
     && cp -r packages /home/node/ \

--- a/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
@@ -146,10 +146,9 @@ const insertSampleCases = async ({
       } else if (contactToCreate.rawJson) {
         delete contactToCreate.rawJson.categories;
       }
-      const { contact: savedContact } = await contactDb.create()(
-        accounts[i % accounts.length],
-        contactToCreate,
-      );
+      const { contact: savedContact } = (
+        await contactDb.create()(accounts[i % accounts.length], contactToCreate)
+      ).unwrap();
       connectedContact = await contactDb.connectToCase()(
         savedContact.accountSid,
         savedContact.id.toString(),
@@ -226,7 +225,8 @@ describe('/cases route', () => {
         contactToCreate.taskId = `TASK_SID`;
         contactToCreate.channelSid = `CHANNEL_SID`;
         contactToCreate.serviceSid = 'SERVICE_SID';
-        createdContact = (await contactDb.create()(accountSid, contactToCreate)).contact;
+        createdContact = (await contactDb.create()(accountSid, contactToCreate)).unwrap()
+          .contact;
         createdContact = await contactDb.connectToCase()(
           accountSid,
           createdContact.id.toString(),
@@ -505,7 +505,8 @@ describe('/cases route', () => {
           toCreate.channelSid = `CHANNEL_SID`;
           toCreate.serviceSid = 'SERVICE_SID';
           // Connects createdContact with createdCase2
-          createdContact = (await contactDb.create()(accountSid, toCreate)).contact;
+          createdContact = (await contactDb.create()(accountSid, toCreate)).unwrap()
+            .contact;
           createdContact = await contactDb.connectToCase()(
             accountSid,
             createdContact.id.toString(),

--- a/hrm-domain/hrm-service/service-tests/permissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/permissions.test.ts
@@ -155,8 +155,9 @@ describe('/permissions/:action route with contact objectType', () => {
           channelSid: 'channelSid',
           serviceSid: 'serviceSid',
         } as NewContactRecord;
-
-        const { contact: createdContact } = await contactDB.create()(accountSid, contact);
+        const { contact: createdContact } = (
+          await contactDB.create()(accountSid, contact)
+        ).unwrap();
         createdContacts[accountSid] = createdContact;
 
         await Promise.all(

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -72,11 +72,12 @@ describe('/profiles', () => {
     let defaultFlags: profilesDB.ProfileFlag[];
     beforeEach(async () => {
       existingProfiles = (await profilesDB.listProfiles(accountSid, {}, {})).profiles;
-      createdProfiles = await Promise.all(
-        profilesNames.map(name =>
-          profilesDB.createProfile()(accountSid, { name, createdBy: workerSid }),
-        ),
-      );
+      createdProfiles = [];
+      for (const name of profilesNames) {
+        createdProfiles.push(
+          await profilesDB.createProfile()(accountSid, { name, createdBy: workerSid }),
+        );
+      }
       defaultFlags = await profilesDB.getProfileFlagsForAccount(accountSid);
 
       const murray = createdProfiles.find(p => p.name === 'Murray');


### PR DESCRIPTION
## Description

Fixes the error handling / retry mechanism for constraint violations creating contacts

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Create multiple contacts (ideally 10), custom channels seem to trigger the error condition more often

- Ensure the form is always populated
- Ensure no 500s are logged creating the contact
- Search for HRM logs with the term 'Retrying createContact' - this is positive proof the retry is kicking in

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P