### PR TITLE
chore: lift definitionVersion to Contact root [CHI-3109]

### DIFF
--- a/hrm-domain/hrm-core/contact/sql/contactInsertSql.ts
+++ b/hrm-domain/hrm-core/contact/sql/contactInsertSql.ts
@@ -40,7 +40,8 @@ export const INSERT_CONTACT_SQL = `
       "channelSid",
       "serviceSid",
       "profileId",
-      "identifierId"
+      "identifierId",
+      "definitionVersion"
     ) (SELECT 
         $<accountSid>, 
         $<rawJson>, 
@@ -58,7 +59,8 @@ export const INSERT_CONTACT_SQL = `
         $<channelSid>, 
         $<serviceSid>,
         $<profileId>,
-        $<identifierId>
+        $<identifierId>,
+        $<definitionVersion>
       WHERE NOT EXISTS (
         ${selectSingleContactByTaskId('Contacts')}
       )

--- a/hrm-domain/hrm-core/unit-tests/contact/contactDataAccess.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactDataAccess.test.ts
@@ -54,6 +54,7 @@ describe('create', () => {
     channelSid: undefined,
     serviceSid: undefined,
     isNewRecord: true,
+    definitionVersion: 'as-v1',
   };
 
   test('Task ID specified in payload that is already associated with a contact - returns that contact', async () => {

--- a/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/contact/contactService.test.ts
@@ -120,6 +120,7 @@ describe('createContact', () => {
     number: "that's numberwang",
     channelSid: 'a channel',
     serviceSid: 'a service',
+    definitionVersion: 'as-v1',
   };
 
   const spyOnContact = ({

--- a/hrm-domain/hrm-service/migrations/20250129164910-lift_contact_form_definition_version.js
+++ b/hrm-domain/hrm-service/migrations/20250129164910-lift_contact_form_definition_version.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE "Contacts" ADD COLUMN IF NOT EXISTS "definitionVersion" TEXT;
+    `);
+    console.log('"definitionVersion" column added to table "Contacts"');
+
+    await queryInterface.sequelize.query(`
+      UPDATE "Contacts" SET "definitionVersion" = "rawJson"->>'definitionVersion';
+    `);
+    console.log('"definitionVersion" column populated in table "Contacts"');
+  },
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE public."Contacts" 
+      DROP COLUMN IF EXISTS "definitionVersion";
+    `);
+    console.log('"definitionVersion" column dropped from table "Contacts"');
+  },
+};

--- a/hrm-domain/hrm-service/service-tests/case/casePermissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/casePermissions.test.ts
@@ -101,6 +101,7 @@ describe('isCaseContactOwner condition', () => {
               },
               queueName: 'buh',
               conversationDuration: 0,
+              definitionVersion: 'as-v1',
             },
             ALWAYS_CAN,
             true,

--- a/hrm-domain/hrm-service/service-tests/contact/contactPermissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactPermissions.test.ts
@@ -105,6 +105,7 @@ const createContact = async (
       helpline: 'helpline',
       conversationDuration: 5,
       serviceSid: 'ISxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      definitionVersion: 'as-v1',
     },
     ALWAYS_CAN,
     true,

--- a/hrm-domain/hrm-service/service-tests/contact/createContact.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/createContact.test.ts
@@ -168,6 +168,7 @@ each([
         taskId: 'empty-contact-tasksid',
         channelSid: null,
         serviceSid: null,
+        definitionVersion: 'as-v1',
       },
       expectedGetContact: {
         rawJson: {} as ContactRawJson,

--- a/hrm-domain/hrm-service/service-tests/mocks.ts
+++ b/hrm-domain/hrm-service/service-tests/mocks.ts
@@ -88,6 +88,7 @@ export const contact1: NewContactRecord = {
   conversationDuration: 14,
   profileId: undefined,
   identifierId: undefined,
+  definitionVersion: 'as-v1',
 };
 
 export const contact2: NewContactRecord = {
@@ -148,6 +149,7 @@ export const contact2: NewContactRecord = {
   conversationDuration: 10,
   profileId: undefined,
   identifierId: undefined,
+  definitionVersion: 'as-v1',
 };
 
 export const nonData1: NewContactRecord = {
@@ -262,6 +264,7 @@ export const withTaskId: NewContactRecord = {
   taskId: 'taskId',
   profileId: undefined,
   identifierId: undefined,
+  definitionVersion: 'as-v1',
 };
 export type CaseSectionInsert = {
   section: NewCaseSection;

--- a/hrm-domain/hrm-service/service-tests/searchPermissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/searchPermissions.test.ts
@@ -99,6 +99,7 @@ const createContact = async (twilioWorkerId: WorkerSID): Promise<contactDb.Conta
       helpline: 'helpline',
       conversationDuration: 5,
       serviceSid: 'ISxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      definitionVersion: 'as-v1',
     },
     ALWAYS_CAN,
   );

--- a/hrm-domain/integration-tests/transcripts/src/contactDb.ts
+++ b/hrm-domain/integration-tests/transcripts/src/contactDb.ts
@@ -66,6 +66,7 @@ export const createContact = async (newContact: NewContactRecord): Promise<Conta
     const { isNewRecord, ...created }: CreateResultRecord =
       await conn.one<CreateResultRecord>(INSERT_CONTACT_SQL, {
         ...newContact,
+        definitionVersion: 'as-v1',
         identifierId: identifier.id,
         profileId: profile.id,
         accountSid: ACCOUNT_SID,

--- a/hrm-domain/integration-tests/transcripts/src/fixtures/sampleContacts.ts
+++ b/hrm-domain/integration-tests/transcripts/src/fixtures/sampleContacts.ts
@@ -29,6 +29,7 @@ export const MINIMAL_CONTACT: NewContactRecord = {
   twilioWorkerId: 'WK-integration-test-counselor',
   taskId: 'TK-integration-test',
 
+  definitionVersion: 'as-v1',
   helpline: '',
   number: '',
   timeOfContact: new Date().toISOString(),

--- a/hrm-domain/packages/hrm-types/Contact.ts
+++ b/hrm-domain/packages/hrm-types/Contact.ts
@@ -57,6 +57,7 @@ export type NewContactRecord = {
   caseId?: CaseService['id'];
   profileId?: number;
   identifierId?: number;
+  definitionVersion: string;
 };
 
 export type ExistingContactRecord = {


### PR DESCRIPTION
## Description
This PR
- Adds migration to `Contacts` table that creates and populates `definitionVersion` column (using `rawJson->>definitionVersion`).
- Modifies "create contact" service to use `definitionVersion` given in the payload (either as top level or inside of the `rawJson`).

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
- Start HRM and Flex local servers using `master` branch.
- Create a few contacts.
- Checkout this branch and run migrations. Ensure the migration worked properly.
- Create a few more contacts and ensure the new ones are storing the definition version in the top level column.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P