### PR TITLE
CHI-3235: Refacto case section create endpoint to use result types and return 409s for existing IDs

### DIFF
--- a/hrm-domain/hrm-core/case/caseSection/caseSectionDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseSection/caseSectionDataAccess.ts
@@ -21,8 +21,8 @@ import { DELETE_CASE_SECTION_BY_ID } from './sql/deleteSql';
 import { UPDATE_CASE_SECTION_BY_ID } from './sql/updateSql';
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { TKConditionsSets } from '../../permissions/rulesMap';
-import { isOk, HrmAccountId } from '@tech-matters/types';
-import { txIfNotInOne } from '../../sql';
+import { isOk, HrmAccountId, newOkFromData, TResult } from '@tech-matters/types';
+import { DatabaseErrorResult, inferPostgresErrorResult, txIfNotInOne } from '../../sql';
 import { TOUCH_CASE_SQL } from '../sql/caseUpdateSql';
 import {
   CaseSectionTimelineActivity,
@@ -44,35 +44,41 @@ export const isCaseSectionTimelineActivity = (
 
 export const create =
   (task?) =>
-  async (sectionRecord: CaseSectionRecord): Promise<CaseSectionRecord> => {
-    const insertSectionStatement = `${pgp.helpers.insert(
-      sectionRecord,
-      [
-        'caseId',
-        'sectionType',
-        'sectionId',
-        'createdBy',
-        'createdAt',
-        'sectionTypeSpecificData',
-        'accountSid',
-        'eventTimestamp',
-      ],
-      'CaseSections',
-    )} RETURNING *`;
+  async (
+    sectionRecord: CaseSectionRecord,
+  ): Promise<TResult<DatabaseErrorResult['error'], CaseSectionRecord>> => {
+    try {
+      const insertSectionStatement = `${pgp.helpers.insert(
+        sectionRecord,
+        [
+          'caseId',
+          'sectionType',
+          'sectionId',
+          'createdBy',
+          'createdAt',
+          'sectionTypeSpecificData',
+          'accountSid',
+          'eventTimestamp',
+        ],
+        'CaseSections',
+      )} RETURNING *`;
 
-    return txIfNotInOne(task, async connection => {
-      const [[createdSection]]: CaseSectionRecord[][] =
-        await connection.multi<CaseSectionRecord>(
-          [insertSectionStatement, TOUCH_CASE_SQL].join(';\n'),
-          {
-            accountSid: sectionRecord.accountSid,
-            caseId: sectionRecord.caseId,
-            updatedBy: sectionRecord.createdBy,
-          },
-        );
+      return await txIfNotInOne(task, async connection => {
+        const [[createdSection]]: CaseSectionRecord[][] =
+          await connection.multi<CaseSectionRecord>(
+            [insertSectionStatement, TOUCH_CASE_SQL].join(';\n'),
+            {
+              accountSid: sectionRecord.accountSid,
+              caseId: sectionRecord.caseId,
+              updatedBy: sectionRecord.createdBy,
+            },
+          );
 
-      return createdSection;
-    });
+        return newOkFromData(createdSection);
+      });
+    } catch (error) {
+      return inferPostgresErrorResult(error);
+    }
   };
 
 export const getById = async (

--- a/hrm-domain/hrm-core/case/caseSection/caseSectionRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseSection/caseSectionRoutesV0.ts
@@ -22,6 +22,7 @@ import {
   deleteCaseSection,
   getCaseSection,
   getCaseSectionTypeList,
+  isResourceAlreadyExistsResult,
   replaceCaseSection,
 } from './caseSectionService';
 import '@tech-matters/twilio-worker-auth';
@@ -101,7 +102,7 @@ const newCaseSectionsRouter = (isPublic: boolean) => {
       user,
       params: { caseId, sectionType },
     } = req;
-    const createdCase = await createCaseSection(
+    const createdCaseResult = await createCaseSection(
       hrmAccountId,
       caseId,
       sectionType,
@@ -109,7 +110,11 @@ const newCaseSectionsRouter = (isPublic: boolean) => {
       user.workerSid,
     );
 
-    res.json(createdCase);
+    if (isResourceAlreadyExistsResult(createdCaseResult)) {
+      throw createError(409, createdCaseResult);
+    }
+
+    res.json(createdCaseResult.unwrap());
   });
 
   caseSectionsRouter.put(

--- a/hrm-domain/hrm-core/case/caseSection/caseSectionService.ts
+++ b/hrm-domain/hrm-core/case/caseSection/caseSectionService.ts
@@ -35,8 +35,47 @@ import {
 import { TwilioUser } from '@tech-matters/twilio-worker-auth';
 import { RulesFile, TKConditionsSets } from '../../permissions/rulesMap';
 import { ListConfiguration } from '../caseDataAccess';
-import { HrmAccountId } from '@tech-matters/types';
+import {
+  ErrorResult,
+  HrmAccountId,
+  isErr,
+  newOkFromData,
+  TResult,
+} from '@tech-matters/types';
 import { updateCaseNotify } from '../caseService';
+import {
+  DatabaseErrorResult,
+  isDatabaseUniqueConstraintViolationErrorResult,
+} from '../../sql';
+import { SuccessResult } from '@tech-matters/types';
+
+type ResourceAlreadyExistsResult = ErrorResult<'ResourceAlreadyExists'> & {
+  cause: DatabaseErrorResult;
+  resourceIdentifier: string;
+  resourceType: 'caseSection';
+};
+
+const newResourceAlreadyExistsResult = (
+  resourceIdentifier: string,
+  cause: DatabaseErrorResult,
+) => {
+  const message = `caseSection resource already exists: ${resourceIdentifier}`;
+  return {
+    _tag: 'Result',
+    status: 'error',
+    error: 'ResourceAlreadyExists',
+    cause,
+    resourceIdentifier,
+    resourceType: 'caseSection',
+    message,
+    unwrap: () => {
+      throw new Error(message);
+    },
+  } as const;
+};
+
+export const isResourceAlreadyExistsResult = (result: TResult<any, any>) =>
+  isErr(result) && result.error === 'ResourceAlreadyExists';
 
 const sectionRecordToSection = (
   sectionRecord: CaseSectionRecord | undefined,
@@ -55,7 +94,9 @@ export const createCaseSection = async (
   newSection: NewCaseSection,
   workerSid: string,
   skipSearchIndex = false,
-): Promise<CaseSection> => {
+): Promise<
+  ResourceAlreadyExistsResult | DatabaseErrorResult | SuccessResult<CaseSection>
+> => {
   const nowISO = new Date().toISOString();
   const record: CaseSectionRecord = {
     sectionId: randomUUID(),
@@ -67,15 +108,24 @@ export const createCaseSection = async (
     createdAt: nowISO,
     accountSid,
   };
-
-  const created = await create()(record);
+  const createdResult = await create()(record);
+  if (isErr(createdResult)) {
+    if (
+      isDatabaseUniqueConstraintViolationErrorResult(createdResult) &&
+      createdResult.table === 'CaseSections'
+    ) {
+      const resourceIdentifier = `${caseId}/${sectionType}/${record.sectionId}`;
+      const cause = createdResult;
+      return newResourceAlreadyExistsResult(resourceIdentifier, cause);
+    }
+  }
 
   if (!skipSearchIndex) {
     // trigger index operation but don't await for it
     updateCaseNotify({ accountSid, caseId: parseInt(caseId, 10) });
   }
 
-  return sectionRecordToSection(created);
+  return newOkFromData(sectionRecordToSection(createdResult.unwrap()));
 };
 
 export const replaceCaseSection = async (

--- a/packages/types/Result.ts
+++ b/packages/types/Result.ts
@@ -111,7 +111,7 @@ export const ensureRejection = <TError extends ErrorResult<any>, TData>(
   };
 };
 
-type SuccessResult<TData> = ResultBase & {
+export type SuccessResult<TData> = ResultBase & {
   status: 'success';
   data: TData;
   readonly unwrap: () => TData;


### PR DESCRIPTION
## Description

- The POST create endpoint for a case section now uses result types in its implementation
- The service now specifically returns a 409 for scenarios where the caller specified the sectionId, and that sectionId already exists in this case, for this case section type

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [N/A] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->

Review and merge prior to reviewing https://github.com/techmatters/hrm/pull/846/files

### Verification steps

Tested with other PRs

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P