### PR TITLE
CHI-3279: Deprecate onlyEssentialData flag

### DIFF
--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -201,7 +201,6 @@ const generalizedSearchQueryFunction = <T>(
         limit,
         offset,
       );
-      console.log(statement);
       const result: CaseWithCount[] = await connection.any<CaseWithCount>(
         statement,
         queryValues,

--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -133,8 +133,7 @@ export const getById = async (
   caseId: number,
   accountSid: HrmAccountId,
   { workerSid, isSupervisor }: TwilioUser,
-  contactViewPermissions: TKConditionsSets<'contact'>,
-  onlyEssentialData?: boolean,
+  contactViewPermissions: TKConditionsSets<'contact'>
 ): Promise<CaseRecord | undefined> => {
   const db = await getDbForAccount(accountSid);
   return db.task(async connection => {
@@ -142,7 +141,6 @@ export const getById = async (
       'Cases',
       contactViewPermissions,
       isSupervisor,
-      onlyEssentialData,
     );
     const queryValues = { accountSid, caseId, twilioWorkerSid: workerSid };
     return connection.oneOrNone<CaseRecord>(statement, queryValues);
@@ -172,7 +170,6 @@ export type SearchQueryFunction<T> = (
   accountSid: HrmAccountId,
   searchCriteria: T,
   filters?: CaseListFilters,
-  onlyEssentialData?: boolean,
 ) => Promise<{ cases: CaseRecord[]; count: number }>;
 
 const generalizedSearchQueryFunction = <T>(
@@ -187,7 +184,6 @@ const generalizedSearchQueryFunction = <T>(
     accountSid,
     searchCriteria,
     filters,
-    onlyEssentialData,
   ) => {
     const db = await getDbForAccount(accountSid);
     const { limit, offset, sortBy, sortDirection } =
@@ -201,7 +197,6 @@ const generalizedSearchQueryFunction = <T>(
         contactPermissions,
         filters,
         orderClause,
-        onlyEssentialData,
       );
       const queryValues = sqlQueryParamsBuilder(
         accountSid,

--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -206,7 +206,7 @@ const generalizedSearchQueryFunction = <T>(
         limit,
         offset,
       );
-
+      console.log(statement);
       const result: CaseWithCount[] = await connection.any<CaseWithCount>(
         statement,
         queryValues,
@@ -270,26 +270,15 @@ export const updateStatus = async (
   status: string,
   updatedBy: TwilioUserIdentifier,
   accountSid: HrmAccountId,
-  { isSupervisor }: TwilioUser,
-  contactViewPermissions: TKConditionsSets<'contact'>,
-) => {
+): Promise<CaseRecord> => {
   const db = await getDbForAccount(accountSid);
-  const statementValues = {
-    accountSid,
-    twilioWorkerSid: updatedBy,
-    caseId: id,
-  };
   return db.tx(async transaction => {
-    await transaction.none(
+    return transaction.oneOrNone(
       updateByIdSql(
         { status, updatedBy, updatedAt: new Date().toISOString() },
         accountSid,
         id,
       ),
-    );
-    return transaction.oneOrNone(
-      selectSingleCaseByIdSql('Cases', contactViewPermissions, isSupervisor),
-      statementValues,
     );
   });
 };

--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -36,7 +36,6 @@ import {
   CaseRecordCommon,
   CaseService,
 } from '@tech-matters/hrm-types';
-import { CaseSectionRecord } from './caseSection/types';
 import { pick } from 'lodash';
 import { HrmAccountId } from '@tech-matters/types';
 import QueryStream from 'pg-query-stream';
@@ -56,16 +55,12 @@ export const VALID_CASE_CREATE_FIELDS: (keyof CaseRecordCommon)[] = [
 
 export type NewCaseRecord = CaseRecordCommon;
 
-export type CaseRecordUpdate = Partial<NewCaseRecord> &
-  Pick<NewCaseRecord, 'updatedBy'> & {
-    caseSections?: CaseSectionRecord[];
-  };
+export type CaseRecordUpdate = Partial<NewCaseRecord> & Pick<NewCaseRecord, 'updatedBy'>;
 
 export type CaseRecord = CaseRecordCommon & {
   id: number;
   connectedContacts?: Contact[];
   contactsOwnedByUserCount?: number;
-  caseSections?: CaseSectionRecord[];
 };
 
 type CaseWithCount = CaseRecord & { totalCount: number };
@@ -215,7 +210,15 @@ const generalizedSearchQueryFunction = <T>(
       return { rows: result, count: totalCount };
     });
 
-    return { cases: rows, count };
+    return {
+      cases: rows.map(r => ({
+        ...r,
+        ...(r.connectedContacts
+          ? { connectedContacts: r.connectedContacts.slice(0, 1) }
+          : {}),
+      })),
+      count,
+    };
   };
 };
 

--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -133,7 +133,7 @@ export const getById = async (
   caseId: number,
   accountSid: HrmAccountId,
   { workerSid, isSupervisor }: TwilioUser,
-  contactViewPermissions: TKConditionsSets<'contact'>
+  contactViewPermissions: TKConditionsSets<'contact'>,
 ): Promise<CaseRecord | undefined> => {
   const db = await getDbForAccount(accountSid);
   return db.task(async connection => {

--- a/hrm-domain/hrm-core/case/caseReindexService.ts
+++ b/hrm-domain/hrm-core/case/caseReindexService.ts
@@ -15,7 +15,7 @@
  */
 
 import { HrmAccountId } from '@tech-matters/types';
-import { caseRecordToCase } from './caseService';
+import { caseRecordToCase, getTimelineForCase } from './caseService';
 import { publishCaseChangeNotification } from '../notifications/entityChangeNotify';
 import { maxPermissions } from '../permissions';
 import formatISO from 'date-fns/formatISO';
@@ -63,6 +63,7 @@ export const reindexCasesStream = async (
         try {
           const { MessageId } = await publishCaseChangeNotification({
             accountSid,
+            timeline: await getTimelineForCase(accountSid, maxPermissions, caseObj),
             case: caseObj,
             operation: 'reindex',
           });

--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -41,14 +41,10 @@ const newCaseRouter = (isPublic: boolean) => {
         hrmAccountId,
         user,
         body: { status },
-        can,
-        permissions,
       } = req;
       const { id } = req.params;
       const updatedCase = await caseApi.updateCaseStatus(id, status, hrmAccountId, {
-        can,
         user,
-        permissions,
       });
       if (!updatedCase) {
         throw createError(404);

--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -145,8 +145,8 @@ const newCaseRouter = (isPublic: boolean) => {
       const timeline = await getCaseTimeline(
         hrmAccountId,
         req,
-        parseInt(caseId),
-        (sectionTypes ?? 'note,referral').split(','),
+        caseId,
+        (sectionTypes ?? '').split(','),
         includeContacts?.toLowerCase() !== 'false',
         { limit: limit ?? 20, offset: offset ?? 0 },
       );

--- a/hrm-domain/hrm-core/case/caseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/caseRoutesV0.ts
@@ -108,18 +108,12 @@ const newCaseRouter = (isPublic: boolean) => {
   casesRouter.get('/:id', isPublic ? canViewCase : openEndpoint, async (req, res) => {
     const { hrmAccountId, permissions, can, user } = req;
     const { id } = req.params;
-    const onlyEssentialData = Boolean(req.query.onlyEssentialData);
 
-    const caseFromDB = await caseApi.getCase(
-      id,
-      hrmAccountId,
-      {
-        can,
-        user,
-        permissions,
-      },
-      onlyEssentialData,
-    );
+    const caseFromDB = await caseApi.getCase(id, hrmAccountId, {
+      can,
+      user,
+      permissions,
+    });
 
     if (!caseFromDB) {
       throw createError(404);
@@ -176,17 +170,9 @@ const newCaseRouter = (isPublic: boolean) => {
      */
     casesRouter.get('/', openEndpoint, async (req, res) => {
       const { hrmAccountId } = req;
-      const {
-        sortDirection,
-        sortBy,
-        limit,
-        offset,
-        onlyEssentialData: onlyEssentialDataParam,
-        ...search
-      } = req.query;
+      const { sortDirection, sortBy, limit, offset, ...search } = req.query;
 
       const { closedCases, counselor, helpline, ...searchCriteria } = search;
-      const onlyEssentialData = Boolean(onlyEssentialDataParam);
 
       const cases = await caseApi.searchCases(
         hrmAccountId,
@@ -194,21 +180,14 @@ const newCaseRouter = (isPublic: boolean) => {
         searchCriteria,
         { filters: { includeOrphans: false }, closedCases, counselor, helpline },
         req,
-        onlyEssentialData,
       );
       res.json(cases);
     });
 
     casesRouter.post('/search', openEndpoint, async (req, res) => {
       const { hrmAccountId } = req;
-      const {
-        closedCases,
-        counselor,
-        helpline,
-        filters,
-        onlyEssentialData,
-        ...searchCriteria
-      } = req.body || {};
+      const { closedCases, counselor, helpline, filters, ...searchCriteria } =
+        req.body || {};
 
       const searchResults = await caseApi.searchCases(
         hrmAccountId,
@@ -216,7 +195,6 @@ const newCaseRouter = (isPublic: boolean) => {
         searchCriteria,
         { closedCases, counselor, helpline, filters },
         req,
-        onlyEssentialData,
       );
       res.json(searchResults);
     });

--- a/hrm-domain/hrm-core/case/caseSection/sql/readSql.ts
+++ b/hrm-domain/hrm-core/case/caseSection/sql/readSql.ts
@@ -60,7 +60,7 @@ const selectCaseContactsForTimeline = (
         'contact' as "activityType",
         to_jsonb("contacts") AS  "activity"
         FROM "Contacts" "contacts"
-        WHERE "contacts"."caseId" = IN ($<caseIds:csv>) AND "contacts"."accountSid" = $<accountSid>
+        WHERE "contacts"."caseId" IN ($<caseIds:csv>) AND "contacts"."accountSid" = $<accountSid>
         AND ${listContactsPermissionWhereClause(
           viewContactPermissions as ContactListCondition[][],
           userIsSupervisor,

--- a/hrm-domain/hrm-core/case/caseSection/sql/readSql.ts
+++ b/hrm-domain/hrm-core/case/caseSection/sql/readSql.ts
@@ -38,27 +38,29 @@ export const SELECT_CASE_SECTION_BY_ID = `
     AND "sectionId" = $<sectionId>
     `;
 
-export const SELECT_CASE_SECTIONS_FOR_TIMELINE = `
+const selectSectionsForTimeline = (filterByType: boolean) => `
   SELECT
+        "caseId"::text AS "caseId",
         "eventTimestamp" AS "timestamp",
         'case-section' as "activityType",
         to_jsonb("caseSections") AS  "activity"
   FROM "CaseSections" AS "caseSections"
   WHERE "accountSid" = $<accountSid>
-    AND "caseId" = $<caseId>
-    AND "sectionType" IN ($<sectionTypes:csv>)
+    AND "caseId" IN ($<caseIds:csv>)
+    ${filterByType ? `AND "sectionType" IN ($<sectionTypes:csv>)` : ''}
     `;
 
-export const selectCaseContactsForTimeline = (
+const selectCaseContactsForTimeline = (
   viewContactPermissions: TKConditionsSets<'contact'>,
   userIsSupervisor: boolean,
 ) => `
-        SELECT 
+        SELECT
+        "caseId"::text AS "caseId",
         "timeOfContact" AS "timestamp",
         'contact' as "activityType",
         to_jsonb("contacts") AS  "activity"
         FROM "Contacts" "contacts"
-        WHERE "contacts"."caseId" = $<caseId> AND "contacts"."accountSid" = $<accountSid>
+        WHERE "contacts"."caseId" = IN ($<caseIds:csv>) AND "contacts"."accountSid" = $<accountSid>
         AND ${listContactsPermissionWhereClause(
           viewContactPermissions as ContactListCondition[][],
           userIsSupervisor,
@@ -68,24 +70,24 @@ export const selectCaseContactsForTimeline = (
 export const selectCaseTimelineSql = (
   user: TwilioUser,
   viewContactPermissions: TKConditionsSets<'contact'>,
-  includeSections: boolean,
+  includeSections: 'none' | 'all' | 'some',
   includeContacts: boolean,
 ): TResult<'InvalidSettings', string> => {
-  if (!includeSections && !includeContacts) {
+  if (includeSections === 'none' && !includeContacts) {
     return newErr({
       message: 'Must include either sections or contacts to run query',
       error: 'InvalidSettings',
     });
   }
 
-  const PAGINATION_SQL = `ORDER BY "timestamp" DESC LIMIT $<limit> OFFSET $<offset>`;
+  const PAGINATION_SQL = `ORDER BY "caseId", "timestamp" DESC LIMIT $<limit> OFFSET $<offset>`;
 
   if (!includeContacts) {
     return newOk({
       data: `SELECT 
     "sectionEvents".*, 
     (count(*) OVER())::INTEGER AS "totalCount" 
-    FROM (${SELECT_CASE_SECTIONS_FOR_TIMELINE}) AS "sectionEvents"
+    FROM (${selectSectionsForTimeline(includeSections !== 'all')}) AS "sectionEvents"
       ${PAGINATION_SQL}`,
     });
   }
@@ -105,7 +107,7 @@ export const selectCaseTimelineSql = (
     data: `SELECT 
      "contactAndSectionEvents".*, 
     (count(*) OVER())::INTEGER AS "totalCount" FROM ((
-    ${SELECT_CASE_SECTIONS_FOR_TIMELINE}
+    ${selectSectionsForTimeline(includeSections !== 'all')}
     ) UNION ALL (
     ${selectCaseContactsForTimeline(viewContactPermissions, user.isSupervisor)}
     )) AS "contactAndSectionEvents"

--- a/hrm-domain/hrm-core/case/caseSection/timelineToLegacyCaseProperties.ts
+++ b/hrm-domain/hrm-core/case/caseSection/timelineToLegacyCaseProperties.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  CaseSection,
+  isCaseSectionTimelineActivity,
+  isContactTimelineActivity,
+} from './types';
+import { TimelineActivity, Contact } from '@tech-matters/hrm-types';
+
+export const timelineToLegacySections = (
+  timeline: TimelineActivity<any>[],
+): Record<string, CaseSection[]> => {
+  const sections: Record<string, CaseSection[]> = {};
+  for (const { activity } of timeline.filter(isCaseSectionTimelineActivity)) {
+    sections[activity.sectionType] = sections[activity.sectionType] ?? [];
+    const { accountSid, caseId, ...section } = activity;
+    sections[activity.sectionType].push(section);
+  }
+
+  return sections;
+};
+
+export const timelineToLegacyConnectedContacts = (
+  timeline: TimelineActivity<any>[],
+): Contact[] =>
+  timeline.filter(isContactTimelineActivity).map(contact => contact.activity);

--- a/hrm-domain/hrm-core/case/caseSection/types.ts
+++ b/hrm-domain/hrm-core/case/caseSection/types.ts
@@ -13,7 +13,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { CaseSectionRecord, CaseSection } from '@tech-matters/hrm-types';
+import {
+  CaseSection,
+  CaseSectionRecord,
+  CaseSectionTimelineActivity,
+  ContactTimelineActivity,
+  TimelineActivity,
+} from '@tech-matters/hrm-types';
 
 export { CaseSectionRecord, CaseSection };
 
@@ -26,3 +32,17 @@ export type CaseSectionUpdate = Omit<
 export type NewCaseSection = Omit<CaseSectionUpdate, 'updatedAt' | 'updatedBy'> & {
   sectionId?: string;
 };
+
+export type TimelineActivityRecord = TimelineActivity<any> & { caseId: string };
+
+export type TimelineDbRecords = {
+  count: number;
+  activities: TimelineActivityRecord[];
+};
+export const isCaseSectionTimelineActivity = (
+  activity: TimelineActivity<any>,
+): activity is CaseSectionTimelineActivity => activity.activityType === 'case-section';
+
+export const isContactTimelineActivity = (
+  activity: TimelineActivity<any>,
+): activity is ContactTimelineActivity => activity.activityType === 'contact';

--- a/hrm-domain/hrm-core/case/sql/caseGetSql.ts
+++ b/hrm-domain/hrm-core/case/sql/caseGetSql.ts
@@ -50,7 +50,7 @@ const leftJoinLateralContacts = (
             'c2',
           )}
         )
-          
+        LIMIT 1  
       ) "contacts" ON true`;
 
 export const selectSingleCaseByIdSql = (
@@ -59,16 +59,10 @@ export const selectSingleCaseByIdSql = (
   userIsSupervisor: boolean,
 ) => `SELECT
       "cases".*,
-      "caseSections"."caseSections",
       "contacts"."connectedContacts",
       "contactsOwnedCount"."contactsOwnedByUserCount"
       FROM "${tableName}" AS "cases"
       ${leftJoinLateralContacts(contactViewPermissions, userIsSupervisor)}
-      LEFT JOIN LATERAL (
-        SELECT COALESCE(jsonb_agg(to_jsonb(cs) ORDER BY cs."createdAt"), '[]') AS  "caseSections"
-        FROM "CaseSections" cs
-        WHERE cs."caseId" = cases.id AND cs."accountSid" = cases."accountSid"
-      ) "caseSections" ON true
       LEFT JOIN LATERAL (
         ${selectContactsOwnedCount('twilioWorkerSid')}
       ) "contactsOwnedCount" ON true

--- a/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
+++ b/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
@@ -78,6 +78,7 @@ const selectContacts = (
         userIsSupervisor,
       )}
       GROUP BY "contacts"."caseId", "contacts"."accountSid"
+      
       `;
 
 const enum FilterableDateField {

--- a/hrm-domain/hrm-core/case/sql/caseUpdateSql.ts
+++ b/hrm-domain/hrm-core/case/sql/caseUpdateSql.ts
@@ -47,7 +47,7 @@ export const updateByIdSql = (
         ${pgp.helpers.update(updatedValues, updateCaseColumnSet)} 
         ${statusUpdatedSetSql(updatedValues)}
         ${pgp.as.format(
-          `WHERE "Cases"."accountSid" = $<accountSid> AND "Cases"."id" = $<caseId>`,
+          `WHERE "Cases"."accountSid" = $<accountSid> AND "Cases"."id" = $<caseId> RETURNING *`,
           {
             accountSid,
             caseId,

--- a/hrm-domain/hrm-core/unit-tests/case/caseDataAccess.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/case/caseDataAccess.test.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { createMockCaseInsert, createMockCaseRecord } from './mock-cases';
+import { createMockCaseInsert, createMockCaseRecord } from './mockCases';
 import * as pgPromise from 'pg-promise';
 import { getMockAccountDb, mockConnection, mockTask } from '../mockDb';
 import * as caseDb from '../../case/caseDataAccess';
@@ -64,7 +64,7 @@ describe('getById', () => {
     const result = await caseDb.getById(caseId, accountSid, user, [['everyone']]);
 
     expect(oneOrNoneSpy).toHaveBeenCalledWith(
-      expect.stringContaining('CSAMReports'),
+      expect.stringContaining('"Cases"'),
       expect.objectContaining({ accountSid, caseId }),
     );
     expect(result).not.toBeDefined();
@@ -310,7 +310,6 @@ describe('search', () => {
       );
       const statementExecuted = getSqlStatement(anySpy);
       expect(statementExecuted).toContain('Contacts');
-      expect(statementExecuted).toContain('CSAMReports');
       expect(result.count).toEqual(1337);
       expect(result.cases).toStrictEqual(expectedResult);
     },

--- a/hrm-domain/hrm-core/unit-tests/case/caseService.test.ts
+++ b/hrm-domain/hrm-core/unit-tests/case/caseService.test.ts
@@ -16,7 +16,8 @@
 
 import * as caseDb from '../../case/caseDataAccess';
 import * as caseApi from '../../case/caseService';
-import { createMockCase, createMockCaseRecord } from './mock-cases';
+import * as caseSectionApi from '../../case/caseSection/caseSectionService';
+import { createMockCase, createMockCaseRecord } from './mockCases';
 import each from 'jest-each';
 import { CaseRecord, NewCaseRecord } from '../../case/caseDataAccess';
 import '@tech-matters/testing/expectToParseAsDate';
@@ -61,6 +62,9 @@ test('create case', async () => {
   const createSpy = jest.spyOn(caseDb, 'create').mockResolvedValue(createdCaseRecord);
   // const getByIdSpy =
   jest.spyOn(caseDb, 'getById').mockResolvedValueOnce(createdCaseRecord);
+  jest
+    .spyOn(caseSectionApi, 'getMultipleCaseTimelines')
+    .mockResolvedValue({ count: 0, timelines: {} });
 
   const createdCase = await caseApi.createCase(caseToBeCreated, accountSid, workerSid);
   // any worker & account specified on the object should be overwritten with the ones from the user
@@ -108,50 +112,12 @@ describe('searchCases', () => {
     ],
   });
 
-  const firstChild = caseWithContact.connectedContacts![0];
-  const caseWithContactEssentialData = {
-    id: caseWithContact.id,
-    status: caseWithContact.status,
-    connectedContacts: [
-      {
-        rawJson: {
-          childInformation: {
-            firstName: firstChild.rawJson?.childInformation.firstName,
-            lastName: firstChild.rawJson?.childInformation.firstName,
-          },
-        },
-      },
-    ],
-    twilioWorkerId: caseWithContact.twilioWorkerId,
-    categories: caseWithContact.categories,
-    createdAt: caseWithContact.createdAt,
-    updatedAt: caseWithContact.updatedAt,
-    info: {
-      summary: caseWithContact.info.summary,
-      followUpDate: caseWithContact.info.followUpDate,
-      definitionVersion: caseWithContact.info.definitionVersion,
-    },
-    precalculatedPermissions: caseWithContact.precalculatedPermissions,
-  };
-
   const caseRecordWithContact = createMockCaseRecord({
     accountSid,
     id: caseId,
     helpline: 'helpline',
     status: 'open',
     info: {},
-    caseSections: [
-      {
-        accountSid,
-        sectionTypeSpecificData: { note: 'Child with covid-19' },
-        createdBy: 'WK-contact-adder',
-        createdAt: baselineCreatedDate,
-        eventTimestamp: baselineCreatedDate,
-        caseId,
-        sectionType: 'note',
-        sectionId: 'NOTE_1',
-      },
-    ],
     twilioWorkerId,
     connectedContacts: [
       {
@@ -177,28 +143,11 @@ describe('searchCases', () => {
     connectedContacts: [],
   };
 
-  const caseWithoutContactEssentialData = {
-    ...caseWithContactEssentialData,
-    connectedContacts: [],
-  };
-
   const caseRecordWithoutContact = createMockCaseRecord({
     id: caseId,
     accountSid,
     helpline: 'helpline',
     status: 'open',
-    caseSections: [
-      {
-        accountSid,
-        sectionTypeSpecificData: { note: 'Child with covid-19' },
-        createdBy: 'WK-contact-adder',
-        createdAt: baselineCreatedDate,
-        eventTimestamp: baselineCreatedDate,
-        caseId,
-        sectionType: 'note',
-        sectionId: 'NOTE_1',
-      },
-    ],
     twilioWorkerId,
     connectedContacts: [],
   });
@@ -260,20 +209,6 @@ describe('searchCases', () => {
       expectedCases: [
         {
           ...caseWithoutContact,
-          categories: {},
-          precalculatedPermissions: {
-            userOwnsContact: false,
-          },
-        },
-      ],
-    },
-    {
-      description: 'list cases',
-      listConfig: { offset: 30, limit: 45 },
-      casesFromDb: [caseRecordWithoutContact],
-      expectedCases: [
-        {
-          ...caseWithoutContactEssentialData,
           categories: {},
           precalculatedPermissions: {
             userOwnsContact: false,

--- a/hrm-domain/hrm-core/unit-tests/case/mockCases.ts
+++ b/hrm-domain/hrm-core/unit-tests/case/mockCases.ts
@@ -53,24 +53,20 @@ export const createMockCaseRecord = (partial: Partial<CaseRecord>): CaseRecord =
 };
 
 export const createMockCaseInsert = (partial: Partial<NewCaseRecord>): NewCaseRecord => {
-  const insert = Object.assign(
+  return Object.assign(
     {
       ...createMockCaseRecord({}),
     },
     partial,
   );
-  delete insert.caseSections;
-  return insert;
 };
 
 export const createMockCase = (partial: Partial<CaseService>): CaseService => {
   const record = createMockCaseRecord({});
-  delete record.caseSections;
   return Object.assign(
     {
       ...record,
       categories: {},
-      sections: {},
     },
     partial,
   );

--- a/hrm-domain/hrm-service/docker-database/docker-compose-persistent.yml
+++ b/hrm-domain/hrm-service/docker-database/docker-compose-persistent.yml
@@ -14,7 +14,7 @@
 
 services:
   db:
-    image: library/postgres:12.10
+    image: library/postgres:16.8
 
     environment:
       POSTGRES_USER: rdsadmin

--- a/hrm-domain/hrm-service/docker-database/docker-compose.yml
+++ b/hrm-domain/hrm-service/docker-database/docker-compose.yml
@@ -14,7 +14,7 @@
 
 services:
   db:
-    image: library/postgres:12.10
+    image: library/postgres:16.8
 
     environment:
       POSTGRES_USER: rdsadmin

--- a/hrm-domain/hrm-service/migrations/20250417093200-include_twilioWorkerId_in_index.js
+++ b/hrm-domain/hrm-service/migrations/20250417093200-include_twilioWorkerId_in_index.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DROP INDEX IF EXISTS "CaseSections_caseId_accountSid_idx";`,
+    );
+    console.log('DROPPED CaseSections_caseId_accountSid_idx');
+    await queryInterface.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "CaseSections_caseId_accountSid_twilioWorkerId_idx"
+    ON public."Contacts" USING btree
+    ("caseId" ASC NULLS LAST, "accountSid" ASC NULLS LAST, "twilioWorkerId" ASC NULLS LAST)
+    INCLUDE("twilioWorkerId")
+    WITH (deduplicate_items=True)
+;`,
+    );
+    console.log('Created CaseSections_caseId_accountSid_twilioWorkerId_idx');
+  },
+  down: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DROP INDEX IF EXISTS "CaseSections_caseId_accountSid_twilioWorkerId_idx";`,
+    );
+    console.log('DROPPED CaseSections_caseId_accountSid_twilioWorkerId_idx');
+    await queryInterface.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "CaseSections_caseId_accountSid_idx"
+    ON public."Contacts" USING btree
+    ("caseId" ASC NULLS LAST, "accountSid" ASC NULLS LAST)
+    INCLUDE("twilioWorkerId")
+    WITH (deduplicate_items=True)
+;`,
+    );
+    console.log('Created CaseSections_caseId_accountSid_idx');
+  },
+};

--- a/hrm-domain/hrm-service/service-tests/case.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case.test.ts
@@ -16,23 +16,13 @@
 
 /* eslint-disable jest/no-standalone-expect,no-await-in-loop */
 
-import each from 'jest-each';
-
-import { db } from './dbConnection';
 import * as caseApi from '@tech-matters/hrm-core/case/caseService';
-import {
-  createContact,
-  connectContactToCase,
-  addConversationMediaToContact,
-} from '@tech-matters/hrm-core/contact/contactService';
 import { CaseService } from '@tech-matters/hrm-core/case/caseService';
 import * as caseDb from '@tech-matters/hrm-core/case/caseDataAccess';
 
 import * as mocks from './mocks';
-import { ruleFileActionOverride } from './permissions-overrides';
-import { headers, setRules, useOpenRules } from './server';
+import { headers } from './server';
 import { newTwilioUser } from '@tech-matters/twilio-worker-auth';
-import { isS3StoredTranscript } from '@tech-matters/hrm-core/conversation-media/conversationMedia';
 import { ALWAYS_CAN } from './mocks';
 import { casePopulated } from './mocks';
 import { setupServiceTests } from './setupServiceTest';
@@ -40,24 +30,6 @@ import { setupServiceTests } from './setupServiceTest';
 const { case1, case2, accountSid, workerSid } = mocks;
 
 const { request } = setupServiceTests(workerSid);
-
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const deleteContactById = (id: number, accountSid: string) =>
-  db.task(t =>
-    t.none(`
-      DELETE FROM "Contacts"
-      WHERE "id" = ${id} AND "accountSid" = '${accountSid}';
-  `),
-  );
-
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const deleteJobsByContactId = (contactId: number, accountSid: string) =>
-  db.task(t =>
-    t.manyOrNone(`
-      DELETE FROM "ContactJobs"
-      WHERE "contactId" = ${contactId} AND "accountSid" = '${accountSid}';
-    `),
-  );
 
 describe('/cases route', () => {
   const route = `/v0/accounts/${accountSid}/cases`;

--- a/hrm-domain/hrm-service/service-tests/case/caseTimeline.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseTimeline.test.ts
@@ -24,7 +24,7 @@ import {
   workerSid,
 } from '../mocks';
 import { CaseService, createCase } from '@tech-matters/hrm-core/case/caseService';
-import { NewCaseSection } from '@tech-matters/hrm-core/case/caseSection/types';
+import { isCaseSectionTimelineActivity, NewCaseSection } from '@tech-matters/hrm-core/case/caseSection/types';
 import each from 'jest-each';
 import { createCaseSection } from '@tech-matters/hrm-core/case/caseSection/caseSectionService';
 import { addDays, addHours, parseISO } from 'date-fns';
@@ -36,7 +36,6 @@ import {
   searchContacts,
 } from '@tech-matters/hrm-core/contact/contactService';
 import {
-  isCaseSectionTimelineActivity,
   TimelineActivity,
 } from '@tech-matters/hrm-core/case/caseSection/caseSectionDataAccess';
 import { setupServiceTests } from '../setupServiceTest';

--- a/hrm-domain/hrm-service/service-tests/case/caseTimeline.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseTimeline.test.ts
@@ -24,7 +24,10 @@ import {
   workerSid,
 } from '../mocks';
 import { CaseService, createCase } from '@tech-matters/hrm-core/case/caseService';
-import { isCaseSectionTimelineActivity, NewCaseSection } from '@tech-matters/hrm-core/case/caseSection/types';
+import {
+  isCaseSectionTimelineActivity,
+  NewCaseSection,
+} from '@tech-matters/hrm-core/case/caseSection/types';
 import each from 'jest-each';
 import { createCaseSection } from '@tech-matters/hrm-core/case/caseSection/caseSectionService';
 import { addDays, addHours, parseISO } from 'date-fns';
@@ -35,9 +38,7 @@ import {
   createContact,
   searchContacts,
 } from '@tech-matters/hrm-core/contact/contactService';
-import {
-  TimelineActivity,
-} from '@tech-matters/hrm-core/case/caseSection/caseSectionDataAccess';
+import { TimelineActivity } from '@tech-matters/hrm-types';
 import { setupServiceTests } from '../setupServiceTest';
 
 const { request } = setupServiceTests(workerSid);
@@ -284,11 +285,14 @@ describe('GET /cases/:caseId/timeline', () => {
         .filter(ev => !isCaseSectionTimelineActivity(ev))
         .map(ev => ev.activity);
       expect(count).toBe(expectedTotalCount);
-      activityContacts.forEach(ec =>
-        expect(ec).toStrictEqual(
-          expectedContacts.find(expected => expected.id === ec.id),
-        ),
-      );
+      activityContacts.forEach(ec => {
+        const {
+          accountSid: acct,
+          caseId,
+          ...expectedContact
+        } = expectedContacts.find(expected => expected.id === ec.id);
+        expect(ec).toStrictEqual(expectedContact);
+      });
     },
   );
 });

--- a/hrm-domain/hrm-service/service-tests/case/caseUpdates.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseUpdates.test.ts
@@ -299,7 +299,6 @@ each([publicApiTestSuiteParameters, internalApiTestSuiteParameters]).describe(
         const fromDb = await caseApi.getCase(originalCase.id, accountSid, ALWAYS_CAN);
         expect(fromDb).toStrictEqual({
           ...expected,
-          sections: {},
           connectedContacts: [],
         });
 

--- a/hrm-domain/hrm-service/service-tests/case/caseValidation.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseValidation.ts
@@ -36,25 +36,33 @@ export const validateCaseListResponse = (
     );
     return;
   }
-  if (expectedCaseAndContactModels.length > 0) {
-    expect(actual.body.cases.length).toBeGreaterThan(0);
-  }
 
-  if (expectedCaseAndContactModels.length > 0 && actual.body.cases.length > 0) {
-    const hasExpectedCases = expectedCaseAndContactModels.some(
-      ({ case: expectedCase }) => {
-        if (expectedCase.info?.operatingArea) {
-          return actual.body.cases.some(
-            actualCase =>
-              actualCase.info?.operatingArea === expectedCase.info.operatingArea,
-          );
-        }
-        return true;
-      },
-    );
+  expect(actual.body).toStrictEqual(
+    expect.objectContaining({
+      cases: expect.arrayContaining([expect.anything()]),
+      count,
+    }),
+  );
+  expectedCaseAndContactModels.forEach(
+    ({ case: expectedCaseModel, contact: expectedContactModel }, index) => {
+      const { connectedContacts, ...caseDataValues } = expectedCaseModel;
+      expect(actual.body.cases[index]).toMatchObject({
+        ...caseDataValues,
+        createdAt: expectedCaseModel.createdAt,
+        updatedAt: expectedCaseModel.updatedAt,
+      });
 
-    expect(hasExpectedCases).toBe(true);
-  }
+      expect(actual.body.cases[index].connectedContacts).toStrictEqual([
+        expect.objectContaining({
+          ...expectedContactModel,
+          timeOfContact: expect.toParseAsDate(expectedContactModel.timeOfContact),
+          createdAt: expect.toParseAsDate(expectedContactModel.createdAt),
+          finalizedAt: expect.toParseAsDate(expectedContactModel.finalizedAt),
+          updatedAt: expect.toParseAsDate(expectedContactModel.updatedAt),
+        }),
+      ]);
+    },
+  );
 };
 
 export const validateSingleCaseResponse = (

--- a/hrm-domain/hrm-service/service-tests/contact/contactPermissions.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/contactPermissions.test.ts
@@ -391,9 +391,9 @@ describe('Time based condition', () => {
         async ({ permissions, expectedPermittedContactCreationTimes }: TestCase) => {
           const subRoute = id => `${caseBaseRoute}/${id}`;
           setRules({ viewContact: permissions });
-          const expectedIds = expectedPermittedContactCreationTimes.map(cct =>
-            parseISO(sampleContacts[cct.toISOString()].timeOfContact),
-          );
+          const expectedIds = expectedPermittedContactCreationTimes
+            .map(cct => parseISO(sampleContacts[cct.toISOString()].timeOfContact))
+            .slice(0, 1);
           const { status, body } = await request
             .get(subRoute(sampleCase.id))
             .set(headers);
@@ -414,9 +414,9 @@ describe('Time based condition', () => {
         '$description',
         async ({ permissions, expectedPermittedContactCreationTimes }: TestCase) => {
           setRules({ viewContact: permissions });
-          const expectedIds = expectedPermittedContactCreationTimes.map(cct =>
-            parseISO(sampleContacts[cct.toISOString()].timeOfContact),
-          );
+          const expectedIds = expectedPermittedContactCreationTimes
+            .map(cct => parseISO(sampleContacts[cct.toISOString()].timeOfContact))
+            .slice(0, 1);
           const {
             body: { cases, count },
             status,

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -413,7 +413,7 @@ describe('/profiles', () => {
               createdCases
                 .map(({ createdAt, updatedAt, childName, ...rest }) => ({
                   ...rest,
-                  connectedContacts: rest.connectedContacts?.sort(sortById),
+                  connectedContacts: rest.connectedContacts?.sort(sortById).slice(0, 1),
                 }))
                 .sort(sortById),
             );

--- a/hrm-domain/integration-tests/docker-compose-integration-tests.yml
+++ b/hrm-domain/integration-tests/docker-compose-integration-tests.yml
@@ -16,7 +16,7 @@ version: '3'
 
 services:
   db:
-    image: library/postgres:16.3
+    image: library/postgres:16.8
 
     environment:
       POSTGRES_USER: rdsadmin

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/caseService.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/caseService.ts
@@ -14,7 +14,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { CaseService, CaseSection, TimelineResult } from '@tech-matters/hrm-types';
+import type {
+  CaseService,
+  CaseSection,
+  TimelineApiResponse,
+} from '@tech-matters/hrm-types';
 import { callHrmApi } from '@tech-matters/hrm-authentication';
 import { isErr, newErr } from '@tech-matters/types';
 
@@ -224,7 +228,7 @@ export const getCaseSections = async ({
 
     const authHeader = `Basic ${staticKey}`;
 
-    const result = await callHrmApi<TimelineResult>(baseUrl)({
+    const result = await callHrmApi<TimelineApiResponse>(baseUrl)({
       urlPath,
       authHeader,
       method: 'GET',

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
@@ -14,7 +14,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { CaseSection, CaseService, TimelineApiResponse } from '@tech-matters/hrm-types';
+import type {
+  CaseSection,
+  CaseService,
+  TimelineApiResponse,
+} from '@tech-matters/hrm-types';
 import {
   createCase,
   createCaseSection,

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { CaseSection, CaseService, TimelineResult } from '@tech-matters/hrm-types';
+import type { CaseSection, CaseService, TimelineApiResponse } from '@tech-matters/hrm-types';
 import {
   createCase,
   createCaseSection,
@@ -282,7 +282,7 @@ export const getOrCreateCase = async ({
   }
 };
 
-export const wasPendingIncidentCreated = (timeline: TimelineResult) =>
+export const wasPendingIncidentCreated = (timeline: TimelineApiResponse) =>
   Boolean(timeline.activities.length) &&
   timeline.activities.some(
     t =>

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
@@ -34,7 +34,7 @@ export const toCreateIncident = ({
         ? [`Reporting District: ${callerInformation.reportingDistrict}`]
         : []),
       ...(callerInformation?.identifier911
-        ? [`(911 Incident #${callerInformation.identifier911}`]
+        ? [`911 Incident #${callerInformation.identifier911}`]
         : []),
       childInformation?.incidentSummary,
     ].join('; ') as string,

--- a/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
+++ b/hrm-domain/packages/hrm-search-config/convertToIndexDocument.ts
@@ -96,7 +96,7 @@ const convertCaseToCaseDocument = ({
     sections,
     info,
   } = caseObj;
-  const mappedSections: CaseDocument['sections'] = Object.entries(sections).flatMap(
+  const mappedSections: CaseDocument['sections'] = Object.entries(sections ?? {}).flatMap(
     ([sectionType, sectionsArray]) =>
       sectionsArray.map(section => ({
         accountSid: accountSid as string,

--- a/hrm-domain/packages/hrm-search-config/payload.ts
+++ b/hrm-domain/packages/hrm-search-config/payload.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  CaseSection,
   CaseService,
   Contact,
   NotificationOperation,
@@ -47,9 +48,7 @@ export type IndexCaseMessage = {
   entityType: 'case';
   operation: SupportedNotificationOperation;
   case: Pick<CaseService, 'id'> &
-    Partial<Omit<CaseService, 'sections'>> & {
-      sections: NonNullable<CaseService['sections']>;
-    };
+    Partial<CaseService> & { sections?: Record<string, CaseSection[]> };
 };
 
 export type IndexMessage = { accountSid: AccountSID } & (

--- a/hrm-domain/packages/hrm-types/Case.ts
+++ b/hrm-domain/packages/hrm-types/Case.ts
@@ -15,10 +15,7 @@
  */
 
 import { HrmAccountId, TwilioUserIdentifier, WorkerSID } from '@tech-matters/types';
-import { CaseSectionRecord } from './CaseSection';
 import { Contact } from './Contact';
-
-type CaseSection = Omit<CaseSectionRecord, 'accountSid' | 'sectionType' | 'caseId'>;
 
 export type PrecalculatedCasePermissionConditions = {
   isCaseContactOwner: boolean; // Does the requesting user own any of the contacts currently connected to the case?
@@ -54,5 +51,4 @@ export type CaseService = CaseRecordCommon & {
   categories: Record<string, string[]>;
   precalculatedPermissions?: PrecalculatedPermissions;
   connectedContacts?: Contact[];
-  sections: Record<string, CaseSection[]>;
 };

--- a/hrm-domain/packages/hrm-types/CaseSection.ts
+++ b/hrm-domain/packages/hrm-types/CaseSection.ts
@@ -45,4 +45,7 @@ export type CaseSectionTimelineActivity = TimelineActivity<CaseSectionRecord> & 
   activityType: 'case-section';
 };
 
-export type TimelineResult = { count: number; activities: TimelineActivity<any>[] };
+export type TimelineApiResponse = {
+  count: number;
+  activities: TimelineActivity<any>[];
+};

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/index.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/index.ts
@@ -18,7 +18,7 @@ import subHours from 'date-fns/subHours';
 import parseISO from 'date-fns/parseISO';
 import isValid from 'date-fns/isValid';
 import { applyContextConfigOverrides } from './context';
-import { pullCases } from './pull-cases';
+import { pullCases } from './pullCases';
 import { pullContacts } from './pull-contacts';
 import { pullProfiles } from './pull-profiles';
 

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/pullCases.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/pullCases.ts
@@ -27,10 +27,7 @@ import {
   timelineToLegacySections,
   timelineToLegacyConnectedContacts,
 } from '@tech-matters/hrm-core/case/caseSection/timelineToLegacyCaseProperties';
-import {
-  CaseService,
-  getTimelinesForCases,
-} from '@tech-matters/hrm-core/case/caseService';
+import { CaseService } from '@tech-matters/hrm-core/case/caseService';
 
 const getSearchParams = (startDate: Date, endDate: Date) => ({
   filters: {
@@ -63,7 +60,7 @@ export const pullCases = async (startDate: Date, endDate: Date) => {
   const casesWithContactIdOnly: (Omit<CaseService, 'connectedContacts' | 'categories'> & {
     connectedContacts: string[];
     sections: Record<string, CaseSection[]>;
-  })[] = (await getTimelinesForCases(accountSid, maxPermissions, cases)).map(
+  })[] = (await caseApi.getTimelinesForCases(accountSid, maxPermissions, cases)).map(
     ({ case: c, timeline }) => {
       const sections: Record<string, CaseSection[]> = timelineToLegacySections(timeline);
       const connectedContacts: string[] = timelineToLegacyConnectedContacts(timeline).map(

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/index.test.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/index.test.ts
@@ -20,11 +20,11 @@ import parseISO from 'date-fns/parseISO';
 
 import { pullData } from '../../index';
 import * as pullContactsModule from '../../pull-contacts';
-import * as pullCasesModule from '../../pull-cases';
+import * as pullCasesModule from '../../pullCases';
 import * as pullProfilesModule from '../../pull-profiles';
 
 jest.mock('../../pull-contacts');
-jest.mock('../../pull-cases');
+jest.mock('../../pullCases');
 jest.mock('../../pull-profiles');
 
 const getParamsFromSpy = (spy: jest.SpyInstance) => ({

--- a/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/pullCases.test.ts
+++ b/hrm-domain/scheduled-tasks/hrm-data-pull/tests/unit/pullCases.test.ts
@@ -21,7 +21,7 @@ import addDays from 'date-fns/addDays';
 
 import * as caseApi from '@tech-matters/hrm-core/case/caseService';
 import * as context from '../../context';
-import { pullCases } from '../../pull-cases';
+import { pullCases } from '../../pullCases';
 import { HrmAccountId } from '@tech-matters/types';
 import { defaultLimitAndOffset } from '@tech-matters/hrm-core/autoPaginate';
 

--- a/test-support/docker-compose-service-test.yml
+++ b/test-support/docker-compose-service-test.yml
@@ -14,7 +14,7 @@
 
 services:
   db:
-    image: library/postgres:12.10
+    image: library/postgres:16.8
 
     environment:
       POSTGRES_USER: rdsadmin


### PR DESCRIPTION
## Description

- remove support for 'onlyEssentialData' flag in cases, now this is always true
- add support for querying the timelines for multiple case IDs in a single query
- rework the hrm data pull to query the timelines for the cases separately to the cases records

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P