### PR TITLE
CHI-3250 Case Section per responder (LA Circle)

### DIFF
--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -57,38 +57,46 @@ const newCaseRouter = (isPublic: boolean) => {
     },
   );
 
+  const patchCaseOverviewHandler = async (req, res) => {
+    const {
+      hrmAccountId,
+      user: { workerSid },
+      body,
+    } = req;
+    const { id } = req.params;
+    const { followUpDate } = body ?? {};
+    if (
+      followUpDate !== undefined &&
+      followUpDate !== null &&
+      isNaN(parseISO(followUpDate).valueOf())
+    ) {
+      throw createError(
+        400,
+        `Invalid followUpDate provided: ${followUpDate} - must be a valid ISO 8601 date string`,
+      );
+    }
+    const updatedCase = await caseApi.updateCaseOverview(
+      hrmAccountId,
+      id,
+      body,
+      workerSid,
+    );
+    if (!updatedCase) {
+      throw createError(404);
+    }
+    res.json(updatedCase);
+  };
+
   casesRouter.put(
     '/:id/overview',
     isPublic ? canEditCaseOverview : openEndpoint,
-    async (req, res) => {
-      const {
-        hrmAccountId,
-        user: { workerSid },
-        body,
-      } = req;
-      const { id } = req.params;
-      const { followUpDate } = body ?? {};
-      if (
-        followUpDate !== undefined &&
-        followUpDate !== null &&
-        isNaN(parseISO(followUpDate).valueOf())
-      ) {
-        throw createError(
-          400,
-          `Invalid followUpDate provided: ${followUpDate} - must be a valid ISO 8601 date string`,
-        );
-      }
-      const updatedCase = await caseApi.updateCaseOverview(
-        hrmAccountId,
-        id,
-        body,
-        workerSid,
-      );
-      if (!updatedCase) {
-        throw createError(404);
-      }
-      res.json(updatedCase);
-    },
+    patchCaseOverviewHandler,
+  );
+
+  casesRouter.patch(
+    '/:id/overview',
+    isPublic ? canEditCaseOverview : openEndpoint,
+    patchCaseOverviewHandler,
   );
 
   casesRouter.post('/', openEndpoint, async (req, res) => {

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/caseReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/caseReport.ts
@@ -16,7 +16,7 @@
  */
 
 import { ItemProcessor, NewCaseSectionInfo } from './types';
-import { addSectionToAseloCase } from './caseUpdater';
+import { addDependentSectionToAseloCase, addSectionToAseloCase } from './caseUpdater';
 import { isErr, isOk, newErr } from '@tech-matters/types';
 
 export type CaseReport = {
@@ -207,39 +207,37 @@ const addCaseReportSectionToAseloCase = addSectionToAseloCase(
   'caseReport',
   caseReportToCaseReportCaseSection,
 );
-const addPehSectionToAseloCase = addSectionToAseloCase(
+const addPehSectionToAseloCase = addDependentSectionToAseloCase(
   'personExperiencingHomelessness',
   caseReportToPehCaseSection,
 );
-const addSafetyPlanSectionToAseloCase = addSectionToAseloCase(
+const addSafetyPlanSectionToAseloCase = addDependentSectionToAseloCase(
   'safetyPlan',
   caseReportToSafetyPlanCaseSection,
 );
-const addSudSurveySectionToAseloCase = addSectionToAseloCase(
+const addSudSurveySectionToAseloCase = addDependentSectionToAseloCase(
   'sudSurvey',
   caseReportToSudSurveyCaseSection,
 );
 
 export const addCaseReportSectionsToAseloCase: ItemProcessor<CaseReport> = async (
   caseReport: CaseReport,
+
+  lastSeen: string,
 ) => {
-  const caseReportResult = await addCaseReportSectionToAseloCase(caseReport, 'something');
+  const caseReportResult = await addCaseReportSectionToAseloCase(caseReport, lastSeen);
   if (isOk(caseReportResult)) {
     const additionalSectionsResults: ReturnType<
-      ReturnType<typeof addSectionToAseloCase>
+      ReturnType<typeof addDependentSectionToAseloCase>
     >[] = [];
     if (caseReport.demographics) {
-      additionalSectionsResults.push(addPehSectionToAseloCase(caseReport, 'something'));
+      additionalSectionsResults.push(addPehSectionToAseloCase(caseReport));
     }
     if (caseReport.collaborative_sud_survey) {
-      additionalSectionsResults.push(
-        addSudSurveySectionToAseloCase(caseReport, 'something'),
-      );
+      additionalSectionsResults.push(addSudSurveySectionToAseloCase(caseReport));
     }
     if (caseReport.safety_plan) {
-      additionalSectionsResults.push(
-        addSafetyPlanSectionToAseloCase(caseReport, 'something'),
-      );
+      additionalSectionsResults.push(addSafetyPlanSectionToAseloCase(caseReport));
     }
     const errors = (await Promise.all(additionalSectionsResults)).filter(isErr);
     if (errors.length) {

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
@@ -66,6 +66,7 @@ export const incidentReportToCaseSection = ({
   scene_arrival_interval,
   triage_interval,
   transport_interval,
+  total_scene_interval,
   total_incident_interval,
 }: IncidentReport): NewCaseSectionInfo => {
   return {
@@ -87,6 +88,7 @@ export const incidentReportToCaseSection = ({
         sceneArrivalInterval: scene_arrival_interval,
         triageInterval: triage_interval,
         transportInterval: transport_interval,
+        totalSceneInterval: total_scene_interval,
         totalIncidentTime: total_incident_interval,
       },
     },

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
@@ -39,12 +39,21 @@ export type IncidentReport = {
   number_of_patient_transports: number;
   responders: Responder[];
   tags: string[];
+  // Incident intervals
+  activation_interval: number | null;
+  enroute_time_interval: number | null;
+  scene_arrival_interval: number | null;
+  triage_interval: number | null;
+  total_scene_interval: number | null;
+  transport_interval: number | null;
+  total_incident_interval: number | null;
 };
 
 export const incidentReportToCaseSection = ({
   id,
   case_id,
   updated_at,
+  created_at,
   incident_class_id,
   category,
   latitude,
@@ -52,6 +61,12 @@ export const incidentReportToCaseSection = ({
   address,
   transport_destination,
   number_of_patient_transports,
+  activation_interval,
+  enroute_time_interval,
+  scene_arrival_interval,
+  triage_interval,
+  transport_interval,
+  total_incident_interval,
 }: IncidentReport): NewCaseSectionInfo => {
   return {
     caseId: case_id as string,
@@ -59,6 +74,7 @@ export const incidentReportToCaseSection = ({
     section: {
       sectionId: id.toString(),
       sectionTypeSpecificData: {
+        incidentCreationTimestamp: created_at,
         operatingArea: incident_class_id,
         incidentType: category,
         latitude,
@@ -66,6 +82,12 @@ export const incidentReportToCaseSection = ({
         locationAddress: address,
         numberOfClientsTransported: number_of_patient_transports,
         transportDestination: transport_destination,
+        activationInterval: activation_interval,
+        enrouteInterval: enroute_time_interval,
+        sceneArrivalInterval: scene_arrival_interval,
+        triageInterval: triage_interval,
+        transportInterval: transport_interval,
+        totalIncidentTime: total_incident_interval,
       },
     },
   };

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
@@ -44,6 +44,7 @@ export type IncidentReport = {
   number_of_patient_transports: number;
   responders: Responder[];
   tags: string[];
+  comment: string | null;
   // Incident intervals
   activation_interval: number | null;
   enroute_time_interval: number | null;
@@ -73,6 +74,7 @@ export const incidentReportToCaseSection = ({
   total_scene_interval,
   total_incident_interval,
   tags,
+  comment,
 }: IncidentReport): NewCaseSectionInfo => {
   return {
     caseId: case_id as string,
@@ -96,6 +98,7 @@ export const incidentReportToCaseSection = ({
         totalSceneInterval: total_scene_interval,
         totalIncidentTime: total_incident_interval,
         tags,
+        comments: comment,
       },
     },
   };

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/index.ts
@@ -29,10 +29,10 @@ export const handler = async ({
 }): Promise<0> => {
   const API_POLL_CONFIGS = {
     caseReport: {
-      url: new URL(`${process.env.BEACON_BASE_URL}/api/aselo/casereports/updates`),
+      url: new URL(`${process.env.BEACON_BASE_URL}/api/aselo/case_reports/updates`),
       headers: beaconHeaders,
       lastUpdateSeenSsmKey: lastCaseReportUpdateSeenSsmKey,
-      itemExtractor: (body: any) => body.casereports,
+      itemExtractor: (body: any) => body.case_reports,
       itemProcessor: addCaseReportSectionsToAseloCase,
       maxItemsInChunk: parseInt(process.env.MAX_CASE_REPORTS_PER_CALL || '1000'),
       maxChunksToRead: parseInt(process.env.MAX_CONSECUTIVE_API_CALLS || '10'),

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/index.ts
@@ -14,10 +14,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { incidentReportToCaseSection } from './incidentReport';
+import { addIncidentReportSectionsToAseloCase } from './incidentReport';
 import { accountSid, beaconHeaders } from './config';
 import { readApiInChunks } from './apiChunkReader';
-import { addSectionToAseloCase } from './caseUpdater';
 import { addCaseReportSectionsToAseloCase } from './caseReport';
 
 const lastIncidentReportUpdateSeenSsmKey = `/${process.env.NODE_ENV}/hrm/custom-integration/uscr/${accountSid}/beacon/latest_incident_report_seen`;
@@ -44,7 +43,7 @@ export const handler = async ({
       headers: beaconHeaders,
       lastUpdateSeenSsmKey: lastIncidentReportUpdateSeenSsmKey,
       itemExtractor: (body: any) => body.incidents,
-      itemProcessor: addSectionToAseloCase('incidentReport', incidentReportToCaseSection),
+      itemProcessor: addIncidentReportSectionsToAseloCase,
       maxItemsInChunk: parseInt(process.env.MAX_INCIDENT_REPORTS_PER_CALL || '1000'),
       maxChunksToRead: parseInt(process.env.MAX_CONSECUTIVE_API_CALLS || '10'),
       itemTypeName: 'incident report',

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/responder.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/responder.ts
@@ -28,20 +28,12 @@ export type Responder = {
     hospital_arrival_received_at: string | null;
     complete_incident_received_at: string | null;
   };
-  intervals: {
-    enroute_time_interval: number | null;
-    scene_arrival_interval: number | null;
-    triage_interval: number | null;
-    total_scene_interval: number | null;
-    transport_interval: number | null;
-    total_incident_interval: number | null;
-  };
 };
 
 export const responderToCaseSection = (
   caseId: string,
   incidentReportId: number,
-  { name, timestamps, intervals, id }: Responder,
+  { name, timestamps, id }: Responder,
   lastUpdated: string,
 ): NewCaseSectionInfo => ({
   caseId,
@@ -56,11 +48,6 @@ export const responderToCaseSection = (
       transportTimestamp: timestamps.transport_info_received_at,
       destinationArrivalTimestamp: timestamps.hospital_arrival_received_at,
       incidentCompleteTimestamp: timestamps.complete_incident_received_at,
-      enrouteInterval: intervals.enroute_time_interval,
-      sceneArrivalInterval: intervals.scene_arrival_interval,
-      triageInterval: intervals.triage_interval,
-      transportInterval: intervals.transport_interval,
-      totalIncidentTime: intervals.total_incident_interval,
     },
   },
 });

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/responder.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/responder.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { NewCaseSectionInfo } from './types';
+
+export type Responder = {
+  id: number;
+  name: string;
+  timestamps: {
+    alert_reply_received_at: string | null;
+    enroute_received_at: string | null;
+    on_scene_received_at: string | null;
+    additional_reply_received_at: string | null;
+    transport_info_received_at: string | null;
+    hospital_arrival_received_at: string | null;
+    complete_incident_received_at: string | null;
+  };
+  intervals: {
+    enroute_time_interval: number | null;
+    scene_arrival_interval: number | null;
+    triage_interval: number | null;
+    total_scene_interval: number | null;
+    transport_interval: number | null;
+    total_incident_interval: number | null;
+  };
+};
+
+export const responderToCaseSection = (
+  caseId: string,
+  incidentReportId: number,
+  { name, timestamps, intervals, id }: Responder,
+  lastUpdated: string,
+): NewCaseSectionInfo => ({
+  caseId,
+  lastUpdated,
+  section: {
+    sectionId: `${incidentReportId}/${id}`,
+    sectionTypeSpecificData: {
+      responderName: name,
+      enrouteTimestamp: timestamps.enroute_received_at,
+      onSceneTimestamp: timestamps.on_scene_received_at,
+      additionalResourcesTimestamp: timestamps.additional_reply_received_at,
+      transportTimestamp: timestamps.transport_info_received_at,
+      destinationArrivalTimestamp: timestamps.hospital_arrival_received_at,
+      incidentCompleteTimestamp: timestamps.complete_incident_received_at,
+      enrouteInterval: intervals.enroute_time_interval,
+      sceneArrivalInterval: intervals.scene_arrival_interval,
+      triageInterval: intervals.triage_interval,
+      transportInterval: intervals.transport_interval,
+      totalIncidentTime: intervals.total_incident_interval,
+    },
+  },
+});

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
@@ -37,6 +37,13 @@ const EMPTY_INCIDENT_REPORT: IncidentReport = {
   updated_at: '',
   responders: [],
   tags: [],
+  activation_interval: null,
+  enroute_time_interval: null,
+  scene_arrival_interval: null,
+  triage_interval: null,
+  total_scene_interval: null,
+  transport_interval: null,
+  total_incident_interval: null,
 };
 
 export const generateIncidentReport = (

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
@@ -38,6 +38,7 @@ const EMPTY_INCIDENT_REPORT: IncidentReport = {
   updated_at: '',
   responders: [],
   tags: [],
+  comment: null,
   activation_interval: null,
   enroute_time_interval: null,
   scene_arrival_interval: null,

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
@@ -18,6 +18,7 @@ import { IncidentReport } from '../src/incidentReport';
 import { CaseReport } from '../src/caseReport';
 
 const EMPTY_INCIDENT_REPORT: IncidentReport = {
+  priority: '',
   address: '',
   caller_name: '',
   caller_number: '',
@@ -28,7 +29,7 @@ const EMPTY_INCIDENT_REPORT: IncidentReport = {
   created_at: '',
   description: '',
   id: undefined as any,
-  incident_class_id: 0,
+  class: '',
   latitude: 0,
   longitude: 0,
   status: '',

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
@@ -112,7 +112,6 @@ const generateIncidentReports = (
           id,
           name: `Responder for case #${caseIds[indexInCurrentIteration]} on incident #${iteration} with id #${id}`,
           timestamps: {} as any,
-          intervals: {} as any,
         })),
         caller_number: '1234567890',
         created_at: start.toISOString(),

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
@@ -186,7 +186,7 @@ export const mockBeacon = async <TItem>(
         statusCode: 200,
         body: JSON.stringify({
           status: 'success',
-          [apiPath.includes('incidents') ? 'incidents' : 'casereports']: response,
+          [apiPath.includes('incidents') ? 'incidents' : 'case_reports']: response,
         }),
         headers: BEACON_RESPONSE_HEADERS,
       };
@@ -264,7 +264,7 @@ describe('Beacon Polling Service', () => {
       const apiPath =
         apiType === 'incidentReport'
           ? '/api/aselo/incidents/updates'
-          : '/api/aselo/casereports/updates';
+          : '/api/aselo/case_reports/updates';
       test(`[${apiType}] Returns less than the maximum records - doesn't query again`, async () => {
         const caseIds = await generateCases(4);
         if (apiType === 'incidentReport') {
@@ -563,7 +563,7 @@ describe('Beacon Polling Service', () => {
         const caseReports = generateCaseReports(2, 1, caseIds);
         mockedBeaconEndpoint = await mockBeacon(
           await mockingProxy.mockttpServer(),
-          '/api/aselo/casereports/updates',
+          '/api/aselo/case_reports/updates',
           [caseReports],
         );
         // Act

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
@@ -356,8 +356,8 @@ describe('Beacon Polling Service', () => {
             incidentReportId,
           }: { responder: Responder; incidentReportId: number },
         ) => {
-          const { name } = responder;
-          expect(actual.sectionId).toBe(`${incidentReportId}/${name}`);
+          const { name, id } = responder;
+          expect(actual.sectionId).toBe(`${incidentReportId}/${id}`);
           expect(actual.sectionTypeSpecificData).toMatchObject({
             responderName: name,
           });

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/caseReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/caseReport.test.ts
@@ -14,55 +14,18 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { NewCaseSection } from '../../src/types';
 import { generateCaseReport, generateCompleteCaseReport } from '../mockGenerators';
 import { addCaseReportSectionsToAseloCase, CaseReport } from '../../src/caseReport';
 import '@tech-matters/testing';
 import { isErr, isOk } from '@tech-matters/types';
 import { AssertionError } from 'node:assert';
+import { verifyAddSectionRequest } from './verifyAddSectionRequest';
 
 const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn();
 
 global.fetch = mockFetch;
 
 describe('addCaseReportSectionsToAseloCase', () => {
-  const verifyAddSectionRequest = (
-    caseId: string,
-    caseSectionType:
-      | 'caseReport'
-      | 'personExperiencingHomelessness'
-      | 'sudSurvey'
-      | 'safetyPlan',
-    expectedCaseSection: NewCaseSection,
-    firstRequest = true,
-  ) => {
-    expect(mockFetch.mock.calls.length).toBeGreaterThan(firstRequest ? 0 : 1);
-    const [firstCall, ...subsequentCalls] = mockFetch.mock.calls;
-    const callsToCheck = firstRequest ? [firstCall] : subsequentCalls;
-    const call = callsToCheck.find(
-      ([url]) =>
-        url ===
-        `${process.env.INTERNAL_HRM_URL}/internal/v0/accounts/${process.env.ACCOUNT_SID}/cases/${caseId}/sections/${caseSectionType}`,
-    );
-    if (!call) {
-      throw new AssertionError({
-        message: `Expected request to ${caseSectionType} section not found`,
-        actual: mockFetch.mock.calls,
-      });
-    }
-
-    expect(call[1]).toStrictEqual({
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Basic ${process.env.STATIC_KEY}`,
-      },
-      body: expect.any(String),
-    });
-    let parsedJson = JSON.parse(call[1]!.body as string);
-    expect(parsedJson).toStrictEqual(expectedCaseSection);
-  };
-
   const caseReportWithCoreSection = generateCaseReport({
     id: 'caseReportId',
     case_id: '5678',

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/caseUpdater.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/caseUpdater.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { NewCaseSection } from '../../src/types';
-import { addSectionToAseloCase } from '../../src/caseUpdater';
+import {
+  addDependentSectionToAseloCase,
+  addSectionToAseloCase,
+} from '../../src/caseUpdater';
 import { isErr, isOk } from '@tech-matters/types';
 import { AssertionError } from 'node:assert';
 
@@ -30,24 +33,29 @@ type Chicken = {
   boc: 'boc' | 'bwaaaaak' | 'bocARGGH';
 };
 
-describe('addSectionToAseloCase', () => {
-  const verifyAddSectionRequest = (
-    caseId: string,
-    expectedCaseSection: NewCaseSection,
-  ) => {
-    expect(mockFetch).toHaveBeenCalledWith(
-      `${process.env.INTERNAL_HRM_URL}/internal/v0/accounts/${process.env.ACCOUNT_SID}/cases/${caseId}/sections/chicken`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Basic ${process.env.STATIC_KEY}`,
-        },
-        body: JSON.stringify(expectedCaseSection),
+const verifyAddSectionRequest = (caseId: string, expectedCaseSection: NewCaseSection) => {
+  expect(mockFetch).toHaveBeenCalledWith(
+    `${process.env.INTERNAL_HRM_URL}/internal/v0/accounts/${process.env.ACCOUNT_SID}/cases/${caseId}/sections/chicken`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${process.env.STATIC_KEY}`,
       },
-    );
-  };
+      body: JSON.stringify(expectedCaseSection),
+    },
+  );
+};
 
+beforeEach(async () => {
+  jest.clearAllMocks();
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ message: 'OK' }),
+  } as Response);
+});
+
+describe('addSectionToAseloCase', () => {
   const chickenAdder = addSectionToAseloCase('chicken', (chicken: Chicken) => {
     return {
       caseId: chicken.case_id,
@@ -61,15 +69,7 @@ describe('addSectionToAseloCase', () => {
     };
   });
 
-  beforeEach(async () => {
-    jest.clearAllMocks();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ message: 'OK' }),
-    } as Response);
-  });
-
-  test('most beacon incident report properties map to equivalents in the Aselo case section', async () => {
+  test('creates an Aselo case section from source data using the mapper provided and adds it to the case via the HRM API, returning the updated last_seen', async () => {
     const result = await chickenAdder(
       {
         case_id: '1234',
@@ -251,6 +251,172 @@ describe('addSectionToAseloCase', () => {
       },
       '40',
     );
+    if (isErr(result)) {
+      expect(result.error).toEqual({
+        level: 'error',
+        thrownError,
+        type: 'UnexpectedError',
+      });
+      expect(result.message).toEqual('boom');
+    } else {
+      throw new AssertionError({ message: 'Expected error', actual: result });
+    }
+  });
+});
+
+describe('addDependentSectionToAseloCase', () => {
+  const dependentChickenAdder = addDependentSectionToAseloCase(
+    'chicken',
+    (chicken: Chicken) => {
+      return {
+        caseId: chicken.case_id,
+        section: {
+          sectionId: chicken.id,
+          sectionTypeSpecificData: {
+            boc: chicken.boc,
+          },
+        },
+      };
+    },
+  );
+  test('creates an Aselo case section from source data using the mapper provided and adds it to the case via the HRM API', async () => {
+    const result = await dependentChickenAdder({
+      case_id: '1234',
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
+    verifyAddSectionRequest('1234', {
+      sectionId: '5678',
+      sectionTypeSpecificData: {
+        boc: 'bocARGGH',
+      },
+    });
+    if (isOk(result)) {
+      expect(result.unwrap()).not.toBeDefined();
+    } else throw new AssertionError({ message: 'Did not expect error', actual: result });
+  });
+  test('Service responds with 409 - returns warn level error result', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => 'Already exists',
+    } as Response);
+    const result = await dependentChickenAdder({
+      case_id: '1234',
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
+    if (isErr(result)) {
+      expect(result.error).toEqual({
+        level: 'warn',
+        caseId: '1234',
+        sectionId: '5678',
+        type: 'SectionExists',
+      });
+    } else {
+      throw new AssertionError({ message: 'Expected error', actual: result });
+    }
+    verifyAddSectionRequest('1234', {
+      sectionId: '5678',
+      sectionTypeSpecificData: {
+        boc: 'bocARGGH',
+      },
+    });
+  });
+  test('Service responds with 404 - returns warn level error result', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'No case',
+    } as Response);
+    const result = await dependentChickenAdder({
+      case_id: '1234',
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
+    if (isErr(result)) {
+      expect(result.error).toEqual({
+        level: 'warn',
+        caseId: '1234',
+        sectionId: '5678',
+        type: 'CaseNotFound',
+      });
+    } else {
+      throw new AssertionError({ message: 'Expected error', actual: result });
+    }
+    verifyAddSectionRequest('1234', {
+      sectionId: '5678',
+      sectionTypeSpecificData: {
+        boc: 'bocARGGH',
+      },
+    });
+  });
+  test('Service responds with 500 - returns error level error result', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'No case',
+    } as Response);
+    const result = await dependentChickenAdder({
+      case_id: '1234',
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
+    if (isErr(result)) {
+      expect(result.error).toEqual({
+        level: 'error',
+        status: 500,
+        type: 'UnexpectedHttpError',
+        body: 'No case',
+      });
+    } else {
+      throw new AssertionError({ message: 'Expected error', actual: result });
+    }
+    verifyAddSectionRequest('1234', {
+      sectionId: '5678',
+      sectionTypeSpecificData: {
+        boc: 'bocARGGH',
+      },
+    });
+  });
+  test('No case id provided - returns error without requesting', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'No case',
+    } as Response);
+    const result = await dependentChickenAdder({
+      case_id: undefined as any,
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
+    if (isErr(result)) {
+      expect(result.error).toEqual({
+        level: 'error',
+        sectionId: '5678',
+        type: 'CaseNotSpecified',
+      });
+    } else {
+      throw new AssertionError({ message: 'Expected error', actual: result });
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+  test('Error caused by something other than HTTP response code', async () => {
+    const thrownError = new Error('boom');
+    mockFetch.mockImplementation(() => {
+      throw thrownError;
+    });
+    const result = await dependentChickenAdder({
+      case_id: 'boc',
+      id: '5678',
+      boc: 'bocARGGH',
+      chicken_counter: 42,
+    });
     if (isErr(result)) {
       expect(result.error).toEqual({
         level: 'error',

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
@@ -165,7 +165,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
             },
           },
           {
-            name: 'Chalie Ballantyne',
+            name: 'Charlie Ballantyne',
             id: 6184,
             timestamps: {
               alert_reply_received_at: '1969',
@@ -179,7 +179,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
             intervals: {
               enroute_time_interval: 208,
               scene_arrival_interval: 3,
-              triage_interval: 208,
+              triage_interval: null,
               total_scene_interval: 411,
               transport_interval: null,
               total_incident_interval: 208,
@@ -229,7 +229,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
       {
         sectionId: '5678/6184',
         sectionTypeSpecificData: {
-          responderName: 'Lorna Ballantyne',
+          responderName: 'Charlie Ballantyne',
           enrouteTimestamp: '1970',
           onSceneTimestamp: '1974',
           additionalResourcesTimestamp: null,

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
@@ -83,6 +83,7 @@ describe('incidentReportToCaseSection', () => {
         enrouteInterval: 208,
         sceneArrivalInterval: 3,
         triageInterval: 208,
+        totalSceneInterval: 411,
         transportInterval: null,
         totalIncidentTime: 55 * 52,
       },
@@ -203,6 +204,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         enrouteInterval: 208,
         sceneArrivalInterval: 3,
         triageInterval: 208,
+        totalSceneInterval: 411,
         transportInterval: null,
         totalIncidentTime: 55 * 52,
       },
@@ -285,6 +287,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         sceneArrivalInterval: 3,
         triageInterval: 208,
         transportInterval: null,
+        totalSceneInterval: 411,
         totalIncidentTime: 55 * 52,
       },
     });

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
@@ -29,6 +29,7 @@ describe('incidentReportToCaseSection', () => {
   test('most beacon incident report properties map to equivalents in the Aselo case section', () => {
     const { section, caseId, lastUpdated } = incidentReportToCaseSection(
       generateIncidentReport({
+        created_at: '1969',
         case_id: '1234',
         id: 5678,
         incident_class_id: 6,
@@ -41,6 +42,13 @@ describe('incidentReportToCaseSection', () => {
         number_of_patient_transports: 4000000000,
         updated_at: 'not long ago',
         tags: [],
+        activation_interval: 1,
+        enroute_time_interval: 208,
+        scene_arrival_interval: 3,
+        triage_interval: 208,
+        total_scene_interval: 411,
+        transport_interval: null,
+        total_incident_interval: 55 * 52,
         responders: [
           {
             name: 'Lorna Ballantyne',
@@ -54,14 +62,6 @@ describe('incidentReportToCaseSection', () => {
               hospital_arrival_received_at: '2025',
               complete_incident_received_at: '2026 (est)',
             },
-            intervals: {
-              enroute_time_interval: 208,
-              scene_arrival_interval: 3,
-              triage_interval: 208,
-              total_scene_interval: 411,
-              transport_interval: null,
-              total_incident_interval: 55 * 52,
-            },
           },
         ],
       }),
@@ -71,6 +71,7 @@ describe('incidentReportToCaseSection', () => {
     expect(section).toStrictEqual({
       sectionId: '5678',
       sectionTypeSpecificData: {
+        incidentCreationTimestamp: '1969',
         operatingArea: 6,
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,
@@ -78,6 +79,12 @@ describe('incidentReportToCaseSection', () => {
         locationAddress: 'Echo Park, Los Angeles, CA, USA',
         transportDestination: 'Europa, Saturn',
         numberOfClientsTransported: 4000000000,
+        activationInterval: 1,
+        enrouteInterval: 208,
+        sceneArrivalInterval: 3,
+        triageInterval: 208,
+        transportInterval: null,
+        totalIncidentTime: 55 * 52,
       },
     });
   });
@@ -130,6 +137,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
   test('Responders specified - adds case section and responders', async () => {
     await addIncidentReportSectionsToAseloCase(
       generateIncidentReport({
+        created_at: '1969',
         case_id: '1234',
         id: 5678,
         incident_class_id: 6,
@@ -142,6 +150,13 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         number_of_patient_transports: 4000000000,
         updated_at: 'just now',
         tags: [],
+        activation_interval: 1,
+        enroute_time_interval: 208,
+        scene_arrival_interval: 3,
+        triage_interval: 208,
+        total_scene_interval: 411,
+        transport_interval: null,
+        total_incident_interval: 55 * 52,
         responders: [
           {
             name: 'Lorna Ballantyne',
@@ -154,14 +169,6 @@ describe('addIncidentReportSectionsToAseloCase', () => {
               transport_info_received_at: '1978',
               hospital_arrival_received_at: '2025',
               complete_incident_received_at: '2026 (est)',
-            },
-            intervals: {
-              enroute_time_interval: 208,
-              scene_arrival_interval: 3,
-              triage_interval: 208,
-              total_scene_interval: 411,
-              transport_interval: null,
-              total_incident_interval: 55 * 52,
             },
           },
           {
@@ -176,14 +183,6 @@ describe('addIncidentReportSectionsToAseloCase', () => {
               hospital_arrival_received_at: null,
               complete_incident_received_at: '1974',
             },
-            intervals: {
-              enroute_time_interval: 208,
-              scene_arrival_interval: 3,
-              triage_interval: null,
-              total_scene_interval: 411,
-              transport_interval: null,
-              total_incident_interval: 208,
-            },
           },
         ],
       }),
@@ -192,6 +191,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
     verifyAddSectionRequest('1234', 'incidentReport', {
       sectionId: '5678',
       sectionTypeSpecificData: {
+        incidentCreationTimestamp: '1969',
         operatingArea: 6,
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,
@@ -199,6 +199,12 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         locationAddress: 'Echo Park, Los Angeles, CA, USA',
         transportDestination: 'Europa, Saturn',
         numberOfClientsTransported: 4000000000,
+        activationInterval: 1,
+        enrouteInterval: 208,
+        sceneArrivalInterval: 3,
+        triageInterval: 208,
+        transportInterval: null,
+        totalIncidentTime: 55 * 52,
       },
     });
     verifyAddSectionRequest(
@@ -214,11 +220,6 @@ describe('addIncidentReportSectionsToAseloCase', () => {
           transportTimestamp: '1978',
           destinationArrivalTimestamp: '2025',
           incidentCompleteTimestamp: '2026 (est)',
-          enrouteInterval: 208,
-          sceneArrivalInterval: 3,
-          triageInterval: 208,
-          transportInterval: null,
-          totalIncidentTime: 55 * 52,
         },
       },
       false,
@@ -236,11 +237,6 @@ describe('addIncidentReportSectionsToAseloCase', () => {
           transportTimestamp: null,
           destinationArrivalTimestamp: null,
           incidentCompleteTimestamp: '1974',
-          enrouteInterval: 208,
-          sceneArrivalInterval: 3,
-          triageInterval: null,
-          transportInterval: null,
-          totalIncidentTime: 208,
         },
       },
       false,
@@ -250,6 +246,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
   test('No responders - just adds case section', async () => {
     await addIncidentReportSectionsToAseloCase(
       generateIncidentReport({
+        created_at: '1969',
         case_id: '1234',
         id: 5678,
         incident_class_id: 6,
@@ -262,12 +259,20 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         number_of_patient_transports: 4000000000,
         updated_at: 'just now',
         tags: [],
+        activation_interval: 1,
+        enroute_time_interval: 208,
+        scene_arrival_interval: 3,
+        triage_interval: 208,
+        total_scene_interval: 411,
+        transport_interval: null,
+        total_incident_interval: 55 * 52,
       }),
       'not long ago',
     );
     verifyAddSectionRequest('1234', 'incidentReport', {
       sectionId: '5678',
       sectionTypeSpecificData: {
+        incidentCreationTimestamp: '1969',
         operatingArea: 6,
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,
@@ -275,6 +280,12 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         locationAddress: 'Echo Park, Los Angeles, CA, USA',
         transportDestination: 'Europa, Saturn',
         numberOfClientsTransported: 4000000000,
+        activationInterval: 1,
+        enrouteInterval: 208,
+        sceneArrivalInterval: 3,
+        triageInterval: 208,
+        transportInterval: null,
+        totalIncidentTime: 55 * 52,
       },
     });
   });

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
@@ -84,6 +84,7 @@ describe('incidentReportToCaseSection', () => {
         total_scene_interval: 411,
         transport_interval: null,
         total_incident_interval: 55 * 52,
+        comment: 'far out...',
         responders: [
           {
             name: 'Lorna Ballantyne',
@@ -122,6 +123,7 @@ describe('incidentReportToCaseSection', () => {
         transportInterval: null,
         totalIncidentTime: 55 * 52,
         tags: ['tag1', 'tag2'],
+        comments: 'far out...',
       },
     });
   });
@@ -188,6 +190,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         number_of_patient_transports: 4000000000,
         updated_at: 'just now',
         tags: ['tag1', 'tag2'],
+        comment: 'far out...',
         activation_interval: 1,
         enroute_time_interval: 208,
         scene_arrival_interval: 3,
@@ -245,6 +248,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         transportInterval: null,
         totalIncidentTime: 55 * 52,
         tags: ['tag1', 'tag2'],
+        comments: 'far out...',
       },
     });
     verifyAddSectionRequest(
@@ -311,6 +315,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         total_scene_interval: 411,
         transport_interval: null,
         total_incident_interval: 55 * 52,
+        comment: 'far out...',
       }),
       'not long ago',
     );
@@ -333,6 +338,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         totalSceneInterval: 411,
         totalIncidentTime: 55 * 52,
         tags: ['tag1', 'tag2'],
+        comments: 'far out...',
       },
     });
     verifyUpdateOverviewRequest('1234', {

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { responderToCaseSection } from '../../src/responder';
+
+const mockFetch: jest.MockedFunction<typeof fetch> = jest.fn();
+global.fetch = mockFetch;
+
+describe('responderToCaseSection', () => {
+  test('most beacon incident report properties map to equivalents in the Aselo case section', () => {
+    const { section, caseId, lastUpdated } = responderToCaseSection(
+      '1234',
+      5678,
+      {
+        name: 'Lorna Ballantyne',
+        id: 6183,
+        timestamps: {
+          alert_reply_received_at: '1969',
+          enroute_received_at: '1970',
+          on_scene_received_at: '1974',
+          additional_reply_received_at: '80s',
+          transport_info_received_at: '1978',
+          hospital_arrival_received_at: '2025',
+          complete_incident_received_at: '2026 (est)',
+        },
+        intervals: {
+          enroute_time_interval: 208,
+          scene_arrival_interval: 3,
+          triage_interval: 208,
+          total_scene_interval: 411,
+          transport_interval: null,
+          total_incident_interval: 55 * 52,
+        },
+      },
+      'not long ago',
+    );
+    expect(caseId).toBe('1234');
+    expect(lastUpdated).toBe('not long ago');
+    expect(section).toStrictEqual({
+      sectionId: '5678/6183',
+      sectionTypeSpecificData: {
+        responderName: 'Charlie Ballantyne',
+        enrouteTimestamp: '1970',
+        onSceneTimestamp: '1974',
+        additionalResourcesTimestamp: '80s',
+        transportTimestamp: '1978',
+        destinationArrivalTimestamp: '2025',
+        incidentCompleteTimestamp: '2026 (est)',
+        enrouteInterval: 208,
+        sceneArrivalInterval: 3,
+        triageInterval: null,
+        transportInterval: null,
+        totalIncidentTime: 55 * 52,
+      },
+    });
+  });
+});

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
@@ -52,7 +52,7 @@ describe('responderToCaseSection', () => {
     expect(section).toStrictEqual({
       sectionId: '5678/6183',
       sectionTypeSpecificData: {
-        responderName: 'Charlie Ballantyne',
+        responderName: 'Lorna Ballantyne',
         enrouteTimestamp: '1970',
         onSceneTimestamp: '1974',
         additionalResourcesTimestamp: '80s',
@@ -61,7 +61,7 @@ describe('responderToCaseSection', () => {
         incidentCompleteTimestamp: '2026 (est)',
         enrouteInterval: 208,
         sceneArrivalInterval: 3,
-        triageInterval: null,
+        triageInterval: 208,
         transportInterval: null,
         totalIncidentTime: 55 * 52,
       },

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/responder.test.ts
@@ -36,14 +36,6 @@ describe('responderToCaseSection', () => {
           hospital_arrival_received_at: '2025',
           complete_incident_received_at: '2026 (est)',
         },
-        intervals: {
-          enroute_time_interval: 208,
-          scene_arrival_interval: 3,
-          triage_interval: 208,
-          total_scene_interval: 411,
-          transport_interval: null,
-          total_incident_interval: 55 * 52,
-        },
       },
       'not long ago',
     );
@@ -59,11 +51,6 @@ describe('responderToCaseSection', () => {
         transportTimestamp: '1978',
         destinationArrivalTimestamp: '2025',
         incidentCompleteTimestamp: '2026 (est)',
-        enrouteInterval: 208,
-        sceneArrivalInterval: 3,
-        triageInterval: 208,
-        transportInterval: null,
-        totalIncidentTime: 55 * 52,
       },
     });
   });

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/verifyAddSectionRequest.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/verifyAddSectionRequest.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { NewCaseSection } from '../../src/types';
+import type { MockedFunction } from 'jest-mock';
+import { AssertionError } from 'node:assert';
+
+export const verifyAddSectionRequest = (
+  caseId: string,
+  caseSectionType:
+    | 'caseReport'
+    | 'personExperiencingHomelessness'
+    | 'sudSurvey'
+    | 'safetyPlan'
+    | 'incidentReport'
+    | 'assignedResponder',
+  expectedCaseSection: NewCaseSection,
+  firstRequest = true,
+) => {
+  const mockFetch = global.fetch as MockedFunction<typeof global.fetch>;
+  expect(mockFetch.mock.calls.length).toBeGreaterThan(firstRequest ? 0 : 1);
+  const [firstCall, ...subsequentCalls] = mockFetch.mock.calls;
+  const callsToCheck = firstRequest ? [firstCall] : subsequentCalls;
+  const call = callsToCheck.find(
+    ([url, options]) =>
+      url ===
+        `${process.env.INTERNAL_HRM_URL}/internal/v0/accounts/${process.env.ACCOUNT_SID}/cases/${caseId}/sections/${caseSectionType}` &&
+      JSON.parse(options!.body!.toString()).sectionId === expectedCaseSection.sectionId,
+  );
+  if (!call) {
+    throw new AssertionError({
+      message: `Expected request to ${caseSectionType} section not found`,
+      actual: mockFetch.mock.calls,
+    });
+  }
+
+  expect(call[1]).toStrictEqual({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${process.env.STATIC_KEY}`,
+    },
+    body: expect.any(String),
+  });
+  let parsedJson = JSON.parse(call[1]!.body as string);
+  expect(parsedJson).toStrictEqual(expectedCaseSection);
+};


### PR DESCRIPTION
## Description

Now adds a separate case section for each responder item in the beacon payload.

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Feature flags / configuration added

### Other Related Issues

https://github.com/techmatters/flex-plugins/pull/2881 - Flex reconfiguration

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P