### PR TITLE
fix: Correctly pull accounts to check for pending cleanup jobs [CHI-2859]

### DIFF
--- a/hrm-domain/hrm-core/contact-job/contact-job-data-access.ts
+++ b/hrm-domain/hrm-core/contact-job/contact-job-data-access.ts
@@ -169,12 +169,8 @@ export const getPendingCleanupJobs = async (
   );
 };
 
-export const getPendingCleanupJobAccountSids = async (
-  maxCleanupRetentionDays: number,
-): Promise<string[]> => {
-  const ret = await db.task(tx =>
-    tx.manyOrNone(PENDING_CLEANUP_JOB_ACCOUNT_SIDS_SQL, { maxCleanupRetentionDays }),
-  );
+export const getPendingCleanupJobAccountSids = async (): Promise<string[]> => {
+  const ret = await db.task(tx => tx.manyOrNone(PENDING_CLEANUP_JOB_ACCOUNT_SIDS_SQL));
   return ret?.map(r => r.accountSid);
 };
 

--- a/hrm-domain/hrm-core/contact-job/sql/contact-job-sql.ts
+++ b/hrm-domain/hrm-core/contact-job/sql/contact-job-sql.ts
@@ -61,7 +61,6 @@ export const PENDING_CLEANUP_JOB_ACCOUNT_SIDS_SQL = `
   WHERE
     "cleanupStatus" = '${ContactJobCleanupStatus.PENDING}'
     AND "completed" IS NOT NULL
-    AND "completed" < (current_timestamp - interval '$<maxCleanupRetentionDays> day')
 `;
 
 export const PULL_DUE_JOBS_SQL = `

--- a/hrm-domain/hrm-service/service-tests/contact-job/contactJobCleanup.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/contactJobCleanup.test.ts
@@ -57,7 +57,7 @@ const completionPayload = {
 
 const backDateJob = (jobId: string) =>
   db.oneOrNone(
-    `UPDATE "ContactJobs" SET "completed" = (current_timestamp - interval '366 day') WHERE "id" = $1 RETURNING *`,
+    `UPDATE "ContactJobs" SET "completed" = (current_timestamp - interval '3660 day') WHERE "id" = $1 RETURNING *`,
     [jobId],
   );
 

--- a/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact-job/jobTypes/retrieveTranscript.test.ts
@@ -191,6 +191,8 @@ describe('publish retrieve-transcript job type', () => {
       return callback as any;
     });
 
+    expect(publishRetrieveContactTranscriptSpy).toHaveBeenCalledTimes(0);
+
     const processorIntervalCallback =
       contactJobProcessor.processContactJobs() as unknown as () => Promise<void>;
 

--- a/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
@@ -162,9 +162,7 @@ const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> 
  */
 export const cleanupContactJobs = async (): Promise<void> => {
   try {
-    const accountSids = await getPendingCleanupJobAccountSids(
-      MAX_CLEANUP_JOB_RETENTION_DAYS,
-    );
+    const accountSids = await getPendingCleanupJobAccountSids();
 
     console.log(`Cleaning up contact jobs for accounts:`, accountSids);
 

--- a/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
@@ -35,7 +35,7 @@ import {
   isS3StoredTranscriptPending,
 } from '@tech-matters/hrm-core/conversation-media/conversation-media';
 
-const MAX_CLEANUP_JOB_RETENTION_DAYS = 365;
+const MAX_CLEANUP_JOB_RETENTION_DAYS = 3650;
 
 /**
  * Delete the twilio channel associated with a completed transcript job

--- a/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
@@ -129,6 +129,10 @@ const cleanupContactJob = async (job: ContactJob): Promise<void> => {
  * @returns number of days to retain cleanup jobs
  */
 const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> => {
+  console.log(
+    '>>>>> getCleanupRetentionDays looking for',
+    `/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`,
+  );
   let ssmRetentionDays: number;
   try {
     ssmRetentionDays =
@@ -137,6 +141,7 @@ const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> 
           `/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`,
         ),
       ) || MAX_CLEANUP_JOB_RETENTION_DAYS;
+    console.log('>>>>> ssmRetentionDays:', ssmRetentionDays);
   } catch (err) {
     console.error(
       `Error trying to fetch /${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days ${err}, using default`,

--- a/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
@@ -129,10 +129,7 @@ const cleanupContactJob = async (job: ContactJob): Promise<void> => {
  * @returns number of days to retain cleanup jobs
  */
 const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> => {
-  console.log(
-    '>>>>> getCleanupRetentionDays looking for',
-    `/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`,
-  );
+  console.log(`/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`);
   let ssmRetentionDays: number;
   try {
     ssmRetentionDays =
@@ -141,7 +138,6 @@ const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> 
           `/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`,
         ),
       ) || MAX_CLEANUP_JOB_RETENTION_DAYS;
-    console.log('>>>>> ssmRetentionDays:', ssmRetentionDays);
   } catch (err) {
     console.error(
       `Error trying to fetch /${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days ${err}, using default`,

--- a/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
+++ b/hrm-domain/scheduled-tasks/contact-job-cleanup/index.ts
@@ -129,7 +129,6 @@ const cleanupContactJob = async (job: ContactJob): Promise<void> => {
  * @returns number of days to retain cleanup jobs
  */
 const getCleanupRetentionDays = async (accountSid): Promise<number | undefined> => {
-  console.log(`/${process.env.NODE_ENV}/hrm/${accountSid}/transcript_retention_days`);
   let ssmRetentionDays: number;
   try {
     ssmRetentionDays =


### PR DESCRIPTION
## Description
This PR fixes yet one more bug around "cleanup jobs".

Basically, before we were only marking accounts as for cleanup check only if they had a `pending` job that was older than `MAX_CLEANUP_JOB_RETENTION_DAYS` (currently set to 1 year).
This PR removes that condition, marking accounts as for cleanup check if they have at least a pending job. We then check, for each account, if there are due due cleanup jobs.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2859)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
See link in this message.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P