### PR TITLE
Add tags to ECS tasks

### DIFF
--- a/.github/workflows/hrm-ecs-deploy.yml
+++ b/.github/workflows/hrm-ecs-deploy.yml
@@ -144,6 +144,7 @@ jobs:
           service: ${{ inputs.environment }}-job-processor
           cluster: ${{ inputs.environment }}-ecs-cluster
           wait-for-service-stability: true
+          tags: Environment:${{ inputs.environment }}
 
       - name: Download current ECS task definition for the api service
         run: aws ecs describe-task-definition --task-definition ${{ inputs.environment }}-hrm-task --query taskDefinition > task-definition.json
@@ -163,6 +164,7 @@ jobs:
           service: ${{ inputs.environment }}-ecs-service
           cluster: ${{ inputs.environment }}-ecs-cluster
           wait-for-service-stability: true
+          tags: Environment:${{ inputs.environment }}
 
       - name: Download current ECS task definition for scheduled tasks
         run: aws ecs describe-task-definition --task-definition ${{ inputs.environment }}-hrm-scheduled-task --query taskDefinition > task-definition-hrm-scheduled-task.json


### PR DESCRIPTION
## Goal

I want to be able to track our AWS spend by environment (eg prod/staging/dev). This is easy to do when our AWS resources all have an `Environment` tag.

One of our major costs is our running ECS tasks for HRM and the job processor. For some weird reason, it seems that in order to divide costs, the _tasks themselves_ need to be tagged. Tagging the clusters or services is insufficient.

I have manually added a tag [here](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/production-ecs-cluster/services/production-ecs-service/tasks/2c2ce94726be4255ba88a944c8b0d643/tags?region=us-east-1) and it seems to be tracking costs as desired.

![image](https://github.com/user-attachments/assets/131cb668-66ab-4ab0-acf5-c9b75d1b6584)

This draft PR is my attempt to have these tags created as part of our automated deploys. I could use a little help from someone in seeing if this is correct and testing it out.

### Checklist
- [ ] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Feature flags / configuration added

### Verification steps
- After a deploy, check that the ECS tasks for HRM and the job processor have the appropriate tags.
- After a couple days, look at the [billing and cost explorer](https://us-east-1.console.aws.amazon.com/costmanagement/home?region=us-east-1#/cost-explorer?chartStyle=GROUP&costAggregate=unBlendedCost&endDate=2024-08-16&excludeForecasting=false&filter=%5B%7B%22dimension%22:%7B%22id%22:%22Service%22,%22displayValue%22:%22Service%22%7D,%22operator%22:%22INCLUDES%22,%22values%22:%5B%7B%22value%22:%22Amazon%20Elastic%20Container%20Service%22,%22displayValue%22:%22Elastic%20Container%20Service%22%7D%5D%7D%5D&futureRelativeRange=CUSTOM&granularity=Monthly&groupBy=%5B%22CostCategory:By%20Helpline%22%5D&historicalRelativeRange=CUSTOM&isDefault=true&reportName=New%20cost%20and%20usage%20report&showOnlyUncategorized=false&showOnlyUntagged=false&startDate=2024-08-13&usageAggregate=undefined&useNormalizedUnits=false) in AWS to confirm that ECS charges are correctly categorized.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P