### PR TITLE
chore: add migration to sanitize hyphens from phone number identifiers [CHI-2873]

### DIFF
--- a/hrm-domain/hrm-service/migrations/20240726181829-sanitize-identifiers-remove-hyphens.js
+++ b/hrm-domain/hrm-service/migrations/20240726181829-sanitize-identifiers-remove-hyphens.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      -- Fix the contacts for the conflicting records
+      UPDATE "Contacts" SET "profileId" = sanitized."targetProfile", "identifierId" = sanitized."targetId"
+      FROM (
+        --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+        SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile"
+        FROM "Identifiers" "main" 
+        INNER JOIN (
+          SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
+			    JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
+          WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
+			    GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
+        ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+        INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
+        ORDER BY replace("identifier", '-', '')
+      ) AS sanitized WHERE "identifierId" = sanitized."conflictId" AND "identifierId" != sanitized."targetId"
+    `);
+    console.log('Contacts fixed');
+
+    await queryInterface.sequelize.query(`
+      DELETE FROM "Profiles" WHERE "id" IN (
+        SELECT "p2i"."profileId" AS "conflictProfileId"
+        FROM (
+          --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+          SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile"
+          FROM "Identifiers" "main" 
+          INNER JOIN (
+            SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
+			      JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
+          	WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
+			      GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
+          ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+          INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
+          ORDER BY replace("identifier", '-', '')
+        ) AS "sanitized"
+        INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "sanitized"."conflictId" AND "p2i"."identifierId" != "sanitized"."targetId"
+      )
+    `);
+    console.log('Conflicting profiles deleted');
+
+    await queryInterface.sequelize.query(`
+      DELETE FROM "Identifiers" WHERE "id" IN (
+        SELECT "idx"."id" AS "conflictIdentifierId"
+        FROM (
+          --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
+          SELECT "main"."id" AS "conflictId", "grouped"."targetId"
+          FROM "Identifiers" "main" 
+          INNER JOIN (
+            SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
+			      JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
+          	WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
+			      GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
+          ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+          ORDER BY replace("identifier", '-', '')
+        ) AS "sanitized"
+        INNER JOIN "Identifiers" "idx" ON "idx"."id" = "sanitized"."conflictId" AND "idx"."id" != "sanitized"."targetId"
+      )
+    `);
+    console.log('Conflicting identifiers deleted');
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Identifiers" "idx" SET "identifier" = replace("idx"."identifier", '-', '')
+      FROM (
+        SELECT DISTINCT identifiers.* FROM "Identifiers" identifiers
+        JOIN "Contacts" contacts ON identifiers.id = contacts."identifierId"
+        WHERE identifiers.identifier LIKE '%-%' AND contacts."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
+      ) AS "hyphened" WHERE "idx"."id" = "hyphened"."id"
+    `);
+    console.log('hyphened identifiers sanitized');
+  },
+
+  down: async () => {},
+};


### PR DESCRIPTION
## Description
This PR adds an SQL script (migration) that attempts to fix the issues we've seen with phone numbers containing hyphens.
See https://github.com/techmatters/flex-plugins/pull/2461 or the linked jira ticket for more context.

The script is composed of 4 different steps:
- Fix the contacts for the conflicting records:
  This step will gather the information about possibly conflicting contacts, and update them using the minimal identifier (lowest `id`).
  ![image](https://github.com/user-attachments/assets/6b27d4b1-1506-402f-abfb-316b6281364b)
- Delete conflicting profiles:
  This step deletes all the profiles from the above result where `"identifierId" = "sanitized"."conflictId" AND ."identifierId" != "sanitized"."targetId"`, that is, the "duplicates" that are not related the minimal identifier.
  This includes only the profile related to identifier `14` from the above screenshot.
- Delete conflicting identifiers:
  This step deletes all the identifiers from the above result where `"identifierId" = "sanitized"."conflictId" AND ."identifierId" != "sanitized"."targetId"`, that is, the "duplicates" that are not the minimal identifier.
  This includes only the identifier `14` from the above screenshot.
- Update remaining identifiers:
  This step runs a `UPDATE "Identifiers" "idx" SET "identifier" = replace("idx"."identifier", '-', '')` on all the remaining identifiers that contain `-`, but were left in the DB because they are the minimal identifier.
  This includes both identifiers `1` and `8` from the above screenshot, as those were the minimal identifiers but they contained hyphens.

NOTE: All this queries use a clause like
```
JOIN "Contacts" contacts ON identifiers.id = contacts."identifierId"
WHERE identifiers.identifier LIKE '%-%' AND contacts."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
```
to target only those identifiers (and related profiles and contacts) that belong to phone numbers, leaving untouched any other channels. This is because there are, for example, e-mail identifiers that contain hyphens, and we don't want to mess with those.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2873)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
I have a DB dump to set conflicting records and then test this migration. I'm happy to share it and/or join a call and go over this together, to confirm it does what is expected.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P