### PR TITLE
fix: date ranges filters generalized search

### DIFF
--- a/hrm-domain/hrm-core/case/caseSearchIndex.ts
+++ b/hrm-domain/hrm-core/case/caseSearchIndex.ts
@@ -58,8 +58,8 @@ const buildSearchFilters = ({
         field: 'createdAt',
         type: 'range',
         ranges: {
-          ...(dateFrom && { lte: new Date(dateFrom).toISOString() }),
-          ...(dateTo && { gte: new Date(dateTo).toISOString() }),
+          ...(dateFrom && { gte: new Date(dateFrom).toISOString() }),
+          ...(dateTo && { lte: new Date(dateTo).toISOString() }),
         },
       } as const),
   ].filter(Boolean);

--- a/hrm-domain/hrm-core/contact/contactSearchIndex.ts
+++ b/hrm-domain/hrm-core/contact/contactSearchIndex.ts
@@ -54,8 +54,8 @@ const buildSearchFilters = ({
         field: 'timeOfContact',
         type: 'range',
         ranges: {
-          ...(dateFrom && { lte: new Date(dateFrom).toISOString() }),
-          ...(dateTo && { gte: new Date(dateTo).toISOString() }),
+          ...(dateFrom && { gte: new Date(dateFrom).toISOString() }),
+          ...(dateTo && { lte: new Date(dateTo).toISOString() }),
         },
       } as const),
   ].filter(Boolean);


### PR DESCRIPTION
## Description
This PR fixes a bug where setting "date from" or "date to" filters in the search would return empty sets.
This bug was caused because.. I got "less than" and "greater than" operators inverted xD.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
Easier to test in the actual development, so either deploy the branch and test search, or trust me and test after this one is merged :stuck_out_tongue:  

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P