### PR TITLE
fix: Generalized Search - regression transcripts not being included when indexing contacts [CHI-2963]

### DIFF
--- a/hrm-domain/lambdas/contact-retrieve-transcript/index.ts
+++ b/hrm-domain/lambdas/contact-retrieve-transcript/index.ts
@@ -31,6 +31,7 @@ import { exportTranscript } from './exportTranscript';
 
 import type { SQSBatchResponse, SQSEvent, SQSRecord } from 'aws-lambda';
 import type { CompletedContactJobBody } from '@tech-matters/types';
+import { ExportTranscriptDocument } from '@tech-matters/hrm-types';
 
 const completedQueueUrl = process.env.completed_sqs_queue_url as string;
 const hrmEnv = process.env.NODE_ENV;
@@ -78,19 +79,21 @@ const processRetrieveTranscriptRecord = async (
     serviceSid,
   });
 
+  const document: ExportTranscriptDocument = {
+    transcript,
+    accountSid,
+    hrmAccountId,
+    contactId,
+    taskId,
+    twilioWorkerId,
+    serviceSid,
+    channelSid,
+  };
+
   await putS3Object({
     bucket: docsBucketName,
     key: message.filePath,
-    body: JSON.stringify({
-      transcript,
-      accountSid,
-      hrmAccountId,
-      contactId,
-      taskId,
-      twilioWorkerId,
-      serviceSid,
-      channelSid,
-    }),
+    body: JSON.stringify(document),
   });
 
   const completedJob: CompletedRetrieveContactTranscript = {

--- a/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
+++ b/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
@@ -69,7 +69,9 @@ const contactIndexingInputData = async (
       if (bucket && key) {
         const transcriptString = await getS3Object({ bucket, key });
         const parsedTranscript: ExportTranscript = JSON.parse(transcriptString);
-        transcript = parsedTranscript.messages.map(({ body }) => body).join('\n');
+        transcript = parsedTranscript.transcript.messages
+          .map(({ body }) => body)
+          .join('\n');
       }
     }
   } catch (err) {

--- a/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
+++ b/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
@@ -22,7 +22,7 @@ import {
   type IndexCaseMessage,
 } from '@tech-matters/hrm-search-config';
 import { assertExhaustive, type HrmAccountId } from '@tech-matters/types';
-import { ExportTranscript, isS3StoredTranscript } from '@tech-matters/hrm-types';
+import { ExportTranscriptDocument, isS3StoredTranscript } from '@tech-matters/hrm-types';
 import type { MessageWithMeta, MessagesByAccountSid } from './messages';
 
 /**
@@ -68,7 +68,7 @@ const contactIndexingInputData = async (
       const { bucket, key } = location || {};
       if (bucket && key) {
         const transcriptString = await getS3Object({ bucket, key });
-        const parsedTranscript: ExportTranscript = JSON.parse(transcriptString);
+        const parsedTranscript: ExportTranscriptDocument = JSON.parse(transcriptString);
         transcript = parsedTranscript.transcript.messages
           .map(({ body }) => body)
           .join('\n');

--- a/hrm-domain/packages/hrm-types/ConversationMedia.ts
+++ b/hrm-domain/packages/hrm-types/ConversationMedia.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { HrmAccountId } from '@tech-matters/types';
+import { AccountSID, HrmAccountId } from '@tech-matters/types';
 
 type ConversationMediaCommons = {
   id: number;
@@ -115,7 +115,7 @@ export type ExportTranscript = {
 };
 
 export type ExportTranscriptDocument = {
-  accountSid: HrmAccountId;
+  accountSid: AccountSID;
   hrmAccountId: HrmAccountId;
   contactId: number;
   taskId: string;

--- a/hrm-domain/packages/hrm-types/ConversationMedia.ts
+++ b/hrm-domain/packages/hrm-types/ConversationMedia.ts
@@ -108,8 +108,17 @@ export type ExportTranscriptMessage = {
 
 export type ExportTranscript = {
   accountSid: HrmAccountId;
+  hrmAccountId: HrmAccountId;
+  contactId: number;
+  taskId: string;
+  twilioWorkerId: string;
   serviceSid: string;
   channelSid: string;
-  messages: ExportTranscriptMessage[];
-  participants: ExportTranscripParticipants;
+  transcript: {
+    accountSid: string;
+    serviceSid: string;
+    channelSid: string;
+    messages: ExportTranscriptMessage[];
+    participants: ExportTranscripParticipants;
+  };
 };

--- a/hrm-domain/packages/hrm-types/ConversationMedia.ts
+++ b/hrm-domain/packages/hrm-types/ConversationMedia.ts
@@ -107,6 +107,14 @@ export type ExportTranscriptMessage = {
 };
 
 export type ExportTranscript = {
+  accountSid: string;
+  serviceSid: string;
+  channelSid: string;
+  messages: ExportTranscriptMessage[];
+  participants: ExportTranscripParticipants;
+};
+
+export type ExportTranscriptDocument = {
   accountSid: HrmAccountId;
   hrmAccountId: HrmAccountId;
   contactId: number;
@@ -114,11 +122,5 @@ export type ExportTranscript = {
   twilioWorkerId: string;
   serviceSid: string;
   channelSid: string;
-  transcript: {
-    accountSid: string;
-    serviceSid: string;
-    channelSid: string;
-    messages: ExportTranscriptMessage[];
-    participants: ExportTranscripParticipants;
-  };
+  transcript: ExportTranscript;
 };


### PR DESCRIPTION
## Description
This PR fixes a bug where transcripts were not being properly consumed, causing them to be missing from the ElasticSearch indices.

The cause of the bug was a mismatch in the types :man_facepalming: 

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-2963)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
Easiest thing is to confirm [in the logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdevelopment-hrm-search-index-consumer/log-events/2024$252F10$252F04$252F$255B$2524LATEST$255Db0a93fbb6eeb4a8aacdef3a27fa6c298) that the transcript is being included in the payload when indexing in ElasticSearch.

Another way is confirming that you are able to search transcript content.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P