### PR TITLE
Save training data as a valid JSON (array)

### DIFF
--- a/hrm-domain/scheduled-tasks/generate-ai-training-set/index.ts
+++ b/hrm-domain/scheduled-tasks/generate-ai-training-set/index.ts
@@ -96,14 +96,14 @@ export const generate = async (
             callback();
             return;
           }
-          const docJson = JSON.stringify(trainingSetDoc);
           await uploadTrainingSetDocument(
             trainingSetDoc.contactId,
-            docJson,
+            JSON.stringify(trainingSetDoc),
             targetBucket,
             shortCode,
           );
-          this.push(`${docJson}\n`);
+
+          this.push(trainingSetDoc);
           callback();
         },
       }),

--- a/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
+++ b/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
@@ -25,17 +25,43 @@ const fileTimestamp = (date: Date) =>
     .replace(/[:-]/g, '')
     .replace(/[T.].+/, '-');
 
+/**
+ * This function takes a stream of documents and wraps it in an array to be uploaded as a single file
+ */
+const buildStreamAsArray = (trainingSetDocumentStream: ReadableStream): PassThrough => {
+  const wrappedStream = new PassThrough({ objectMode: true });
+  wrappedStream.write('[');
+
+  let isFirstDocument = true;
+
+  trainingSetDocumentStream.on('data', doc => {
+    if (!isFirstDocument) {
+      wrappedStream.write(',');
+    } else {
+      isFirstDocument = false;
+    }
+
+    wrappedStream.write(JSON.stringify(doc));
+  });
+
+  trainingSetDocumentStream.on('end', () => wrappedStream.write(']'));
+
+  return wrappedStream;
+};
+
 export const uploadStreamAsSingleFile = async (
   trainingSetDocumentStream: ReadableStream,
   targetBucket: string,
   helplineCode: string,
 ) => {
+  const streamAsArray = buildStreamAsArray(trainingSetDocumentStream);
+
   const upload = new Upload({
     client: getNativeS3Client(),
     params: {
       Bucket: targetBucket,
       Key: `${helplineCode}/categoryTrainingSet_${fileTimestamp(new Date())}.json`,
-      Body: trainingSetDocumentStream.pipe(new PassThrough({ objectMode: false })),
+      Body: streamAsArray,
     },
   });
 

--- a/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
+++ b/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
@@ -44,7 +44,7 @@ const buildStreamAsArray = (trainingSetDocumentStream: ReadableStream): PassThro
     wrappedStream.write(JSON.stringify(doc));
   });
 
-  trainingSetDocumentStream.on('end', () => wrappedStream.write(']'));
+  trainingSetDocumentStream.on('end', () => wrappedStream.end(']'));
 
   return wrappedStream;
 };
@@ -61,7 +61,7 @@ export const uploadStreamAsSingleFile = async (
     params: {
       Bucket: targetBucket,
       Key: `${helplineCode}/categoryTrainingSet_${fileTimestamp(new Date())}.json`,
-      Body: streamAsArray.pipe(new PassThrough({ objectMode: false })),
+      Body: streamAsArray,
     },
   });
 

--- a/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
+++ b/hrm-domain/scheduled-tasks/generate-ai-training-set/uploadTrainingSet.ts
@@ -61,7 +61,7 @@ export const uploadStreamAsSingleFile = async (
     params: {
       Bucket: targetBucket,
       Key: `${helplineCode}/categoryTrainingSet_${fileTimestamp(new Date())}.json`,
-      Body: streamAsArray,
+      Body: streamAsArray.pipe(new PassThrough({ objectMode: false })),
     },
   });
 


### PR DESCRIPTION
## Description
This PR changes the content of `categoryTrainingSet_<date>-.json` to be a valid JSON file.
The JSON shoulbe be an array of documents.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
[CHI-2937](https://tech-matters.atlassian.net/browse/CHI-2937)

### Verification steps
Run the ECS Task with this code and check the output file.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P

[CHI-2937]: https://tech-matters.atlassian.net/browse/CHI-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ