### PR TITLE
chore: fix sanitize-hypen migration

### DIFF
--- a/hrm-domain/hrm-service/migrations/20240726181829-sanitize-identifiers-remove-hyphens.js
+++ b/hrm-domain/hrm-service/migrations/20240726181829-sanitize-identifiers-remove-hyphens.js
@@ -19,74 +19,53 @@
 module.exports = {
   up: async queryInterface => {
     await queryInterface.sequelize.query(`
-      -- Fix the contacts for the conflicting records
-      UPDATE "Contacts" SET "profileId" = sanitized."targetProfile", "identifierId" = sanitized."targetId"
-      FROM (
+      BEGIN;
+
+      CREATE TEMPORARY TABLE "sanitized" AS (
         --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
         SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile"
         FROM "Identifiers" "main" 
         INNER JOIN (
           SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
-			    JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
-          WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
-			    GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
+          GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
         ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
+        INNER JOIN "Contacts" "contacts" ON "main"."id" = "contacts"."identifierId" AND "main"."accountSid" = "contacts"."accountSid"
         INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
+        WHERE "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
         ORDER BY replace("identifier", '-', '')
-      ) AS sanitized WHERE "identifierId" = sanitized."conflictId" AND "identifierId" != sanitized."targetId"
-    `);
-    console.log('Contacts fixed');
+      );
 
-    await queryInterface.sequelize.query(`
+      -- Fix the contacts for the conflicting records
+      UPDATE "Contacts" 
+      SET "profileId" = "sanitized"."targetProfile", "identifierId" = "sanitized"."targetId"
+      FROM "sanitized" 
+      WHERE "identifierId" = "sanitized"."conflictId" AND "identifierId" != sanitized."targetId";
+
       DELETE FROM "Profiles" WHERE "id" IN (
         SELECT "p2i"."profileId" AS "conflictProfileId"
-        FROM (
-          --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
-          SELECT "main"."id" AS "conflictId", "main"."accountSid", "grouped"."targetId", "p2i"."profileId" AS "targetProfile"
-          FROM "Identifiers" "main" 
-          INNER JOIN (
-            SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
-			      JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
-          	WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
-			      GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
-          ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
-          INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "grouped"."targetId"
-          ORDER BY replace("identifier", '-', '')
-        ) AS "sanitized"
+        FROM "sanitized"
         INNER JOIN "ProfilesToIdentifiers" "p2i" ON "p2i"."identifierId" = "sanitized"."conflictId" AND "p2i"."identifierId" != "sanitized"."targetId"
-      )
-    `);
-    console.log('Conflicting profiles deleted');
-
-    await queryInterface.sequelize.query(`
+      );
+      
       DELETE FROM "Identifiers" WHERE "id" IN (
         SELECT "idx"."id" AS "conflictIdentifierId"
-        FROM (
-          --- All identifiers with conflicts, plus the "target id" which is the minimal id that matches the sanitized identifier
-          SELECT "main"."id" AS "conflictId", "grouped"."targetId"
-          FROM "Identifiers" "main" 
-          INNER JOIN (
-            SELECT "idx"."accountSid", replace("idx"."identifier", '-', '') AS "sanitized", MIN("idx"."id") AS "targetId" FROM "Identifiers" "idx"
-			      JOIN "Contacts" "contacts" ON "idx"."id" = "contacts"."identifierId"
-          	WHERE "idx"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
-			      GROUP BY "idx"."accountSid", replace("idx"."identifier", '-', '') HAVING COUNT(*) > 1
-          ) "grouped" ON replace("main"."identifier", '-', '')="grouped"."sanitized" AND "main"."accountSid"="grouped"."accountSid"
-          ORDER BY replace("identifier", '-', '')
-        ) AS "sanitized"
+        FROM "sanitized"
         INNER JOIN "Identifiers" "idx" ON "idx"."id" = "sanitized"."conflictId" AND "idx"."id" != "sanitized"."targetId"
-      )
-    `);
-    console.log('Conflicting identifiers deleted');
+      );
 
-    await queryInterface.sequelize.query(`
       UPDATE "Identifiers" "idx" SET "identifier" = replace("idx"."identifier", '-', '')
       FROM (
-        SELECT DISTINCT identifiers.* FROM "Identifiers" identifiers
-        JOIN "Contacts" contacts ON identifiers.id = contacts."identifierId"
-        WHERE identifiers.identifier LIKE '%-%' AND contacts."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
-      ) AS "hyphened" WHERE "idx"."id" = "hyphened"."id"
+        SELECT DISTINCT "identifiers".* 
+        FROM "Identifiers" "identifiers"
+        JOIN "Contacts" "contacts" ON "identifiers"."id" = "contacts"."identifierId" AND "identifiers"."accountSid" = "contacts"."accountSid"
+        WHERE "identifiers"."identifier" LIKE '%-%' AND "contacts"."channel" IN ('voice', 'whatsapp', 'sms', 'modica')
+      ) AS "hyphened" 
+      WHERE "idx"."id" = "hyphened"."id";
+
+      DROP TABLE IF EXISTS "sanitized";
+
+      COMMIT;
     `);
-    console.log('hyphened identifiers sanitized');
   },
 
   down: async () => {},


### PR DESCRIPTION
## Description
This PR fixes the issue this migration had, causing it to error and spam logs to our monitoring tools.

The issues were actually two:
- The target identifiers to fix were not being properly addressed. To fix this issue, the JOIN on Contacts using phone-like channels is un-nested from the "broken identifiers", serving as a post-filter to leave out non-phone channels.
- The `sanitized` query, used in the 4 steps of the migration was modified after each execution, preventing the deletion of "non-minimal conflicting identifiers". To fix this issue, the `sanitized` records are stored at the beginning of the transaction in temporary table that is destroyed at the end.

I've tested running the migration against staging, and it looks like it does as intended - removed all the hyphened phone-like identifiers, but preserved other identifiers that contained hyphens like emails and custom channels.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P