### PR TITLE
chore: added "Non Data Contact" toggle behavior to Generalized Search [CHI-2933]

### DIFF
--- a/hrm-domain/hrm-core/contact/contactDataAccess.ts
+++ b/hrm-domain/hrm-core/contact/contactDataAccess.ts
@@ -40,7 +40,7 @@ import {
   newOkFromData,
 } from '@tech-matters/types';
 
-import { ExistingContactRecord, Contact } from '@tech-matters/hrm-types';
+import { ExistingContactRecord, Contact, dataCallTypes } from '@tech-matters/hrm-types';
 
 export { ExistingContactRecord, Contact };
 
@@ -86,12 +86,6 @@ const BLANK_CONTACT_UPDATES: ContactUpdates = {
   caseId: undefined,
   twilioWorkerId: undefined,
   conversationDuration: undefined,
-};
-
-// Intentionally adding only the types of interest here
-const callTypes = {
-  child: 'Child calling about self',
-  caller: 'Someone calling about a child',
 };
 
 type QueryParams = {
@@ -157,7 +151,7 @@ const searchParametersToQueryParameters = (
     accountSid,
     twilioWorkerSid: workerSid,
 
-    dataCallTypes: Object.values(callTypes),
+    dataCallTypes: Object.values(dataCallTypes),
     limit,
     offset,
   };

--- a/hrm-domain/hrm-core/contact/contactSearchIndex.ts
+++ b/hrm-domain/hrm-core/contact/contactSearchIndex.ts
@@ -35,10 +35,12 @@ const buildSearchFilters = ({
   counselor,
   dateFrom,
   dateTo,
+  onlyDataContacts,
 }: {
   counselor?: string;
   dateFrom?: string;
   dateTo?: string;
+  onlyDataContacts?: boolean;
 }): DocumentTypeQueryParams[DocumentType.Contact][] => {
   const searchFilters: DocumentTypeQueryParams[DocumentType.Contact][] = [
     counselor &&
@@ -58,6 +60,13 @@ const buildSearchFilters = ({
           ...(dateTo && { lte: new Date(dateTo).toISOString() }),
         },
       } as const),
+    onlyDataContacts &&
+      ({
+        documentType: DocumentType.Contact,
+        field: 'isDataContact',
+        type: 'term',
+        term: true,
+      } as const),
   ].filter(Boolean);
 
   return searchFilters;
@@ -67,6 +76,7 @@ export const generateContactSearchFilters = (p: {
   counselor?: string;
   dateFrom?: string;
   dateTo?: string;
+  onlyDataContacts?: boolean;
 }) => buildSearchFilters(p).map(generateESFilter);
 
 export type ContactListCondition = Extract<

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -502,6 +502,7 @@ export const generalisedContactSearch = async (
     counselor?: string;
     dateFrom?: string;
     dateTo?: string;
+    onlyDataContacts?: boolean;
   },
   query: Pick<PaginationQuery, 'limit' | 'offset'>,
   ctx: {
@@ -511,7 +512,8 @@ export const generalisedContactSearch = async (
   },
 ): Promise<TResult<'InternalServerError', { count: number; contacts: Contact[] }>> => {
   try {
-    const { searchTerm, counselor, dateFrom, dateTo } = searchParameters;
+    const { searchTerm, counselor, dateFrom, dateTo, onlyDataContacts } =
+      searchParameters;
     const { limit, offset } = query;
 
     const pagination = {
@@ -523,6 +525,7 @@ export const generalisedContactSearch = async (
       counselor,
       dateFrom,
       dateTo,
+      onlyDataContacts,
     });
     const permissionFilters = generateContactPermissionsFilters({
       user: ctx.user,

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -68,7 +68,8 @@ export const convertContactToContactDocument = ({
     transcript,
     twilioWorkerId,
     content: JSON.stringify(rawJson),
-    isDataContact: Object.values(dataCallTypes).includes(rawJson?.callType),
+    isDataContact:
+      Boolean(rawJson) && Object.values(dataCallTypes).includes(rawJson.callType),
     // high_boost_global: '', // highBoostGlobal.join(' '),
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -22,6 +22,7 @@ import {
 } from './hrmIndexDocumentMappings';
 import { CreateIndexConvertedDocument } from '@tech-matters/elasticsearch-client';
 import { IndexPayload, IndexPayloadCase, IndexPayloadContact } from './payload';
+import { dataCallTypes } from '@tech-matters/hrm-types';
 
 const filterUndefined = <T extends CaseDocument | ContactDocument>(doc: T): T =>
   Object.entries(doc).reduce((accum, [key, value]) => {
@@ -67,6 +68,7 @@ export const convertContactToContactDocument = ({
     transcript,
     twilioWorkerId,
     content: JSON.stringify(rawJson),
+    isDataContact: Object.values(dataCallTypes).includes(rawJson.callType),
     // high_boost_global: '', // highBoostGlobal.join(' '),
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -69,7 +69,7 @@ export const convertContactToContactDocument = ({
     twilioWorkerId,
     content: JSON.stringify(rawJson),
     isDataContact:
-      Boolean(rawJson) && Object.values(dataCallTypes).includes(rawJson.callType),
+      Boolean(rawJson) && Object.values(dataCallTypes).includes(rawJson!.callType),
     // high_boost_global: '', // highBoostGlobal.join(' '),
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -68,7 +68,7 @@ export const convertContactToContactDocument = ({
     transcript,
     twilioWorkerId,
     content: JSON.stringify(rawJson),
-    isDataContact: Object.values(dataCallTypes).includes(rawJson.callType),
+    isDataContact: Object.values(dataCallTypes).includes(rawJson?.callType),
     // high_boost_global: '', // highBoostGlobal.join(' '),
     // low_boost_global: '', // lowBoostGlobal.join(' '),
   };

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -60,7 +60,7 @@ export type DocumentTypeQueryParams = {
   [DocumentType.Case]: GenerateTDocQueryParams<DocumentType.Case>;
 };
 
-type GenerateTermQueryParams = { type: 'term'; term: string; boost?: number };
+type GenerateTermQueryParams = { type: 'term'; term: string | boolean; boost?: number };
 type GenerateRangeQueryParams = {
   type: 'range';
   ranges: { lt?: string; lte?: string; gt?: string; gte?: string };

--- a/hrm-domain/packages/hrm-search-config/hrmIndexDocumentMappings/mappings.ts
+++ b/hrm-domain/packages/hrm-search-config/hrmIndexDocumentMappings/mappings.ts
@@ -68,6 +68,9 @@ export const contactMapping = {
   transcript: {
     type: 'text',
   },
+  isDataContact: {
+    type: 'boolean',
+  },
 } as const;
 
 export const casePathToContacts = 'contacts' as const;

--- a/hrm-domain/packages/hrm-types/Contact.ts
+++ b/hrm-domain/packages/hrm-types/Contact.ts
@@ -72,3 +72,8 @@ export type Contact = ExistingContactRecord & {
   referrals?: ReferralWithoutContactId[];
   conversationMedia?: ConversationMedia[];
 };
+
+export const dataCallTypes = {
+  child: 'Child calling about self',
+  caller: 'Someone calling about a child',
+};


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/flex-plugins/pull/2512

## Description
This PR adds support for it's UI counterpart, to add "Non Data Contact" toggle behavior to Generalized Search. To do so:
- Contacts mapping has been modified to include `isDataContact` boolean property (ElasticSearch).
- When the contact is indexed, we compute above property by using `rawJson.callType`.
- When a search is performed, we add an addition filter: if `onlyDataContacts` is present in the query, we add a filter clause to match only contacts that have `isDataContact` field set to true.

IMPORTANT :bangbang: 
This changes require a complete reindex of all the documents.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2933)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
- Indexing lambda is already deployed so you can skip this step.
- Deploy this branch to HRM development server. Alternatively you can run this branch locally, point to dev DB and ES instaces, but that might be more effort :P
- Start a new local Flex using [this branch](https://github.com/techmatters/flex-plugins/pull/2512).
- After a search is performed, confirm that the "Non Data Contacts" toggle behaves as expected. Easiest way to do this is by checking that the amount of contacts greatly reduces if you set this toggle to `true`.
  - Ideally you can also check on HRM logs, where we are temporarily logging the search query, that it includes the appropriate filter on `isDataContact` field.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P