### PR TITLE
Reduce log spam

### DIFF
--- a/hrm-domain/hrm-core/contact-job/contact-job-processor.ts
+++ b/hrm-domain/hrm-core/contact-job/contact-job-processor.ts
@@ -50,14 +50,14 @@ export const JOB_MAX_ATTEMPTS = 20;
 
 export function processContactJobs() {
   if (!processingJobs) {
-    console.log(
+    console.info(
       `Started processing jobs every ${JOB_PROCESSING_INTERVAL_MILLISECONDS} milliseconds.`,
     );
     processingJobs = true;
 
     return setInterval(async () => {
       try {
-        console.debug(`processContactJobs sweep started.`);
+        // console.debug(`processContactJobs sweep started.`);
         await pollAndProcessCompletedContactJobs(JOB_MAX_ATTEMPTS);
         const now = new Date();
         let dueContactJobs: ContactJob[] = [];
@@ -80,7 +80,7 @@ export function processContactJobs() {
           }
         });
         await publishDueContactJobs(dueContactJobs);
-        console.debug(`processContactJobs sweep complete.`);
+        // console.debug(`processContactJobs sweep complete.`);
       } catch (err) {
         console.error(
           new ContactJobPollerError(

--- a/hrm-domain/hrm-core/contact-job/contact-job-publish.ts
+++ b/hrm-domain/hrm-core/contact-job/contact-job-publish.ts
@@ -91,7 +91,7 @@ export const publishScrubTranscriptJob = async (
 export const publishDueContactJobs = async (
   dueContactJobs: ContactJob[],
 ): Promise<PromiseSettledResult<PublishedContactJobResult>[]> => {
-  console.debug(`Processing ${dueContactJobs?.length} due contact jobs.`);
+  // console.debug(`Processing ${dueContactJobs?.length} due contact jobs.`);
   const publishedContactJobResult = await Promise.allSettled(
     dueContactJobs.map(async (dueJob: ContactJob) => {
       try {
@@ -127,7 +127,7 @@ export const publishDueContactJobs = async (
       }
     }),
   );
-  console.debug(`Processed ${dueContactJobs?.length} due contact jobs.`);
+  // console.debug(`Processed ${dueContactJobs?.length} due contact jobs.`);
 
   return publishedContactJobResult;
 };

--- a/lambdas/job-complete/index.ts
+++ b/lambdas/job-complete/index.ts
@@ -15,21 +15,16 @@
  */
 
 import { CompletedJobProcessorError } from '@tech-matters/job-errors';
-import { publishSns } from '@tech-matters/sns-client';
 
 // eslint-disable-next-line prettier/prettier
 import type { SQSBatchResponse, SQSEvent, SQSRecord } from 'aws-lambda';
 
-const processRecord = async (sqsRecord: SQSRecord) => {
+const processRecord = async ({ body, messageId, eventSource }: SQSRecord) => {
   try {
-    const res = await publishSns({
-      message: sqsRecord.body,
-      topicArn: process.env.SNS_TOPIC_ARN || '',
-    });
-
-    console.log(res);
+    console.log('Completed processing message:', messageId, eventSource);
+    console.debug(`Message body:`, body);
   } catch (err) {
-    console.error(new CompletedJobProcessorError('Failed to process record'), err);
+    console.error(new CompletedJobProcessorError('Failed to log completed record'), err);
   }
 };
 

--- a/lambdas/job-complete/package.json
+++ b/lambdas/job-complete/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@tech-matters/job-errors": "^1.0.0",
     "@tech-matters/ssm-cache": "^1.0.0",
-    "@tech-matters/sns-client": "^1.0.0",
     "@tech-matters/types": "^1.0.0"
   },
   "devDependencies": {

--- a/lambdas/job-complete/tsconfig.build.json
+++ b/lambdas/job-complete/tsconfig.build.json
@@ -6,7 +6,6 @@
     { "path": "packages/types" },
     { "path": "packages/job-errors" },
     { "path": "packages/ssm-cache" },
-    { "path": "packages/sns-client" },
     { "path": "lambdas/job-complete" }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -422,7 +422,6 @@
       "license": "AGPL",
       "dependencies": {
         "@tech-matters/job-errors": "^1.0.0",
-        "@tech-matters/sns-client": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
         "@tech-matters/types": "^1.0.0"
       },
@@ -25258,7 +25257,6 @@
       "version": "file:lambdas/job-complete",
       "requires": {
         "@tech-matters/job-errors": "^1.0.0",
-        "@tech-matters/sns-client": "^1.0.0",
         "@tech-matters/ssm-cache": "^1.0.0",
         "@tech-matters/types": "^1.0.0",
         "@tsconfig/node16": "^1.0.3",

--- a/packages/elasticsearch-client/src/createIndex.ts
+++ b/packages/elasticsearch-client/src/createIndex.ts
@@ -34,7 +34,7 @@ export const createIndex = async ({
   }
 
   const params = indexConfig.getCreateIndexParams(index);
-  console.log('Creating index', index, JSON.stringify(params, null, 2));
+  console.info('Creating index', index, JSON.stringify(params));
   const res = await client.indices.create(params);
 
   // This waits for the index to be created and for the shards to be allocated

--- a/packages/elasticsearch-client/src/search.ts
+++ b/packages/elasticsearch-client/src/search.ts
@@ -77,7 +77,7 @@ export const search = async <T>({
     index,
     searchParameters,
   });
-  console.debug('search query', JSON.stringify(query, null, 2));
+  console.debug('search query', JSON.stringify(query));
 
   const { hits } = await client.search(query);
   const total = getTotalValue(hits.total);

--- a/resources-domain/lambdas/search-index/index.ts
+++ b/resources-domain/lambdas/search-index/index.ts
@@ -135,13 +135,13 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
   try {
     // Map the messages and add the documentId to messageId mapping.
     const messages = mapMessages(event.Records, addDocumentIdToMessageId);
-    console.debug('Mapped messages:', JSON.stringify(messages, null, 2));
+    console.debug('Mapped messages:', JSON.stringify(messages));
 
     // Convert the messages to a bulk requests grouped by accountSid.
     const documentsByAccountSid = convertDocumentsToBulkRequest(messages);
     console.debug(
       'Converted documents to bulk request:',
-      JSON.stringify(documentsByAccountSid, null, 2),
+      JSON.stringify(documentsByAccountSid),
     );
 
     // Iterates over groups of documents and index them using an accountSid specific client

--- a/resources-domain/lambdas/search-index/index.ts
+++ b/resources-domain/lambdas/search-index/index.ts
@@ -135,13 +135,13 @@ export const handler = async (event: SQSEvent): Promise<SQSBatchResponse> => {
   try {
     // Map the messages and add the documentId to messageId mapping.
     const messages = mapMessages(event.Records, addDocumentIdToMessageId);
-    console.debug('Mapped messages:', JSON.stringify(messages));
+    console.debug('Mapped messages:', JSON.stringify(messages, null, 2));
 
     // Convert the messages to a bulk requests grouped by accountSid.
     const documentsByAccountSid = convertDocumentsToBulkRequest(messages);
     console.debug(
       'Converted documents to bulk request:',
-      JSON.stringify(documentsByAccountSid),
+      JSON.stringify(documentsByAccountSid, null, 2),
     );
 
     // Iterates over groups of documents and index them using an accountSid specific client

--- a/resources-domain/resources-service/package.json
+++ b/resources-domain/resources-service/package.json
@@ -44,6 +44,8 @@
     "es:delete-index:development": "cross-env NODE_ENV=development tsx ./scripts/elasticsearch/delete-index.ts",
     "es:create-index:staging": "cross-env NODE_ENV=staging tsx ./scripts/elasticsearch/create-index.ts",
     "es:delete-index:staging": "cross-env NODE_ENV=staging tsx ./scripts/elasticsearch/delete-index.ts",
+    "es:create-index:production": "cross-env NODE_ENV=production tsx ./scripts/elasticsearch/create-index.ts",
+    "es:delete-index:production": "cross-env NODE_ENV=production tsx ./scripts/elasticsearch/delete-index.ts",
     "es:create-index:local": "cross-env AWS_REGION=us-east-1 SSM_ENDPOINT=http://localhost:4566 NODE_ENV=local ELASTICSEARCH_CONFIG_node=http://localhost:9200 tsx ./scripts/elasticsearch/create-index.ts",
     "es:delete-index:local": "cross-env AWS_REGION=us-east-1 SSM_ENDPOINT=http://localhost:4566 NODE_ENV=local ELASTICSEARCH_CONFIG_node=http://localhost:9200 tsx ./scripts/elasticsearch/delete-index.ts",
     "build-scripts": "tsc --project tsconfig.scripts.json",

--- a/resources-domain/resources-service/src/resource/resourceService.ts
+++ b/resources-domain/resources-service/src/resource/resourceService.ts
@@ -173,6 +173,11 @@ export const resourceService = () => {
         ({ id, name }) => resourceMap[id] ?? { id, name, _status: 'missing' },
       );
 
+      // Monitors & dashboards use this log statement, review them before updating to ensure they remain aligned.
+      console.info(
+        `[resource-search] AccountSid: ${accountSid} - Search Complete. Total count from ES: ${total}, Paginated count from ES: ${items.length}, Paginated count from DB: ${unsortedResourceList.length}.`,
+      );
+
       return {
         results: orderedResults.map(record =>
           isMissingResource(record) ? record : resourceRecordToApiResource(record),


### PR DESCRIPTION
## Description

Because HRM logging isn't smart enough to group multiline logs as single entries, including tabbing in JSON output is killing out log quota with log entries that are often a single curly brace

Using the default 'compact' JSON output for any JSON logged in HRM should mitigate this

Also:

Change completed lambda to just log rather than broadcast SNS
Remove spammy logs for every run of the contact job processor loop
Add some extra resources logs to build alarms off

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P