### PR TITLE
CHI-2896: permission reject logging

### DIFF
--- a/hrm-domain/hrm-core/case/canPerformCaseAction.ts
+++ b/hrm-domain/hrm-core/case/canPerformCaseAction.ts
@@ -49,8 +49,14 @@ export const canPerformCaseAction = (
       const canEdit = actions.every(action => can(user, action, caseObj));
 
       if (canEdit) {
+        console.debug(
+          `[Permission - PERMITTED] User ${user.workerSid} is permitted to perform ${actions} on case ${hrmAccountId}/${id}`,
+        );
         req.permit();
       } else {
+        console.debug(
+          `[Permission - BLOCKED] User ${user.workerSid} is not permitted to perform ${actions} on case ${hrmAccountId}/${id} - rules failure`,
+        );
         if (notFoundIfNotPermitted) throw createError(404);
         req.block();
       }

--- a/hrm-domain/hrm-core/case/canPerformCaseAction.ts
+++ b/hrm-domain/hrm-core/case/canPerformCaseAction.ts
@@ -33,7 +33,7 @@ export const canPerformCaseAction = (
   notFoundIfNotPermitted = false,
 ) =>
   asyncHandler(async (req, res, next) => {
-    if (!req.isAuthorized()) {
+    if (!req.isPermitted()) {
       const { hrmAccountId, user, can } = req;
       const id = getCaseIdFromRequest(req);
       const caseObj = await getCase(id, hrmAccountId, {
@@ -49,10 +49,10 @@ export const canPerformCaseAction = (
       const canEdit = actions.every(action => can(user, action, caseObj));
 
       if (canEdit) {
-        req.authorize();
+        req.permit();
       } else {
         if (notFoundIfNotPermitted) throw createError(404);
-        req.unauthorize();
+        req.block();
       }
     }
 

--- a/hrm-domain/hrm-core/contact/contactRoutesV0.ts
+++ b/hrm-domain/hrm-core/contact/contactRoutesV0.ts
@@ -230,7 +230,7 @@ contactsRouter.get('/:contactId', canPerformViewContactAction, async (req, res) 
   if (!contact) {
     throw createError(404);
   }
-  if (!req.isAuthorized()) {
+  if (!req.isPermitted()) {
     if (!can(user, actionsMaps.contact.VIEW_CONTACT, contact)) {
       createError(401);
     }

--- a/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
+++ b/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
@@ -43,8 +43,14 @@ const canViewPostSurvey = (req: RequestWithPermissions, res, next) => {
 
     // Nothing from the target param is being used for postSurvey target kind, we can pass null for now
     if (can(user, actionsMaps.postSurvey.VIEW_POST_SURVEY, null)) {
+      console.debug(
+        `[Permission - PERMITTED] User ${user.workerSid} is permitted to perform ${actionsMaps.postSurvey.VIEW_POST_SURVEY} on account ${req.hrmAccountId}`,
+      );
       req.permit();
     } else {
+      console.debug(
+        `[Permission - BLOCKED] User ${user.workerSid} is not permitted to perform ${actionsMaps.postSurvey.VIEW_POST_SURVEY} on account ${req.hrmAccountId}`,
+      );
       req.block();
     }
   }

--- a/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
+++ b/hrm-domain/hrm-core/post-survey/post-survey-routes-v0.ts
@@ -38,14 +38,14 @@ postSurveysRouter.post(
 );
 
 const canViewPostSurvey = (req: RequestWithPermissions, res, next) => {
-  if (!req.isAuthorized()) {
+  if (!req.isPermitted()) {
     const { user, can } = req;
 
     // Nothing from the target param is being used for postSurvey target kind, we can pass null for now
     if (can(user, actionsMaps.postSurvey.VIEW_POST_SURVEY, null)) {
-      req.authorize();
+      req.permit();
     } else {
-      req.unauthorize();
+      req.block();
     }
   }
 

--- a/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
+++ b/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
@@ -70,9 +70,9 @@ export const canPerformActionOnProfileMiddleware = (
     }
 
     if (result.data.isAllowed) {
-      req.authorize();
+      req.permit();
     } else {
-      req.unauthorize();
+      req.block();
     }
 
     next();
@@ -143,9 +143,9 @@ export const canPerformActionOnProfileSectionMiddleware = (
     }
 
     if (result.data.isAllowed) {
-      req.authorize();
+      req.permit();
     } else {
-      req.unauthorize();
+      req.block();
     }
 
     next();

--- a/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
+++ b/hrm-domain/hrm-core/profile/canPerformProfileAction.ts
@@ -70,8 +70,14 @@ export const canPerformActionOnProfileMiddleware = (
     }
 
     if (result.data.isAllowed) {
+      console.debug(
+        `[Permission - PERMITTED] User ${user.workerSid} is permitted to perform ${action} on ${hrmAccountId}/${profileId}`,
+      );
       req.permit();
     } else {
+      console.debug(
+        `[Permission - BLOCKED] User ${user.workerSid} is not permitted to perform ${action} on ${hrmAccountId}/${profileId} - rules failure`,
+      );
       req.block();
     }
 

--- a/hrm-domain/hrm-service/service-tests/contact/connectToCase.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/connectToCase.test.ts
@@ -332,7 +332,7 @@ describe('/contacts/:contactId/connectToCase route', () => {
 
             expect(contact.caseId).toBe(existingCaseId);
           } else {
-            expect(response.status).toBe(401);
+            expect(response.status).toBe(403);
           }
         },
       );
@@ -408,7 +408,7 @@ describe('/contacts/:contactId/connectToCase route', () => {
 
             expect(contact.caseId).toBe(null);
           } else {
-            expect(response.status).toBe(401);
+            expect(response.status).toBe(403);
           }
         },
       );

--- a/hrm-domain/hrm-service/service-tests/contact/contactPatch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactPatch.test.ts
@@ -433,7 +433,7 @@ describe('/contacts/:contactId route', () => {
           .set(headers)
           .send({ conversationDuration: 1337 });
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(403);
       });
 
       type FullPatchTestOptions = {
@@ -567,7 +567,7 @@ describe('/contacts/:contactId route', () => {
       expect(response.status).toBe(404);
     });
 
-    test("Draft contact edited by a user that didn't create or own the contact - returns 401", async () => {
+    test("Draft contact edited by a user that didn't create or own the contact - returns 403", async () => {
       const createdContact = await contactApi.createContact(
         accountSid,
         'WK another creator',
@@ -583,7 +583,7 @@ describe('/contacts/:contactId route', () => {
         .set(headers)
         .send();
 
-      expect(response.status).toBe(401);
+      expect(response.status).toBe(403);
     });
 
     test('Draft contact edited by a user that owns the contact - returns 200', async () => {

--- a/packages/http/index.ts
+++ b/packages/http/index.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export { unauthorized } from './unauthorized';
+export { unauthorized, forbidden } from './unauthorized';
 export {
   configureDefaultPostMiddlewares,
   configureDefaultPreMiddlewares,

--- a/packages/http/unauthorized.ts
+++ b/packages/http/unauthorized.ts
@@ -22,3 +22,10 @@ export const unauthorized = (res: Response) => {
   res.status(401).json(authorizationFailed);
   return authorizationFailed;
 };
+
+export const forbidden = (res: Response) => {
+  const notPermitted = { error: 'Action not permitted' };
+  console.log(`[authorizationMiddleware]: ${JSON.stringify(notPermitted)}`);
+  res.status(403).json(notPermitted);
+  return notPermitted;
+};


### PR DESCRIPTION
## Description

We are getting mysterious clusters of 401s in production which seem to be related to permissions rather than expired tokens. To get better insight into this I want to align our rejection errors with HTTP standards and add logging

* Changed unauthorize / authorize terminology to permit / block to prevent confusion around authentication checks vs permission checks
* Changed permission rejections to throw 403s
* Added logging specifically around permission check outcomes

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P