### PR TITLE
chore: Migrate resource search to shared ES instance [CHI-2827]

### DIFF
--- a/packages/elasticsearch-client/src/executeBulk.ts
+++ b/packages/elasticsearch-client/src/executeBulk.ts
@@ -15,6 +15,7 @@
  */
 import { BulkRequest, BulkResponse } from '@elastic/elasticsearch/lib/api/types';
 import { PassThroughConfig } from './client';
+import createIndex from './createIndex';
 
 export type BulkOperation<T> = {
   id: string;
@@ -32,6 +33,7 @@ export type BulkOperations<T> = BulkOperation<T>[];
 
 export type ExecuteBulkExtraParams<T> = {
   documents: BulkOperations<T>;
+  autocreate?: boolean;
 };
 
 export type ExecuteBulkParams<T> = PassThroughConfig<T> & ExecuteBulkExtraParams<T>;
@@ -43,7 +45,14 @@ export const executeBulk = async <T>({
   index,
   indexConfig,
   documents,
+  autocreate = false,
 }: ExecuteBulkParams<T>): Promise<ExecuteBulkResponse> => {
+  if (autocreate) {
+    // const exists = await client.indices.exists({ index });
+    // NOTE: above check is already performed in createIndex
+    await createIndex({ client, index, indexConfig });
+  }
+
   const body: BulkRequest['operations'] = documents.flatMap(
     (documentItem): BulkRequest['operations'] => {
       if (documentItem.action === 'delete') {

--- a/resources-domain/lambdas/search-index/index.ts
+++ b/resources-domain/lambdas/search-index/index.ts
@@ -83,7 +83,11 @@ export const executeBulk = async (
     Object.keys(documentsByAccountSid).map(async accountSid => {
       const documents = documentsByAccountSid[accountSid];
       const client = (
-        await getClient({ accountSid, indexType: RESOURCE_INDEX_TYPE })
+        await getClient({
+          accountSid,
+          indexType: RESOURCE_INDEX_TYPE,
+          ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
+        })
       ).indexClient(resourceIndexConfiguration);
       try {
         const indexResp = await client.executeBulk({ documents });

--- a/resources-domain/lambdas/search-index/index.ts
+++ b/resources-domain/lambdas/search-index/index.ts
@@ -90,7 +90,7 @@ export const executeBulk = async (
         })
       ).indexClient(resourceIndexConfiguration);
       try {
-        const indexResp = await client.executeBulk({ documents });
+        const indexResp = await client.executeBulk({ documents, autocreate: true });
         await handleErrors(indexResp, addDocumentIdToFailures);
       } catch (err) {
         console.error(new ResourceIndexProcessorError('Error calling executeBulk'), err);


### PR DESCRIPTION
This PR is related to https://github.com/techmatters/infrastructure-config/pull/377.

## Description
This PR makes code changes to the `search-index` lambda needed for it to make usage of the new shared ElasticSearch instance. To do so:
- The indexing function is adjusted to allow for auto creation of indices.
- The lambda also points to the shared instance, by using the elastic search config provided as env var.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2827)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
See related PR.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P