### PR TITLE
CHI-2997:Refactor search indexing to be notifying

### DIFF
--- a/hrm-domain/hrm-core/case/caseReindexService.ts
+++ b/hrm-domain/hrm-core/case/caseReindexService.ts
@@ -16,7 +16,7 @@
 
 import { HrmAccountId } from '@tech-matters/types';
 import { caseRecordToCase } from './caseService';
-import { publishCaseToSearchIndex } from '../jobs/search/publishToSearchIndex';
+import { publishCaseChangeNotification } from '../notifications/entityChangeNotify';
 import { maxPermissions } from '../permissions';
 import formatISO from 'date-fns/formatISO';
 import { CaseRecord, streamCasesForReindexing } from './caseDataAccess';
@@ -61,10 +61,10 @@ export const reindexCasesStream = async (
       async transform(caseRecord: CaseRecord, _, callback) {
         const caseObj = caseRecordToCase(caseRecord);
         try {
-          const { MessageId } = await publishCaseToSearchIndex({
+          const { MessageId } = await publishCaseChangeNotification({
             accountSid,
             case: caseObj,
-            operation: 'index',
+            operation: 'reindex',
           });
 
           this.push(

--- a/hrm-domain/hrm-core/case/caseSection/caseSectionService.ts
+++ b/hrm-domain/hrm-core/case/caseSection/caseSectionService.ts
@@ -36,7 +36,7 @@ import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { RulesFile, TKConditionsSets } from '../../permissions/rulesMap';
 import { ListConfiguration } from '../caseDataAccess';
 import { HrmAccountId } from '@tech-matters/types';
-import { indexCaseInSearchIndex } from '../caseService';
+import { updateCaseNotify } from '../caseService';
 
 const sectionRecordToSection = (
   sectionRecord: CaseSectionRecord | undefined,
@@ -72,7 +72,7 @@ export const createCaseSection = async (
 
   if (!skipSearchIndex) {
     // trigger index operation but don't await for it
-    indexCaseInSearchIndex({ accountSid, caseId: parseInt(caseId, 10) });
+    updateCaseNotify({ accountSid, caseId: parseInt(caseId, 10) });
   }
 
   return sectionRecordToSection(created);
@@ -105,7 +105,7 @@ export const replaceCaseSection = async (
 
   if (!skipSearchIndex) {
     // trigger index operation but don't await for it
-    indexCaseInSearchIndex({ accountSid, caseId: parseInt(caseId, 10) });
+    updateCaseNotify({ accountSid, caseId: parseInt(caseId, 10) });
   }
 
   return sectionRecordToSection(updated);
@@ -183,7 +183,7 @@ export const deleteCaseSection = async (
 
   if (!skipSearchIndex) {
     // trigger index operation but don't await for it
-    indexCaseInSearchIndex({ accountSid, caseId: parseInt(caseId, 10) });
+    updateCaseNotify({ accountSid, caseId: parseInt(caseId, 10) });
   }
 
   return sectionRecordToSection(deleted);

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -78,14 +78,14 @@ import {
   isDatabaseUniqueConstraintViolationErrorResult,
 } from '../sql';
 import { systemUser } from '@tech-matters/twilio-worker-auth';
-import { publishContactToSearchIndex } from '../jobs/search/publishToSearchIndex';
+import { publishContactChangeNotification } from '../notifications/entityChangeNotify';
 import type { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
-import type { IndexMessage } from '@tech-matters/hrm-search-config';
 import {
   ContactListCondition,
   generateContactSearchFilters,
   generateContactPermissionsFilters,
 } from './contactSearchIndex';
+import { NotificationOperation } from '@tech-matters/hrm-types/dist/NotificationOperation';
 
 // Re export as is:
 export { Contact } from './contactDataAccess';
@@ -178,8 +178,8 @@ const initProfile = async (
   });
 };
 
-const doContactInSearchIndexOP =
-  (operation: IndexMessage['operation']) =>
+const doContactChangeNotification =
+  (operation: NotificationOperation) =>
   async ({
     accountSid,
     contactId,
@@ -195,7 +195,7 @@ const doContactInSearchIndexOP =
       const contact = await getById(accountSid, contactId);
 
       if (contact) {
-        await publishContactToSearchIndex({ accountSid, contact, operation });
+        await publishContactChangeNotification({ accountSid, contact, operation });
       }
     } catch (err) {
       console.error(
@@ -205,8 +205,9 @@ const doContactInSearchIndexOP =
     }
   };
 
-const indexContactInSearchIndex = doContactInSearchIndexOP('index');
-const removeContactInSearchIndex = doContactInSearchIndexOP('remove');
+const createContactInSearchIndex = doContactChangeNotification('create');
+const updateContactInSearchIndex = doContactChangeNotification('update');
+const deleteContactInSearchIndex = doContactChangeNotification('delete');
 
 // Creates a contact with all its related records within a single transaction
 export const createContact = async (
@@ -262,7 +263,7 @@ export const createContact = async (
     if (isOk(result)) {
       // trigger index operation but don't await for it
       if (!skipSearchIndex) {
-        indexContactInSearchIndex({ accountSid, contactId: result.data.id });
+        createContactInSearchIndex({ accountSid, contactId: result.data.id });
       }
       return result.data;
     }
@@ -335,7 +336,7 @@ export const patchContact = async (
     // trigger index operation but don't await for it
 
     if (!skipSearchIndex) {
-      indexContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+      updateContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
     }
 
     return applyTransformations(updated);
@@ -350,7 +351,7 @@ export const connectContactToCase = async (
 ): Promise<Contact> => {
   if (caseId === null) {
     // trigger remove operation, awaiting for it, since we'll lost the information of which is the "old case" otherwise
-    await removeContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+    await deleteContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
   }
 
   const updated: Contact | undefined = await connectToCase()(
@@ -367,7 +368,7 @@ export const connectContactToCase = async (
 
   // trigger index operation but don't await for it
   if (!skipSearchIndex) {
-    indexContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+    updateContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
   }
 
   return applyTransformations(updated);
@@ -415,7 +416,10 @@ export const addConversationMediaToContact = async (
 
     // trigger index operation but don't await for it
     if (!skipSearchIndex) {
-      indexContactInSearchIndex({ accountSid, contactId: parseInt(contactIdString, 10) });
+      updateContactInSearchIndex({
+        accountSid,
+        contactId: parseInt(contactIdString, 10),
+      });
     }
 
     return applyTransformations(updated);
@@ -599,7 +603,7 @@ export const updateConversationMediaData =
 
     // trigger index operation but don't await for it
     if (!skipSearchIndex) {
-      indexContactInSearchIndex({ accountSid, contactId });
+      updateContactInSearchIndex({ accountSid, contactId });
     }
 
     return result;

--- a/hrm-domain/hrm-core/contact/contactsReindexService.ts
+++ b/hrm-domain/hrm-core/contact/contactsReindexService.ts
@@ -15,7 +15,7 @@
  */
 
 import { HrmAccountId } from '@tech-matters/types';
-import { publishContactToSearchIndex } from '../jobs/search/publishToSearchIndex';
+import { publishContactChangeNotification } from '../notifications/entityChangeNotify';
 import { maxPermissions } from '../permissions';
 import { Transform } from 'stream';
 import { streamContactsForReindexing } from './contactDataAccess';
@@ -53,7 +53,7 @@ export const reindexContactsStream = async (
       highWaterMark,
       async transform(contact, _, callback) {
         try {
-          const { MessageId } = await publishContactToSearchIndex({
+          const { MessageId } = await publishContactChangeNotification({
             accountSid,
             contact,
             operation: 'reindex',

--- a/hrm-domain/hrm-core/unit-tests/case/caseService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/case/caseService.test.ts
@@ -24,11 +24,11 @@ import { workerSid, accountSid } from '../mocks';
 import { newTwilioUser } from '@tech-matters/twilio-worker-auth';
 import { rulesMap } from '../../permissions';
 import { RulesFile } from '../../permissions/rulesMap';
-import * as publishToSearchIndex from '../../jobs/search/publishToSearchIndex';
+import * as entityChangeNotify from '../../notifications/entityChangeNotify';
 
-const publishToSearchIndexSpy = jest
-  .spyOn(publishToSearchIndex, 'publishCaseToSearchIndex')
-  .mockImplementation(async () => Promise.resolve('Ok') as any);
+const publishCaseChangeNotificationSpy = jest
+  .spyOn(entityChangeNotify, 'publishCaseChangeNotification')
+  .mockImplementation(() => Promise.resolve('Ok') as any);
 
 jest.mock('../../case/caseDataAccess');
 const baselineCreatedDate = new Date(2013, 6, 13).toISOString();
@@ -77,7 +77,7 @@ test('create case', async () => {
   });
 
   await new Promise(process.nextTick);
-  expect(publishToSearchIndexSpy).toHaveBeenCalled();
+  expect(publishCaseChangeNotificationSpy).toHaveBeenCalled();
 });
 
 describe('searchCases', () => {

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -34,7 +34,7 @@ import { ALWAYS_CAN, OPEN_CONTACT_ACTION_CONDITIONS } from '../mocks';
 import '@tech-matters/testing/expectToParseAsDate';
 import { openPermissions } from '../../permissions/json-permissions';
 import { RulesFile, TKConditionsSets } from '../../permissions/rulesMap';
-import * as publishToSearchIndex from '../../jobs/search/publishToSearchIndex';
+import * as entityChangeNotify from '../../notifications/entityChangeNotify';
 
 const flushPromises = async () => {
   await new Promise(process.nextTick);
@@ -42,9 +42,9 @@ const flushPromises = async () => {
   await new Promise(process.nextTick);
 };
 
-const publishToSearchIndexSpy = jest
-  .spyOn(publishToSearchIndex, 'publishContactToSearchIndex')
-  .mockImplementation(async () => Promise.resolve('Ok') as any);
+const publishContactChangeNotificationSpy = jest
+  .spyOn(entityChangeNotify, 'publishContactChangeNotification')
+  .mockImplementation(() => Promise.resolve('Ok') as any);
 
 const accountSid = 'AC-accountSid';
 const workerSid = 'WK-WORKER_SID';
@@ -161,7 +161,7 @@ describe('createContact', () => {
     });
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -191,7 +191,7 @@ describe('createContact', () => {
     });
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -227,7 +227,7 @@ describe('createContact', () => {
     });
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -250,7 +250,7 @@ describe('createContact', () => {
     });
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 
@@ -274,7 +274,7 @@ describe('createContact', () => {
     });
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(returnValue).toStrictEqual(mockContact);
   });
 });
@@ -294,7 +294,7 @@ describe('connectContactToCase', () => {
     );
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(result).toStrictEqual(mockContact);
   });
 
@@ -305,7 +305,7 @@ describe('connectContactToCase', () => {
     expect(
       connectContactToCase(accountSid, '1234', '4321', ALWAYS_CAN),
     ).rejects.toThrow();
-    expect(publishToSearchIndexSpy).not.toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -343,7 +343,7 @@ describe('patchContact', () => {
     );
 
     await flushPromises();
-    expect(publishToSearchIndexSpy).toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).toHaveBeenCalled();
     expect(result).toStrictEqual(mockContact);
     expect(patchSpy).toHaveBeenCalledWith(accountSid, '1234', true, {
       updatedBy: contactPatcherSid,
@@ -368,7 +368,7 @@ describe('patchContact', () => {
     jest.spyOn(contactDb, 'patch').mockReturnValue(patchSpy);
     patchSpy.mockResolvedValue(undefined);
 
-    expect(publishToSearchIndexSpy).not.toHaveBeenCalled();
+    expect(publishContactChangeNotificationSpy).not.toHaveBeenCalled();
     expect(
       patchContact(accountSid, contactPatcherSid, true, '1234', samplePatch, ALWAYS_CAN),
     ).rejects.toThrow();

--- a/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToScriptUpdate.ts
@@ -34,6 +34,9 @@ const convertContactToCaseScriptUpdate = (
   const { accountSid, caseId } = payload.contact;
 
   switch (operation) {
+    case 'create':
+    case 'update':
+    case 'reindex':
     case 'index': {
       const contactDocument = convertContactToContactDocument(payload);
 
@@ -63,6 +66,7 @@ const convertContactToCaseScriptUpdate = (
 
       return { documentUpdate, scriptUpdate };
     }
+    case 'delete':
     case 'remove': {
       const scriptUpdate: Script = {
         source:

--- a/hrm-domain/packages/hrm-search-config/payload.ts
+++ b/hrm-domain/packages/hrm-search-config/payload.ts
@@ -14,20 +14,24 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { CaseService, Contact } from '@tech-matters/hrm-types';
+import type {
+  CaseService,
+  Contact,
+  NotificationOperation,
+} from '@tech-matters/hrm-types';
 import { AccountSID } from '@tech-matters/types';
 
 type IndexOperation = 'index' | 'remove';
 
 export type IndexContactMessage = {
   type: 'contact';
-  operation: IndexOperation;
+  operation: IndexOperation | NotificationOperation;
   contact: Pick<Contact, 'id'> & Partial<Contact>;
 };
 
 export type IndexCaseMessage = {
   type: 'case';
-  operation: IndexOperation;
+  operation: IndexOperation | NotificationOperation;
   case: Pick<CaseService, 'id'> &
     Partial<Omit<CaseService, 'sections'>> & {
       sections: NonNullable<CaseService['sections']>;

--- a/hrm-domain/packages/hrm-types/NotificationOperation.ts
+++ b/hrm-domain/packages/hrm-types/NotificationOperation.ts
@@ -1,0 +1,1 @@
+export type NotificationOperation = 'update' | 'create' | 'delete' | 'reindex';

--- a/hrm-domain/packages/hrm-types/NotificationOperation.ts
+++ b/hrm-domain/packages/hrm-types/NotificationOperation.ts
@@ -1,1 +1,17 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
 export type NotificationOperation = 'update' | 'create' | 'delete' | 'reindex';

--- a/hrm-domain/packages/hrm-types/index.ts
+++ b/hrm-domain/packages/hrm-types/index.ts
@@ -19,5 +19,6 @@ export * from './Referral';
 export * from './ConversationMedia';
 export * from './Case';
 export * from './CaseSection';
+export * from './NotificationOperation';
 export * from './Profile';
 export * from './PostSurvey';


### PR DESCRIPTION
## Description

- Rename 'reindex' API to be a 'notify' API
- Update the exported functions to use the notification operations rather than the indexing operations
- Update the reindex lambda to handle index operations or notify operations so it can migrate to being fed messages from the SNS topic

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
None

### Verification steps

Automated tests
Verify indexing and DW HRM exports still function as expected

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P