### PR TITLE
CHI-2936: Optimise profile query

### DIFF
--- a/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
+++ b/hrm-domain/hrm-core/profile/sql/profile-get-sql.ts
@@ -60,10 +60,6 @@ export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
 	  LEFT JOIN "ProfileSections" pps ON pps."profileId" = profile.id AND pps."accountSid" = profile."accountSid"
     GROUP BY pps."profileId"
   ),
-  
-  HasRelatedContacts AS (
-    SELECT COUNT(*) > 0 as "hasContacts", "profileId" FROM "Contacts" GROUP BY "profileId"
-  )
 
   SELECT
     tp.*,
@@ -77,7 +73,7 @@ export const getProfilesSqlBase = (selectTargetProfilesQuery: string) => `
   LEFT JOIN RelatedProfileFlags rpf ON profiles.id = rpf."profileId"
   LEFT JOIN RelatedProfileSections rps ON profiles.id = rps."profileId"
   -- Remove this hack once we have limited contact view permissions
-  LEFT JOIN HasRelatedContacts hrc ON profiles.id = hrc."profileId"
+  LEFT JOIN LATERAL (SELECT COUNT(*) > 0 as "hasContacts", "profileId", "accountSid" FROM "Contacts" c WHERE profiles.id = c."profileId" AND profiles."accountSid" = c."accountSid" GROUP BY "profileId", "accountSid") hrc ON true
 `;
 
 export const getProfileByIdSql = getProfilesSqlBase(`

--- a/hrm-domain/lambdas/search-index-consumer/index.ts
+++ b/hrm-domain/lambdas/search-index-consumer/index.ts
@@ -73,7 +73,7 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
         case 'contact': {
           const { contact } = message;
           console.info(
-            `[generalised-search-contacts]: Indexing Request Acknowledged By ES. Account SID: ${accountSid}, Case ID: ${
+            `[generalised-search-contacts]: Indexing Request Acknowledged By ES. Account SID: ${accountSid}, Contact ID: ${
               contact.id
             }, Updated / Created At: ${
               contact.updatedAt ?? contact.createdAt


### PR DESCRIPTION
## Description

The CTEs in the profiles query were grouping the entire contacts table using a full scan before running the main query. Replacing with an inline lateral join means we only group the relevant contacts

Spotted investigating the us-east-1 prod outages but doubt this is the root cause unfortunately

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P