### PR TITLE
chore: factored out Profile and PostSurvey types

### DIFF
--- a/hrm-domain/hrm-core/post-survey/post-survey-data-access.ts
+++ b/hrm-domain/hrm-core/post-survey/post-survey-data-access.ts
@@ -14,21 +14,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { NewPostSurvey, PostSurvey } from '@tech-matters/hrm-types';
 import { db } from '../connection-pool';
 import { SELECT_POST_SURVEYS_BY_CONTACT_TASK } from './sql/post-survey-get-sql';
 import { insertPostSurveySql } from './sql/post-survey-insert-sql';
 
-export type NewPostSurvey = {
-  contactTaskId: string;
-  taskId: string;
-  data: Record<string, any>;
-};
-
-export type PostSurvey = NewPostSurvey & {
-  id: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
+export type { NewPostSurvey, PostSurvey };
 
 export const filterByContactTaskId = async (
   accountSid: string,

--- a/hrm-domain/hrm-core/profile/profileDataAccess.ts
+++ b/hrm-domain/hrm-core/profile/profileDataAccess.ts
@@ -14,14 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import {
-  NewIdentifierRecord,
-  NewProfileRecord,
+  type NewIdentifierRecord,
+  type NewProfileRecord,
   insertIdentifierSql,
   insertProfileSql,
   associateProfileToIdentifierSql,
 } from './sql/profile-insert-sql';
 import {
-  NewProfileFlagRecord,
+  type NewProfileFlagRecord,
   associateProfileToProfileFlagSql,
   disassociateProfileFromProfileFlagSql,
   getProfileFlagsByAccountSql,
@@ -31,67 +31,56 @@ import {
   deleteProfileFlagByIdSql,
 } from './sql/profile-flags-sql';
 import {
-  DatabaseErrorResult,
+  type DatabaseErrorResult,
   inferPostgresErrorResult,
   isDatabaseForeignKeyViolationErrorResult,
   isDatabaseUniqueConstraintViolationErrorResult,
-  OrderByDirectionType,
+  type OrderByDirectionType,
   txIfNotInOne,
 } from '../sql';
 import * as profileGetSql from './sql/profile-get-sql';
 import { db } from '../connection-pool';
 import {
-  NewProfileSectionRecord,
+  type NewProfileSectionRecord,
   getProfileSectionByIdSql,
   insertProfileSectionSql,
   updateProfileSectionByIdSql,
 } from './sql/profile-sections-sql';
 import {
-  OrderByColumnType,
-  ProfilesListFilters,
+  type OrderByColumnType,
+  type ProfilesListFilters,
   listProfilesSql,
 } from './sql/profile-list-sql';
 import { getPaginationElements } from '../search';
 import { TOUCH_PROFILE_SQL, updateProfileByIdSql } from './sql/profile-update.sql';
 import {
   ensureRejection,
-  ErrorResult,
   newErr,
   newOkFromData,
-  Result,
-  TwilioUserIdentifier,
-  HrmAccountId,
+  type ErrorResult,
+  type Result,
+  type HrmAccountId,
 } from '@tech-matters/types';
-import { TwilioUser } from '@tech-matters/twilio-worker-auth';
+import type { TwilioUser } from '@tech-matters/twilio-worker-auth';
+import type {
+  RecordCommons,
+  Identifier,
+  IdentifierWithProfiles,
+  ProfileWithRelationships,
+  Profile,
+  ProfileFlag,
+  ProfileSection,
+} from '@tech-matters/hrm-types';
 
 export { ProfilesListFilters } from './sql/profile-list-sql';
 
-type RecordCommons = {
-  id: number;
-  accountSid: HrmAccountId;
-  createdAt: Date;
-  updatedAt: Date;
-  createdBy: TwilioUserIdentifier;
-  updatedBy?: TwilioUserIdentifier;
-};
-
-export type Identifier = NewIdentifierRecord & RecordCommons;
-
-export type IdentifierWithProfiles = Identifier & { profiles: Profile[] };
-
-type ProfileFlagAssociation = {
-  id: ProfileFlag['id'];
-  validUntil: Date | null;
-};
-
-export type ProfileWithRelationships = Profile & {
-  identifiers: Identifier[];
-  profileFlags: ProfileFlagAssociation[];
-  profileSections: {
-    sectionType: ProfileSection['sectionType'];
-    id: ProfileSection['id'];
-  }[];
-  hasContacts: boolean;
+export type {
+  Identifier,
+  IdentifierWithProfiles,
+  ProfileWithRelationships,
+  Profile,
+  ProfileSection,
+  ProfileFlag,
 };
 
 type IdentifierParams =
@@ -152,8 +141,6 @@ export const createIdentifier =
 
     return txIfNotInOne<Identifier>(task, conn => conn.one(statement));
   };
-
-export type Profile = NewProfileRecord & RecordCommons;
 
 export const createProfile =
   (task?) =>
@@ -374,8 +361,6 @@ export const disassociateProfileFromProfileFlag =
       return profile;
     });
 
-export type ProfileFlag = NewProfileFlagRecord & RecordCommons;
-
 export const getProfileFlagsForAccount = async (
   accountSid: HrmAccountId,
 ): Promise<ProfileFlag[]> => {
@@ -435,12 +420,6 @@ export const createProfileFlag = async (
 
   return db.task<ProfileFlag>(async t => t.one(statement));
 };
-
-export type ProfileSection = NewProfileSectionRecord &
-  RecordCommons & {
-    createdBy: string;
-    updatedBy?: string;
-  };
 
 export const createProfileSection =
   (task?) =>

--- a/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-flags-sql.ts
@@ -14,23 +14,16 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import type {
+  NewProfileFlagRecord,
+  NewProfileFlagRecordCommons,
+} from '@tech-matters/hrm-types';
 import { pgp } from '../../connection-pool';
-import { TwilioUserIdentifier, HrmAccountId } from '@tech-matters/types';
 
-type NewRecordCommons = {
-  accountSid: HrmAccountId;
-  createdAt: Date;
-  updatedAt: Date;
-  createdBy: TwilioUserIdentifier;
-  updatedBy: TwilioUserIdentifier;
-};
-
-export type NewProfileFlagRecord = {
-  name: string;
-};
+export type { NewProfileFlagRecord };
 
 export const insertProfileFlagSql = (
-  profileFlag: NewProfileFlagRecord & NewRecordCommons,
+  profileFlag: NewProfileFlagRecord & NewProfileFlagRecordCommons,
 ) => `
   ${pgp.helpers.insert(
     profileFlag,
@@ -42,7 +35,7 @@ export const insertProfileFlagSql = (
 
 export const updateProfileFlagByIdSql = (
   profileFlag: Pick<NewProfileFlagRecord, 'name'> &
-    Pick<NewRecordCommons, 'updatedAt' | 'updatedBy'>,
+    Pick<NewProfileFlagRecordCommons, 'updatedAt' | 'updatedBy'>,
 ) => {
   const { updatedAt, updatedBy, name } = profileFlag;
   const profileFlagWithTimestamp = {
@@ -84,7 +77,7 @@ type AssociateProfileToProfileFlagParams = {
 };
 export const associateProfileToProfileFlagSql = (
   association: AssociateProfileToProfileFlagParams &
-    Omit<NewRecordCommons, 'createdBy' | 'updatedBy'>,
+    Omit<NewProfileFlagRecordCommons, 'createdBy' | 'updatedBy'>,
 ) => `
   ${pgp.helpers.insert(
     association,

--- a/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-insert-sql.ts
@@ -15,18 +15,18 @@
  */
 
 import { pgp } from '../../connection-pool';
-import { TwilioUserIdentifier, HrmAccountId } from '@tech-matters/types';
+import {
+  NewRecordCommons,
+  NewProfileRecord,
+  NewIdentifierRecord,
+  NewProfileToIdentifierRecord,
+} from '@tech-matters/hrm-types';
 
-export type NewRecordCommons = {
-  accountSid: HrmAccountId;
-  createdAt: Date;
-  updatedAt: Date;
-  createdBy: TwilioUserIdentifier;
-  updatedBy: TwilioUserIdentifier;
-};
-
-export type NewProfileRecord = {
-  name: string | null;
+export type {
+  NewRecordCommons,
+  NewProfileRecord,
+  NewIdentifierRecord,
+  NewProfileToIdentifierRecord,
 };
 
 export const insertProfileSql = (profile: NewProfileRecord & NewRecordCommons) => `
@@ -38,10 +38,6 @@ export const insertProfileSql = (profile: NewProfileRecord & NewRecordCommons) =
   RETURNING *
 `;
 
-export type NewIdentifierRecord = {
-  identifier: string;
-};
-
 export const insertIdentifierSql = (
   identifier: NewIdentifierRecord & NewRecordCommons,
 ) => `
@@ -52,11 +48,6 @@ ${pgp.helpers.insert(
 )}
 RETURNING *
 `;
-
-export type NewProfileToIdentifierRecord = {
-  profileId: number;
-  identifierId: number;
-};
 
 export const associateProfileToIdentifierSql = (
   profileToIdentifier: NewProfileToIdentifierRecord & {

--- a/hrm-domain/hrm-core/profile/sql/profile-sections-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-sections-sql.ts
@@ -14,24 +14,16 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import {
+  NewProfileSectionRecord,
+  NewProfileSectionRecordCommons,
+} from '@tech-matters/hrm-types';
 import { pgp } from '../../connection-pool';
 
-type NewRecordCommons = {
-  accountSid: string;
-  createdBy: string;
-  updatedBy?: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type NewProfileSectionRecord = {
-  sectionType: string;
-  profileId: number;
-  content: string;
-};
+export type { NewProfileSectionRecord };
 
 export const insertProfileSectionSql = (
-  profileSection: NewProfileSectionRecord & NewRecordCommons,
+  profileSection: NewProfileSectionRecord & NewProfileSectionRecordCommons,
 ) => `
   ${pgp.helpers.insert(
     profileSection,

--- a/hrm-domain/packages/hrm-types/PostSurvey.ts
+++ b/hrm-domain/packages/hrm-types/PostSurvey.ts
@@ -14,11 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './Contact';
-export * from './Referral';
-export * from './ConversationMedia';
-export * from './Case';
-export * from './CaseSection';
-export * from './Profile';
-export * from './PostSurvey';
-export * from './channelTypes';
+export type NewPostSurvey = {
+  contactTaskId: string;
+  taskId: string;
+  data: Record<string, any>;
+};
+
+export type PostSurvey = NewPostSurvey & {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/hrm-domain/packages/hrm-types/Profile.ts
+++ b/hrm-domain/packages/hrm-types/Profile.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { HrmAccountId, TwilioUserIdentifier } from '@tech-matters/types';
+
+export type NewRecordCommons = {
+  accountSid: HrmAccountId;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: TwilioUserIdentifier;
+  updatedBy: TwilioUserIdentifier;
+};
+
+export type NewProfileRecord = {
+  name: string | null;
+};
+
+export type NewIdentifierRecord = {
+  identifier: string;
+};
+
+export type NewProfileToIdentifierRecord = {
+  profileId: number;
+  identifierId: number;
+};
+
+export type RecordCommons = {
+  id: number;
+  accountSid: HrmAccountId;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: TwilioUserIdentifier;
+  updatedBy?: TwilioUserIdentifier;
+};
+
+export type Identifier = NewIdentifierRecord & RecordCommons;
+
+export type IdentifierWithProfiles = Identifier & { profiles: Profile[] };
+
+export type NewProfileFlagRecordCommons = {
+  accountSid: HrmAccountId;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: TwilioUserIdentifier;
+  updatedBy: TwilioUserIdentifier;
+};
+
+export type NewProfileFlagRecord = {
+  name: string;
+};
+
+export type ProfileFlag = NewProfileFlagRecord & RecordCommons;
+
+type ProfileFlagAssociation = {
+  id: ProfileFlag['id'];
+  validUntil: Date | null;
+};
+
+export type Profile = NewProfileRecord & RecordCommons;
+
+export type NewProfileSectionRecordCommons = {
+  accountSid: string;
+  createdBy: string;
+  updatedBy?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type NewProfileSectionRecord = {
+  sectionType: string;
+  profileId: number;
+  content: string;
+};
+
+export type ProfileSection = NewProfileSectionRecord &
+  RecordCommons & {
+    createdBy: string;
+    updatedBy?: string;
+  };
+
+export type ProfileWithRelationships = Profile & {
+  identifiers: Identifier[];
+  profileFlags: ProfileFlagAssociation[];
+  profileSections: {
+    sectionType: ProfileSection['sectionType'];
+    id: ProfileSection['id'];
+  }[];
+  hasContacts: boolean;
+};


### PR DESCRIPTION
## Description
Not much to add other than what the title says, this get's in a better place since other modules will have access to all the entities types without the need of a dependency on `hrm-core`.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
- "If It Compiles, It Works" :stuck_out_tongue: 

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P