### PR TITLE
CHI-3181: Treat offline contacts in a 'blanked' state as deletions for the search index

### DIFF
--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -336,7 +336,16 @@ export const patchContact = async (
     // trigger index operation but don't await for it
 
     if (!skipSearchIndex) {
-      updateContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+      if (
+        updated.taskId?.startsWith('offline-contact-task-') &&
+        !updated.rawJson.callType &&
+        !updated.finalizedAt
+      ) {
+        // If the task is an offline contact task and the call type is not set, this is a 'reset' contact, effectively deleted, so we should remove it from the index
+        deleteContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+      } else {
+        updateContactInSearchIndex({ accountSid, contactId: parseInt(contactId, 10) });
+      }
     }
 
     return applyTransformations(updated);


### PR DESCRIPTION
## Description

Part of the reason why these are appearing in search results on new search is because when we 'blank' a offline contact after cancelling it, we treat this as an update for the search index so the 'blanked' contact can still be found

It should be treated as a deletion until the contact is reused for a new offline contact. This PR fixes that


### Checklist
- [X] Corresponding issue has been opened
- [N/A] New tests added
- [N/A] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P