### PR TITLE
CHI-3251 Support dynamic case overview properties

### DIFF
--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -49,7 +49,6 @@ import {
 } from '@tech-matters/hrm-types';
 import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import { CaseSectionRecord } from './caseSection/types';
-import { pick } from 'lodash';
 import {
   DocumentType,
   HRM_CASES_INDEX_TYPE,
@@ -69,8 +68,8 @@ import { NotificationOperation } from '@tech-matters/hrm-types/NotificationOpera
 
 export { WELL_KNOWN_CASE_SECTION_NAMES, CaseService, CaseInfoSection };
 
-const CASE_OVERVIEW_PROPERTIES = ['summary', 'followUpDate', 'childIsAtRisk'] as const;
-type CaseOverviewProperties = (typeof CASE_OVERVIEW_PROPERTIES)[number];
+const REQUIRED_CASE_OVERVIEW_PROPERTIES = ['summary'] as const;
+type RequiredCaseOverviewProperties = (typeof REQUIRED_CASE_OVERVIEW_PROPERTIES)[number];
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
@@ -389,12 +388,12 @@ export const updateCaseStatus = async (
 export const updateCaseOverview = async (
   accountSid: CaseService['accountSid'],
   id: CaseService['id'],
-  overview: Pick<CaseService['info'], CaseOverviewProperties>,
+  overview: Partial<CaseService['info']> &
+    Pick<CaseService['info'], RequiredCaseOverviewProperties>,
   workerSid: CaseService['twilioWorkerId'],
   skipSearchIndex = false,
 ): Promise<CaseService> => {
-  const validOverview = pick(overview, CASE_OVERVIEW_PROPERTIES);
-  const updated = await updateCaseInfo(accountSid, id, validOverview, workerSid);
+  const updated = await updateCaseInfo(accountSid, id, overview, workerSid);
 
   if (!skipSearchIndex) {
     // trigger index operation but don't await for it

--- a/hrm-domain/hrm-service/service-tests/case/caseUpdates.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseUpdates.test.ts
@@ -33,7 +33,6 @@ import {
 import * as mocks from '../mocks';
 import { headers, getRequest, getServer, useOpenRules } from '../server';
 import { ALWAYS_CAN, casePopulated } from '../mocks';
-import { pick } from 'lodash';
 import { clearAllTables } from '../dbCleanup';
 import { setupTestQueues } from '../sqs';
 
@@ -253,6 +252,14 @@ describe('PUT /cases/:id/overview route', () => {
         somethingFrom: 'behind the veil',
       },
     },
+    {
+      changeDescription: 'dynamic properties are now supported and saved',
+      newOverview: {
+        summary: 'summary is required',
+        customField1: 'custom value 1',
+        customField2: 'custom value 2',
+      },
+    },
   ];
 
   each(testCases).test(
@@ -278,7 +285,7 @@ describe('PUT /cases/:id/overview route', () => {
         ...originalCase,
         info: {
           ...originalCase.info,
-          ...pick(newOverview, ['summary', 'childIsAtRisk', 'followUpDate']),
+          ...newOverview,
         },
         updatedAt: expect.toParseAsDate(),
         updatedBy: workerSid,


### PR DESCRIPTION
## Description
- This PR modifies the info blob to support dynamic case overview properties while requiring summary (remove childIsAtRisk and followUpDate as required)

### Checklist
- [x] Corresponding issue has been [opened](https://tech-matters.atlassian.net/browse/CHI-3251)
- [x] New tests added
- [x] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
This PR complements[ this flex PR](https://github.com/techmatters/flex-plugins/pull/2845) that saves dynamic case overview properties
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P