### PR TITLE
chore: Remove metadata from transcript before indexing ES [CHI-2794]

### DIFF
--- a/hrm-domain/lambdas/contact-retrieve-transcript/exportTranscript.ts
+++ b/hrm-domain/lambdas/contact-retrieve-transcript/exportTranscript.ts
@@ -19,6 +19,7 @@ import { getClient, TwilioClient } from '@tech-matters/twilio-client';
 import RestException from 'twilio/lib/base/RestException';
 import type { MemberInstance } from 'twilio/lib/rest/chat/v2/service/channel/member';
 import { HrmAccountId } from '@tech-matters/types';
+import { ExportTranscripParticipants, ExportTranscript } from '@tech-matters/hrm-types';
 
 export type ExportTranscriptParams = {
   accountSid: HrmAccountId;
@@ -27,14 +28,7 @@ export type ExportTranscriptParams = {
   channelSid: string;
 };
 
-export type ExportTranscriptResult = Awaited<ReturnType<typeof exportTranscript>>;
-
-export type ExportTranscripParticipants = {
-  [key: string]: {
-    user: Awaited<ReturnType<typeof getUser>>;
-    role: Awaited<ReturnType<typeof getRole>>;
-  };
-};
+export type ExportTranscriptResult = ExportTranscript;
 
 const GUEST_ROLE_CHANNEL = 'guest';
 
@@ -165,7 +159,7 @@ export const exportTranscript = async ({
   authToken,
   channelSid,
   serviceSid,
-}: ExportTranscriptParams) => {
+}: ExportTranscriptParams): Promise<ExportTranscriptResult> => {
   // eslint-disable-next-line no-console
   console.log(
     `Trying to export transcript with accountSid ${accountSid}, serviceSid ${serviceSid}, channelSid ${channelSid}`,

--- a/hrm-domain/lambdas/contact-retrieve-transcript/package.json
+++ b/hrm-domain/lambdas/contact-retrieve-transcript/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "AGPL",
   "dependencies": {
+    "@tech-matters/hrm-types": "^1.0.0",
     "@tech-matters/job-errors": "^1.0.0",
     "@tech-matters/s3-client": "^1.0.0",
     "@tech-matters/sqs-client": "^1.0.0",

--- a/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
+++ b/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
@@ -22,7 +22,11 @@ import {
   type IndexCaseMessage,
 } from '@tech-matters/hrm-search-config';
 import { assertExhaustive, type AccountSID } from '@tech-matters/types';
-import { isChatChannel, isS3StoredTranscript } from '@tech-matters/hrm-types';
+import {
+  ExportTranscript,
+  isChatChannel,
+  isS3StoredTranscript,
+} from '@tech-matters/hrm-types';
 import type { MessageWithMeta, MessagesByAccountSid } from './messages';
 
 /**
@@ -67,7 +71,9 @@ const contactIndexingInputData = async (
       const { location } = transcriptEntry.storeTypeSpecificData;
       const { bucket, key } = location || {};
       if (bucket && key) {
-        transcript = await getS3Object({ bucket, key });
+        const transcriptString = await getS3Object({ bucket, key });
+        const parsedTranscript: ExportTranscript = JSON.parse(transcriptString);
+        transcript = parsedTranscript.messages.map(({ body }) => body).join('\n');
       }
     }
   }

--- a/hrm-domain/packages/hrm-types/ConversationMedia.ts
+++ b/hrm-domain/packages/hrm-types/ConversationMedia.ts
@@ -79,3 +79,44 @@ export const isS3StoredRecording = (m: ConversationMedia): m is S3StoredRecordin
 export const isS3StoredConversationMedia = (
   m: ConversationMedia,
 ): m is S3StoredConversationMedia => isS3StoredTranscript(m) || isS3StoredRecording(m);
+
+export type ExportedTranscriptUser = {
+  sid: string;
+  accountSid: string;
+  serviceSid: string;
+  attributes: string;
+  friendlyName: string;
+  roleSid: string;
+  identity: string;
+  dateCreated: Date;
+  joinedChannelsCount: number;
+  links: string;
+  url: string;
+};
+
+export type ExportTranscripParticipants = {
+  [key: string]: {
+    user: ExportedTranscriptUser | null;
+    role: {
+      isCounselor: boolean;
+    } | null;
+  };
+};
+
+export type ExportTranscriptMessage = {
+  sid: string;
+  dateCreated: Date;
+  from: string;
+  body: string;
+  index: number;
+  type: string;
+  media: any;
+};
+
+export type ExportTranscript = {
+  accountSid: HrmAccountId;
+  serviceSid: string;
+  channelSid: string;
+  messages: ExportTranscriptMessage[];
+  participants: ExportTranscripParticipants;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,6 +220,7 @@
       "version": "1.0.0",
       "license": "AGPL",
       "dependencies": {
+        "@tech-matters/hrm-types": "^1.0.0",
         "@tech-matters/job-errors": "^1.0.0",
         "@tech-matters/s3-client": "^1.0.0",
         "@tech-matters/sqs-client": "^1.0.0",
@@ -17580,6 +17581,7 @@
     "@tech-matters/hrm-jobs-contact-retrieve-transcript": {
       "version": "file:hrm-domain/lambdas/contact-retrieve-transcript",
       "requires": {
+        "@tech-matters/hrm-types": "*",
         "@tech-matters/job-errors": "^1.0.0",
         "@tech-matters/s3-client": "^1.0.0",
         "@tech-matters/sqs-client": "^1.0.0",


### PR DESCRIPTION
## Description
This PR:
- Moves the types related to exported transcripts to `hrm-types` package.
- Removes all metadata from transcripts before indexing in ES, leaving only the messages' body.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2794)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P