### PR TITLE
CHI-3166: Expose the flags for identifier endpoint as an internal route

### DIFF
--- a/hrm-domain/hrm-core/profile/internalProfileRoutesV0.ts
+++ b/hrm-domain/hrm-core/profile/internalProfileRoutesV0.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { publicEndpoint, SafeRouter } from '../permissions';
+import * as profileController from './profileService';
+import createError from 'http-errors';
+
+const internalProfileRouter = SafeRouter();
+
+internalProfileRouter.get(
+  '/identifier/:identifier/flags',
+  publicEndpoint,
+  async (req, res) => {
+    const { hrmAccountId } = req;
+    const { identifier } = req.params;
+
+    const result = await profileController.getProfileFlagsByIdentifier(
+      hrmAccountId,
+      identifier,
+    );
+
+    if (!result) {
+      throw createError(404);
+    }
+
+    res.json(result);
+  },
+);
+
+export default internalProfileRouter.expressRouter;

--- a/hrm-domain/hrm-core/routes.ts
+++ b/hrm-domain/hrm-core/routes.ts
@@ -28,6 +28,7 @@ import adminContacts from './contact/adminContactRoutesV0';
 import adminCases from './case/adminCaseRoutesV0';
 import internalContacts from './contact/internalContactRoutesV0';
 import { Permissions } from './permissions';
+import internalProfiles from './profile/internalProfileRoutesV0';
 
 export const HRM_ROUTES: {
   path: string;
@@ -68,7 +69,10 @@ export const adminApiV0 = () => {
 export const INTERNAL_ROUTES: {
   path: string;
   routerFactory: () => Router;
-}[] = [{ path: '/contacts', routerFactory: () => internalContacts }];
+}[] = [
+  { path: '/contacts', routerFactory: () => internalContacts },
+  { path: '/profiles', routerFactory: () => internalProfiles },
+];
 
 export const internalApiV0 = () => {
   const router: IRouter = Router();


### PR DESCRIPTION
## Description

- Allow the endpoint used to look up flags for an identifier to be accessed on the internal endpoints

Once everything is migrated from serverless to the Twilio Lambda for getProfileFlagsByIdentifier we can remove it from the public set of endpoints

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added
- [n/a] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Deploy this along with the correct version of flex and reconfigure a studio flow to point at the new endpoint for blocking, then check blocking still works

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P