### PR TITLE
chore: Generalized Search - add sort options for empty term and tiebreaker [CHI-2965]

### DIFF
--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -372,6 +372,10 @@ const generateContactsQuery = ({
     highlight: {
       fields: { '*': {} },
     },
+    sort:
+      searchParameters.searchTerm.length === 0
+        ? [{ updatedAt: 'desc' }]
+        : ['_score', { updatedAt: 'desc' }],
     min_score: MIN_SCORE,
     from: pagination.start,
     size: pagination.limit,
@@ -483,6 +487,10 @@ const generateCasesQuery = ({
     highlight: {
       fields: { '*': {} },
     },
+    sort:
+      searchParameters.searchTerm.length === 0
+        ? [{ updatedAt: 'desc' }]
+        : ['_score', { updatedAt: 'desc' }],
     min_score: MIN_SCORE,
     from: pagination.start,
     size: pagination.limit,

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -60,7 +60,11 @@ export type DocumentTypeQueryParams = {
   [DocumentType.Case]: GenerateTDocQueryParams<DocumentType.Case>;
 };
 
-type GenerateTermQueryParams = { type: 'term'; term: string | boolean; boost?: number };
+type GenerateTermQueryParams = {
+  type: 'term';
+  term: string | boolean | number;
+  boost?: number;
+};
 type GenerateRangeQueryParams = {
   type: 'range';
   ranges: { lt?: string; lte?: string; gt?: string; gte?: string };
@@ -193,15 +197,17 @@ const generateQueriesFromId = <TDoc extends DocumentType>({
   const queries = terms
     .map(term => {
       // Ignore terms that are not entirely a number, as that breaks term queries against integer fields
-      if (Number.isNaN(Number(term))) {
+      if (Number.isNaN(Number(term)) || !Number.isInteger(term)) {
         return null;
       }
+
+      const parsed = Number.parseInt(term, 10);
 
       return generateESQuery(
         queryWrapper({
           documentType,
           type: 'term',
-          term,
+          term: parsed,
           boost: boostFactor * BOOST_FACTORS.id,
           field: 'id' as any, // typecast to conform TS, only valid parameters should be accept
           parentPath,

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -205,7 +205,7 @@ const generateQueriesFromId = <TDoc extends DocumentType>({
       const parsed = Number.parseInt(term, 10);
 
       // Ignore numbers that are greater than maximum supported int
-      if (parsed > MAX_INT) {
+      if (parsed >= MAX_INT) {
         return null;
       }
 

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -33,6 +33,7 @@ const BOOST_FACTORS = {
   case: 3,
 };
 const MIN_SCORE = 0.1;
+const MAX_INT = 2147483648; // 2^31, the max integer allowed by ElasticSearch integer type
 
 export const FILTER_ALL_CLAUSE: QueryDslQueryContainer[][] = [
   [
@@ -202,6 +203,11 @@ const generateQueriesFromId = <TDoc extends DocumentType>({
       }
 
       const parsed = Number.parseInt(term, 10);
+
+      // Ignore numbers that are greater than maximum supported int
+      if (parsed > MAX_INT) {
+        return null;
+      }
 
       return generateESQuery(
         queryWrapper({

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -33,7 +33,7 @@ const BOOST_FACTORS = {
   case: 3,
 };
 const MIN_SCORE = 0.1;
-const MAX_INT = 2147483648; // 2^31, the max integer allowed by ElasticSearch integer type
+const MAX_INT = 2147483648 - 1; // 2^31 - 1, the max integer allowed by ElasticSearch integer type
 
 export const FILTER_ALL_CLAUSE: QueryDslQueryContainer[][] = [
   [
@@ -205,7 +205,7 @@ const generateQueriesFromId = <TDoc extends DocumentType>({
       const parsed = Number.parseInt(term, 10);
 
       // Ignore numbers that are greater than maximum supported int
-      if (parsed >= MAX_INT) {
+      if (parsed > MAX_INT) {
         return null;
       }
 


### PR DESCRIPTION
## Description
This PR:
- Adds a tiebreaker based on `updatedAt` for contacts and cases, if the ElasticSearch score is equal.
- Adds a default sort order based on `updatedAt` if the search is performed using an empty term (only filters).
- Adds safe guards against integers going over the ElasticSearch limit when adding queries over ids.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2965)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P