### PR TITLE
refactor: General Search - Migrate contact/case id to be strings in ES mappings [CHI-3060]

### DIFF
--- a/hrm-domain/hrm-core/case/caseReindexService.ts
+++ b/hrm-domain/hrm-core/case/caseReindexService.ts
@@ -68,14 +68,14 @@ export const reindexCasesStream = async (
           });
 
           this.push(
-            `${new Date().toISOString()},${accountSid},contad id: ${
+            `${new Date().toISOString()}, ${accountSid}, case id: ${
               caseObj.id
             } Success, MessageId ${MessageId}
               \n`,
           );
         } catch (err) {
           this.push(
-            `${new Date().toISOString()},${accountSid},contad id: ${caseObj.id} Error: ${
+            `${new Date().toISOString()}, ${accountSid}, case id: ${caseObj.id} Error: ${
               err.message?.replace('"', '""') || String(err)
             }\n`,
           );

--- a/hrm-domain/hrm-core/contact/canPerformContactAction.ts
+++ b/hrm-domain/hrm-core/contact/canPerformContactAction.ts
@@ -190,7 +190,12 @@ const canConnectContact = canPerformActionOnContact(
     { can, user, hrmAccountId, body: { caseId: targetCaseId }, permissions },
   ) => {
     if (
-      !(await canRemoveFromCase(originalCaseId, { can, user, hrmAccountId, permissions }))
+      !(await canRemoveFromCase(String(originalCaseId), {
+        can,
+        user,
+        hrmAccountId,
+        permissions,
+      }))
     ) {
       return false;
     }
@@ -206,7 +211,7 @@ const canConnectContact = canPerformActionOnContact(
 
 export const canDisconnectContact = canPerformActionOnContact(
   actionsMaps.contact.REMOVE_CONTACT_FROM_CASE,
-  async ({ caseId }: Contact, req) => canRemoveFromCase(caseId, req),
+  async ({ caseId }: Contact, req) => canRemoveFromCase(String(caseId), req),
 );
 
 // TODO: Remove when we start disallowing disconnecting contacts via the connect endpoint

--- a/hrm-domain/hrm-core/contact/canPerformContactAction.ts
+++ b/hrm-domain/hrm-core/contact/canPerformContactAction.ts
@@ -168,11 +168,11 @@ export const canPerformViewContactAction = canPerformActionOnContact(
 );
 
 const canRemoveFromCase = async (
-  originalCaseId: string,
+  originalCaseId: number,
   { can, user, hrmAccountId, permissions },
 ): Promise<boolean> => {
   if (originalCaseId) {
-    const originalCaseObj = await getCase(parseInt(originalCaseId), hrmAccountId, {
+    const originalCaseObj = await getCase(originalCaseId, hrmAccountId, {
       can,
       user,
       permissions,
@@ -190,7 +190,7 @@ const canConnectContact = canPerformActionOnContact(
     { can, user, hrmAccountId, body: { caseId: targetCaseId }, permissions },
   ) => {
     if (
-      !(await canRemoveFromCase(String(originalCaseId), {
+      !(await canRemoveFromCase(originalCaseId, {
         can,
         user,
         hrmAccountId,
@@ -199,7 +199,7 @@ const canConnectContact = canPerformActionOnContact(
     ) {
       return false;
     }
-    const targetCaseObj = await getCase(parseInt(targetCaseId), hrmAccountId, {
+    const targetCaseObj = await getCase(parseInt(targetCaseId, 10), hrmAccountId, {
       can,
       user,
       permissions,
@@ -211,7 +211,7 @@ const canConnectContact = canPerformActionOnContact(
 
 export const canDisconnectContact = canPerformActionOnContact(
   actionsMaps.contact.REMOVE_CONTACT_FROM_CASE,
-  async ({ caseId }: Contact, req) => canRemoveFromCase(String(caseId), req),
+  async ({ caseId }: Contact, req) => canRemoveFromCase(caseId, req),
 );
 
 // TODO: Remove when we start disallowing disconnecting contacts via the connect endpoint

--- a/hrm-domain/hrm-core/contact/contactsReindexService.ts
+++ b/hrm-domain/hrm-core/contact/contactsReindexService.ts
@@ -60,16 +60,16 @@ export const reindexContactsStream = async (
           });
 
           this.push(
-            `${new Date().toISOString()},${accountSid},contad id: ${
+            `${new Date().toISOString()}, ${accountSid}, contact id: ${
               contact.id
             } Success, MessageId ${MessageId}
               \n`,
           );
         } catch (err) {
           this.push(
-            `${new Date().toISOString()},${accountSid},contad id: ${contact.id} Error: ${
-              err.message?.replace('"', '""') || String(err)
-            }\n`,
+            `${new Date().toISOString()}, ${accountSid}, contact id: ${
+              contact.id
+            } Error: ${err.message?.replace('"', '""') || String(err)}\n`,
           );
         }
         callback();

--- a/hrm-domain/hrm-core/unit-tests/contact/canPerformContactAction.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/canPerformContactAction.test.ts
@@ -253,7 +253,7 @@ describe('canDisconnectContact', () => {
     let contact = new ContactBuilder().withFinalizedAt(BASELINE_DATE).build();
     beforeEach(() => {
       mockGetContactById.mockResolvedValue(contact);
-      contact.caseId = '123';
+      contact.caseId = 123;
     });
     test('can returns true to permit & case id not set on contact - permits', async () => {
       delete contact.caseId;

--- a/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
+++ b/hrm-domain/lambdas/search-index-consumer/messagesToPayloads.ts
@@ -141,7 +141,7 @@ const generatePayloadFromContact = (
               ...(ps[HRM_CASES_INDEX_TYPE] ?? []),
               {
                 ...m,
-                documentId: parseInt(m.message.contact.caseId, 10),
+                documentId: m.message.contact.caseId,
                 payload: { ...m.message, transcript: m.transcript },
                 indexHandler: 'updateScript',
               },

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -55,7 +55,7 @@ export const convertContactToContactDocument = ({
 
   const contactDocument: ContactDocument = {
     accountSid,
-    id,
+    id: id.toString(),
     createdAt,
     updatedAt,
     createdBy,
@@ -115,7 +115,7 @@ const convertCaseToCaseDocument = ({
 
   const caseDocument: CaseDocument = {
     accountSid,
-    id,
+    id: id.toString(),
     createdAt,
     updatedAt,
     createdBy,

--- a/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
@@ -38,7 +38,7 @@ const convertContactToCaseScriptUpdate = (
       const contactDocument = convertContactToContactDocument(payload);
 
       const documentUpdate: CreateIndexConvertedDocument<CaseDocument> = {
-        id: parseInt(caseId!, 10),
+        id: caseId.toString(),
         accountSid,
         contacts: [contactDocument],
       };
@@ -66,9 +66,9 @@ const convertContactToCaseScriptUpdate = (
     case 'remove': {
       const scriptUpdate: Script = {
         source:
-          'def removeContact(int contactId, List contacts) { contacts.removeIf(contact -> contact.id == contactId); } removeContact(params.contactId, ctx._source.contacts);',
+          'def removeContact(String contactId, List contacts) { contacts.removeIf(contact -> contact.id == contactId); } removeContact(params.contactId, ctx._source.contacts);',
         params: {
-          contactId: payload.contact.id,
+          contactId: payload.contact.id.toString(),
         },
       };
 

--- a/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
@@ -38,7 +38,7 @@ const convertContactToCaseScriptUpdate = (
       const contactDocument = convertContactToContactDocument(payload);
 
       const documentUpdate: CreateIndexConvertedDocument<CaseDocument> = {
-        id: caseId.toString(),
+        id: caseId!.toString(),
         accountSid,
         contacts: [contactDocument],
       };

--- a/hrm-domain/packages/hrm-search-config/hrmIndexDocumentMappings/mappings.ts
+++ b/hrm-domain/packages/hrm-search-config/hrmIndexDocumentMappings/mappings.ts
@@ -39,7 +39,7 @@ const commonProperties = {
 // Properties shared by both types of documents, cases and contacts
 const rootProperties = {
   id: {
-    type: 'integer',
+    type: 'keyword',
   },
   twilioWorkerId: {
     type: 'keyword',

--- a/hrm-domain/packages/hrm-types/Contact.ts
+++ b/hrm-domain/packages/hrm-types/Contact.ts
@@ -16,6 +16,7 @@
 import { HrmAccountId, TwilioUserIdentifier, WorkerSID } from '@tech-matters/types';
 import { ConversationMedia } from './ConversationMedia';
 import { Referral } from './Referral';
+import { CaseService } from './Case';
 
 /**
  * This and contained types are copied from Flex
@@ -53,7 +54,7 @@ export type NewContactRecord = {
   taskId: string;
   channelSid?: string;
   serviceSid?: string;
-  caseId?: string;
+  caseId?: CaseService['id'];
   profileId?: number;
   identifierId?: number;
 };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "scripts": {
     "admin-cli": "npx tsx hrm-domain/hrm-service/scripts/admin-cli.ts",
     "build": "tsc -b --verbose",
+    "clean": "tsc -b --clean",
     "build-and-start": "run-s build start",
     "build-and-start:service": "run-s build start:service",
     "start": "run-s start:db start:localstack start:es start:service",

--- a/packages/elasticsearch-client/src/client.ts
+++ b/packages/elasticsearch-client/src/client.ts
@@ -67,17 +67,12 @@ export type PassThroughConfig<T> = {
   client: EsClient;
 };
 
-const getConfigSsmParameterKey = (indexType: string) =>
-  `/${process.env.NODE_ENV}/${indexType}/${process.env.AWS_REGION}/elasticsearch_config`;
-
 //TODO: type for config
 const getEsConfig = async ({
   config,
-  indexType,
   ssmConfigParameter,
 }: {
-  config: ClientOptions | undefined;
-  indexType: string;
+  config?: ClientOptions | undefined;
   ssmConfigParameter?: string;
 }) => {
   console.log('config', config);
@@ -102,8 +97,7 @@ const getEsConfig = async ({
     return JSON.parse(await getSsmParameter(ssmConfigParameter));
   }
 
-  // TODO: remove this if it's not used anymore?
-  return JSON.parse(await getSsmParameter(getConfigSsmParameterKey(indexType)));
+  throw new Error(`getEsConfig error: no valid config provided to initialize client`);
 };
 
 /**
@@ -123,7 +117,6 @@ export type IndexClient<T> = {
 const getClientOrMock = async ({
   config,
   index,
-  indexType,
   ssmConfigParameter,
 }: GetClientOrMockArgs) => {
   // TODO: mock client for unit tests
@@ -132,9 +125,7 @@ const getClientOrMock = async ({
   //   return mock;
   // }
 
-  const client = new EsClient(
-    await getEsConfig({ config, indexType, ssmConfigParameter }),
-  );
+  const client = new EsClient(await getEsConfig({ config, ssmConfigParameter }));
   return {
     client,
     index,


### PR DESCRIPTION
## Description
This PR addresses the concerns raised in this comment https://github.com/techmatters/hrm/pull/766#discussion_r1816145602.
Basically, we are refactoring the mapping of our ElasticSearch indices, so that `id` property is now a string (`keyword`) rather a number (`integer`) as it was before.
This allows us to use simple queries for content and ids alike, preventing potential issues if the user input contains weird characters, spaces, etc.
To preserve the "boosting factor" over the different properties of the documents, we use the `^` operator supported by simple query strings.

IMPORTANT NOTES:
- This PR needs a migration of our indices. We have to
  - Schedule the migration as it will involve some downtime.
  - [optional] Disable gen search and use legacy search to avoid downtime for any account that might be impacted.
  - Disable the "auto index" feature flag in HRM before deploying.
  - Delete all the `<account sid>-hrm-contacts` and `<account sid>-hrm-cases` indices from the `shared` Elastic Search instances.
  - Re-enable the "auto index" feature flag in HRM before deploying.
  - Historic re-index for the accounts for which we want to re-enable gen search.
  - [optional] Re-enable gen search for those accounts it was disabled for.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3060)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P