### PR TITLE
CHI-3099: Fix in progress contact permission check

### DIFF
--- a/hrm-domain/hrm-core/contact/contactRoutesV0.ts
+++ b/hrm-domain/hrm-core/contact/contactRoutesV0.ts
@@ -32,7 +32,6 @@ import {
   canChangeContactConnection,
   canDisconnectContact,
   canPerformEditContactAction,
-  canPerformEditInProgressContactAction,
   canPerformViewContactAction,
 } from './canPerformContactAction';
 
@@ -174,7 +173,6 @@ contactsRouter.patch(
   '/:contactId',
   validatePatchPayload,
   canPerformEditContactAction,
-  canPerformEditInProgressContactAction,
   async (req, res) => {
     const { hrmAccountId, user } = req;
     const { contactId } = req.params;


### PR DESCRIPTION
## Description

As part of investigating this bug, I saw a problem with the logic of how the new UPDATE_IN_PROGRESS_CONTACT action is evaluated

The desired behaviour for contact updates is

Finalized contacts need to have EDIT_CONTACT permission

In progress contacts need to pass one of the hardcoded checks (is the owner, or is the creator or meets the transfer special case criteria) OR it needs to pass the EDIT_IN_PROGRESS_CONTACT permission

The actual behaviour is

Finalized contacts need to have EDIT_CONTACT OR the EDIT_IN_PROGRESS_CONTACT permission

In progress contacts need to pass one of the hardcoded checks (is the owner, or is the creator or meets the transfer special case criteria) OR it needs to pass the EDIT_IN_PROGRESS_CONTACT permission

Basically EDIT_IN_PROGRESS_CONTACT permission could incorrectly overrule EDIT_CONTACT permission for editing a finalized contact. An edge case for sure because EDIT_IN_PROGRESS_CONTACT would usually be less open than EDIT_CONTACT, but worth fixing

### Checklist
- [X] Corresponding issue has been opened
- [ ] New tests added
- [N/A] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Verify permissions around saving and ending contacts

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P