### PR TITLE
CHI-1734: Reference Attributes endpoints

### DIFF
--- a/resources-domain/resources-service/src/referenceAttributes/referenceAttributeDataAccess.ts
+++ b/resources-domain/resources-service/src/referenceAttributes/referenceAttributeDataAccess.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { AccountSID } from '@tech-matters/types';
+
+import { db } from '../connection-pool';
+import { SELECT_RESOURCE_REFERENCE_ATTRIBUTES_BY_LIST_SQL } from './sql';
+
+export type ResourceReferenceAttributeStringValue = {
+  value: string;
+  id: string;
+  info: any;
+  language: string;
+};
+
+export const getByList = async (
+  accountSid: AccountSID,
+  list: string,
+  language: string | undefined,
+  valueStartsWith: string | undefined,
+): Promise<ResourceReferenceAttributeStringValue[]> => {
+  const res = await db.task(async t =>
+    t.manyOrNone(SELECT_RESOURCE_REFERENCE_ATTRIBUTES_BY_LIST_SQL, {
+      accountSid,
+      list,
+      language: language || undefined, // Ensure any falsy value is converted to undefined so to be NULL for the query
+      valueLikePattern: valueStartsWith ? `${valueStartsWith}%` : undefined,
+    }),
+  );
+  console.debug(
+    `Retrieved ${res.length} reference attributes from list ${list}, language ${language}, values starting with: '${valueStartsWith}'`,
+  );
+  return res;
+};

--- a/resources-domain/resources-service/src/referenceAttributes/referenceAttributeRoutesV0.ts
+++ b/resources-domain/resources-service/src/referenceAttributes/referenceAttributeRoutesV0.ts
@@ -15,30 +15,25 @@
  */
 
 import { IRouter, Router } from 'express';
-import resourceRoutes from './resource/resourceRoutesV0';
-import importRoutes from './import/importRoutesV0';
-import adminSearchRoutes from './admin/adminSearchRoutesV0';
-import { AdminSearchServiceConfiguration } from './admin/adminSearchService';
-import referenceAttributeRoutes from './referenceAttributes/referenceAttributeRoutesV0';
+import { referenceAttributeService } from './referenceAttributeService';
+import { AccountSID } from '@tech-matters/types';
 
-export const apiV0 = () => {
+const referenceAttributeRoutes = () => {
   const router: IRouter = Router();
+  const { getResourceReferenceAttributeList } = referenceAttributeService();
 
-  router.use(resourceRoutes());
-  router.use('/reference-attributes', referenceAttributeRoutes());
+  router.get('/:list', async (req, res) => {
+    const { valueStartsWith, language } = req.query;
+    const { list } = req.params;
+    const result = await getResourceReferenceAttributeList(
+      req.hrmAccountId as AccountSID,
+      list,
+      language as string,
+      valueStartsWith as string,
+    );
+    res.json(result);
+  });
+
   return router;
 };
-
-export const internalApiV0 = () => {
-  const router: IRouter = Router();
-
-  router.use(importRoutes());
-  return router;
-};
-
-export const adminApiV0 = (config: AdminSearchServiceConfiguration) => {
-  const router: IRouter = Router();
-
-  router.use(adminSearchRoutes(config));
-  return router;
-};
+export default referenceAttributeRoutes;

--- a/resources-domain/resources-service/src/referenceAttributes/referenceAttributeService.ts
+++ b/resources-domain/resources-service/src/referenceAttributes/referenceAttributeService.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { AccountSID } from '@tech-matters/types';
+
+import { getByList } from './referenceAttributeDataAccess';
+
+export const referenceAttributeService = () => {
+  return {
+    getResourceReferenceAttributeList: async (
+      accountSid: AccountSID,
+      list: string,
+      language: string,
+      valuePrefix: string,
+    ) => getByList(accountSid, list, language, valuePrefix),
+  };
+};

--- a/resources-domain/resources-service/src/referenceAttributes/sql.ts
+++ b/resources-domain/resources-service/src/referenceAttributes/sql.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export const SELECT_RESOURCE_REFERENCE_ATTRIBUTES_BY_LIST_SQL = `
+  SELECT "id", "value","language","info" FROM "ResourceReferenceStringAttributeValues" 
+  WHERE "accountSid" = $<accountSid> AND 
+  "list" = $<list> AND 
+  ($<language> IS NULL OR "language"=$<language>) AND 
+  ($<valueLikePattern> IS NULL OR "value" LIKE $<valueLikePattern>)`;

--- a/resources-domain/resources-service/tests/service/referenceAttributes.test.ts
+++ b/resources-domain/resources-service/tests/service/referenceAttributes.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { HrmAccountId } from '@tech-matters/types';
+
+import { mockingProxy, mockSuccessfulTwilioAuthentication } from '@tech-matters/testing';
+import { headers, getRequest, getServer } from './server';
+import { db } from '../../src/connection-pool';
+import each from 'jest-each';
+import { pgp } from '../../src/connection-pool';
+import { ResourceReferenceAttributeStringValue } from '../../src/referenceAttributes/referenceAttributeDataAccess';
+
+export const workerSid = 'WK-worker-sid';
+
+const server = getServer();
+const request = getRequest(server);
+
+const testReferenceAttributeValueSeed: (ResourceReferenceAttributeStringValue & {
+  accountSid: HrmAccountId;
+  list: string;
+})[] = [
+  {
+    accountSid: 'AC1',
+    list: 'the-list',
+    value: 'path/structured/value',
+    id: 'baseline',
+    language: 'en',
+    info: { some: 'info' },
+  },
+  {
+    accountSid: 'AC1',
+    list: 'the-list',
+    value: 'path/structured/value',
+    id: 'french',
+    language: 'fr',
+    info: { quelques: 'infos' },
+  },
+  {
+    accountSid: 'AC1',
+    list: 'the-list',
+    value: 'path/structured',
+    id: 'ancestor',
+    language: 'en',
+    info: { some: 'info' },
+  },
+  {
+    accountSid: 'AC1',
+    list: 'the-list',
+    value: 'path/structured/other-value',
+    id: 'other value',
+    language: 'en',
+    info: { some: 'info' },
+  },
+  {
+    accountSid: 'AC1',
+    list: 'the-list',
+    value: 'path/also-structured/value',
+    id: 'other path',
+    language: 'en',
+    info: { some: 'info' },
+  },
+  {
+    accountSid: 'AC1',
+    list: 'other-list',
+    value: 'path/structured/value',
+    id: 'other list',
+    language: 'en',
+    info: { some: 'info' },
+  },
+  {
+    accountSid: 'AC2',
+    list: 'the-list',
+    value: 'path/structured/value',
+    id: 'other account',
+    language: 'en',
+    info: { some: 'info' },
+  },
+];
+
+afterAll(done => {
+  mockingProxy.stop().finally(() => {
+    server.close(done);
+  });
+});
+
+afterAll(async () => {
+  await db.none(`
+DELETE FROM resources."ResourceReferenceStringAttributeValues";
+      `);
+});
+
+beforeAll(async () => {
+  await mockingProxy.start();
+  await mockSuccessfulTwilioAuthentication(workerSid);
+  await db.none(`
+DELETE FROM resources."ResourceReferenceStringAttributeValues";
+      `);
+
+  const testResourceCreateSql = testReferenceAttributeValueSeed
+    .map(fieldValues =>
+      pgp.helpers.insert(
+        fieldValues,
+        ['accountSid', 'list', 'value', 'id', 'language', 'info'],
+        { schema: 'resources', table: 'ResourceReferenceStringAttributeValues' },
+      ),
+    )
+    .join(';\n');
+  // console.log(testResourceCreateSql); // handy for debugging
+  await db.multi(testResourceCreateSql);
+});
+
+/*
+ * This function expects attributes to have been applied in a specific pattern (as defined in the beforeAll step):
+ * - Each resource has a number of attributes equal to its index
+ * - Even numbered attributes have 1 value, odd numbered attributes have 2 values
+ * - Each value has the same info
+ * - Each value has the same language
+ */
+const verifyReferenceAttributes = (
+  expectedIds: string[],
+  attributeValues: ResourceReferenceAttributeStringValue[],
+) => {
+  expectedIds.forEach(id => {
+    const attribute = attributeValues.find(att => att.id === id);
+    const seedAttribute = testReferenceAttributeValueSeed.find(att => att.id === id);
+    expect(seedAttribute).toBeTruthy(); // If this fails, fix your test!
+    // Redundant IF clause but it will keep typescript happy
+    if (seedAttribute) {
+      const { accountSid, list, ...expectedAttributes } = seedAttribute;
+      expect(attribute).toMatchObject(expectedAttributes);
+    }
+  });
+  expect(attributeValues.length).toBe(expectedIds.length);
+};
+
+describe('GET /reference-attributes/:list', () => {
+  const basePath = '/v0/accounts/AC1/resources/reference-attributes';
+
+  test('No auth headers - should return 401 unauthorized with no auth headers', async () => {
+    const response = await request.get(basePath);
+    expect(response.status).toBe(401);
+    expect(response.body).toStrictEqual({ error: 'Authorization failed' });
+  });
+
+  type TestCase = {
+    description: string;
+    valueStartsWith?: string;
+    language?: string;
+    expectedIds: string[];
+    list?: string;
+  };
+
+  const testCases: TestCase[] = [
+    {
+      description: 'No query arguments - returns full specified list for all languages',
+      expectedIds: ['baseline', 'french', 'ancestor', 'other value', 'other path'],
+    },
+    {
+      description:
+        'Language query arguments - returns full specified list for specified language only',
+      language: 'en',
+      expectedIds: ['baseline', 'ancestor', 'other value', 'other path'],
+    },
+    {
+      description:
+        'valueStartsWithFilter set - returns specified list with filter applied for all languages',
+      valueStartsWith: 'path/structured/',
+      expectedIds: ['baseline', 'other value', 'french'],
+    },
+    {
+      description:
+        'valueStartsWithFilter and language set- returns specified list with filter applied for specified language',
+      valueStartsWith: 'path/structured/',
+      language: 'en',
+      expectedIds: ['baseline', 'other value'],
+    },
+    {
+      description:
+        'valueStartsWithFilter and language set- returns specified list with filter applied for specified language',
+      list: 'not-even-a-list',
+      expectedIds: [],
+    },
+  ];
+
+  each(testCases).test(
+    '$description',
+    async ({ valueStartsWith, language, expectedIds, list = 'the-list' }: TestCase) => {
+      const queryItems = Object.entries({ valueStartsWith, language }).filter(
+        ([, value]) => value,
+      );
+      const queryString = queryItems.map(([k, v]) => `${k}=${v}`).join('&');
+      const response = await request
+        .get(`${basePath}/${list}${queryString.length ? '?' : ''}${queryString}`)
+        .set(headers);
+      console.log(response.body);
+      verifyReferenceAttributes(expectedIds, response.body);
+    },
+  );
+});


### PR DESCRIPTION
## Description

Add endpoint to load lists of reference attributes used in the resource search UI, optionally filtered on value prefix and language

This is primarily to bring down the Flex bundle size

### Checklist
- [X] Corresponding issue has been opened
- [X] New tests added
- N/A Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

With a version of Flex with this PR:

Regression test location filters in the resource search feature

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P