### PR TITLE
chore: Generalized Search - implement simple query, refactor queries [CHI-3004]

### DIFF
--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -146,6 +146,7 @@ export const generateESQuery = <TDoc extends DocumentType>(
         simple_query_string: {
           fields: [getFieldName(p)],
           query: p.query,
+          flags: 'FUZZY|NEAR|PHRASE|WHITESPACE',
           ...(p.boost && { boost: p.boost }),
         },
       };

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -71,6 +71,11 @@ type GenerateRangeQueryParams = {
   ranges: { lt?: string; lte?: string; gt?: string; gte?: string };
 };
 type GenerateQueryStringQuery = { type: 'queryString'; query: string; boost?: number };
+type GenerateSimpleQueryStringQuery = {
+  type: 'simpleQueryString';
+  query: string;
+  boost?: number;
+};
 type GenerateMustNotQueryParams<TDoc extends DocumentType> = {
   type: 'mustNot';
   innerQuery: DocumentTypeQueryParams[TDoc];
@@ -97,6 +102,7 @@ type GenerateQueryParams<TDoc extends DocumentType> =
       | GenerateTermQueryParams
       | GenerateRangeQueryParams
       | GenerateQueryStringQuery
+      | GenerateSimpleQueryStringQuery
     ))
   | GenerateMustNotQueryParams<TDoc>
   | GenerateNestedQueryParams<TDoc>;
@@ -130,6 +136,15 @@ export const generateESQuery = <TDoc extends DocumentType>(
       return {
         query_string: {
           default_field: getFieldName(p),
+          query: p.query,
+          ...(p.boost && { boost: p.boost }),
+        },
+      };
+    }
+    case 'simpleQueryString': {
+      return {
+        simple_query_string: {
+          fields: [getFieldName(p)],
           query: p.query,
           ...(p.boost && { boost: p.boost }),
         },
@@ -225,7 +240,7 @@ const generateQueriesFromId = <TDoc extends DocumentType>({
   return queries;
 };
 
-const generateQueriesFromSearchTerms = <TDoc extends DocumentType>({
+const generateQueryFromSearchTerms = <TDoc extends DocumentType>({
   searchTerm,
   documentType,
   field,
@@ -242,37 +257,19 @@ const generateQueriesFromSearchTerms = <TDoc extends DocumentType>({
   documentType: TDoc;
   field: keyof DocumentTypeToDocument[TDoc];
   parentPath?: string;
-}): QueryDslQueryContainer[] => {
-  const terms = searchTerm.split(' ');
-
-  const queries = [
-    // query for exact matches on the term(s)
-    ...(terms.length > 1
-      ? [
-          { query: terms.join('AND'), boost: 3 * boostFactor },
-          { query: terms.join(' '), boost: 2 * boostFactor },
-        ]
-      : [{ query: terms.join(' '), boost: 2 * boostFactor }]),
-
-    // query for partial matches on the term(s)
-    { query: terms.map(t => `*${t}*`).join(' '), boost: 1.5 * boostFactor },
-
-    // query for fuzzy matches on the term(s)
-    { query: terms.map(t => `${t}~1`).join(' '), boost: 1 * boostFactor },
-  ].map(({ boost, query }) =>
-    generateESQuery(
-      queryWrapper({
-        documentType,
-        type: 'queryString',
-        query,
-        boost,
-        field: field as any, // typecast to conform TS, only valid parameters should be accept
-        parentPath,
-      }),
-    ),
+}): QueryDslQueryContainer => {
+  const query = generateESQuery(
+    queryWrapper({
+      documentType,
+      type: 'simpleQueryString',
+      query: searchTerm,
+      boost: boostFactor,
+      field: field as any, // typecast to conform TS, only valid parameters should be accept
+      parentPath,
+    }),
   );
 
-  return queries;
+  return query;
 };
 
 const generateTranscriptQueriesFromFilters = ({
@@ -288,7 +285,7 @@ const generateTranscriptQueriesFromFilters = ({
     p: DocumentTypeQueryParams[DocumentType],
   ) => DocumentTypeQueryParams[DocumentType];
 }): QueryDslQueryContainer[] => {
-  const queries = generateQueriesFromSearchTerms({
+  const query = generateQueryFromSearchTerms({
     documentType: DocumentType.Contact,
     field: 'transcript',
     searchTerm: searchParameters.searchTerm,
@@ -300,9 +297,9 @@ const generateTranscriptQueriesFromFilters = ({
   return transcriptFilters.map(filter => ({
     bool: {
       filter: filter,
-      should: queries.map(q => ({
-        bool: { must: [q] },
-      })),
+      should: {
+        bool: { must: [query] },
+      },
     },
   }));
 };
@@ -317,7 +314,7 @@ const generateContactsQueriesFromFilters = ({
   queryWrapper?: (
     p: DocumentTypeQueryParams[DocumentType],
   ) => DocumentTypeQueryParams[DocumentType];
-}) => {
+}): QueryDslQueryContainer[] => {
   const { searchFilters, permissionFilters } = searchParameters;
 
   if (searchParameters.searchTerm.length === 0) {
@@ -337,7 +334,7 @@ const generateContactsQueriesFromFilters = ({
   });
 
   const queries = [
-    ...generateQueriesFromSearchTerms({
+    generateQueryFromSearchTerms({
       documentType: DocumentType.Contact,
       field: 'content',
       searchTerm: searchParameters.searchTerm,
@@ -416,7 +413,7 @@ const generateCasesQueriesFromFilters = ({
   searchParameters,
 }: {
   searchParameters: SearchParametersCases;
-}) => {
+}): QueryDslQueryContainer[] => {
   const { searchFilters, permissionFilters } = searchParameters;
 
   if (searchParameters.searchTerm.length === 0) {
@@ -428,7 +425,7 @@ const generateCasesQueriesFromFilters = ({
     }));
   }
 
-  const contactQueries = generateContactsQueriesFromFilters({
+  const contactsQueries = generateContactsQueriesFromFilters({
     searchParameters: { ...searchParameters, type: DocumentType.Contact },
     queryWrapper: p => ({
       documentType: DocumentType.Case,
@@ -440,7 +437,7 @@ const generateCasesQueriesFromFilters = ({
   });
 
   const queries = [
-    ...generateQueriesFromSearchTerms({
+    generateQueryFromSearchTerms({
       documentType: DocumentType.Case,
       field: 'content',
       searchTerm: searchParameters.searchTerm,
@@ -453,7 +450,7 @@ const generateCasesQueriesFromFilters = ({
     }),
   ];
 
-  const sectionsQueries = generateQueriesFromSearchTerms({
+  const sectionsQuery = generateQueryFromSearchTerms({
     documentType: DocumentType.CaseSection,
     field: 'content',
     searchTerm: searchParameters.searchTerm,
@@ -474,10 +471,10 @@ const generateCasesQueriesFromFilters = ({
         ...queries.map(q => ({
           bool: { must: [q] },
         })),
-        ...sectionsQueries.map(q => ({
-          bool: { must: [q] },
-        })),
-        ...contactQueries,
+        {
+          bool: { must: [sectionsQuery] },
+        },
+        ...contactsQueries,
       ],
     },
   }));


### PR DESCRIPTION
## Description
This PR
- Introduces [simple queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax).
- Refactors search over `content` (case, case section, contact, transcript) to use the above. This approach is more resilient to direct user input while also simplifies the code used to generate queries, at the expense of loosing some custom weights we introduced when originally implemented.

The reason for this change is to prevent bugs being thrown by our ElasticSearch services when users introduced special characters. Another option (for historical purposes) was to escape the special characters, but that feels like a more fragile approach. See https://github.com/techmatters/hrm/pull/759.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3004)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
- Deploy to development.
- Confirm search works as expected.
  - For advanced queries check the documentation on simple queries linked above.
- Confirm special characters do not break the service.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P