### PR TITLE
fix: empty category sent to Beacon on dispatch

### DIFF
--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
@@ -189,8 +189,6 @@ export const getOrCreateCase = async ({
       return contactResult;
     }
 
-    console.log('>>>> contact result', contactResult);
-
     if (contactResult.data.caseId) {
       const caseResult = await getCase({
         accountSid,

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/hrm-service/index.ts
@@ -189,6 +189,8 @@ export const getOrCreateCase = async ({
       return contactResult;
     }
 
+    console.log('>>>> contact result', contactResult);
+
     if (contactResult.data.caseId) {
       const caseResult = await getCase({
         accountSid,

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
@@ -24,12 +24,17 @@ export const toCreateIncident = ({
   caseObj: CaseService;
   contact: Contact;
 }): CreateIncidentParams => {
+  const { callerInformation, childInformation, caseInformation, categories } =
+    contact.rawJson || {};
+
+  const category = Object.values(categories || {})
+    .find(c => c.length)
+    ?.shift();
+
   console.log(
     '>>>> categories will be',
     Object.values(contact.rawJson?.categories || {})[0][0],
   );
-  const { callerInformation, childInformation, caseInformation, categories } =
-    contact.rawJson || {};
   return {
     contact_id: contact.id.toString(),
     case_id: caseObj.id,
@@ -54,7 +59,7 @@ export const toCreateIncident = ({
       gender: childInformation?.gender as string,
       race: childInformation?.race as string,
     },
-    category: Object.values(categories || {})[0][0],
+    category: category!,
     priority: caseInformation?.priority as string,
     is_officer_on_standby: callerInformation?.officerStandby as boolean,
   };

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
@@ -24,6 +24,10 @@ export const toCreateIncident = ({
   caseObj: CaseService;
   contact: Contact;
 }): CreateIncidentParams => {
+  console.log(
+    '>>>> categories will be',
+    Object.values(contact.rawJson?.categories || {})[0][0],
+  );
   const { callerInformation, childInformation, caseInformation, categories } =
     contact.rawJson || {};
   return {

--- a/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-dispatcher/mapping.ts
@@ -31,10 +31,6 @@ export const toCreateIncident = ({
     .find(c => c.length)
     ?.shift();
 
-  console.log(
-    '>>>> categories will be',
-    Object.values(contact.rawJson?.categories || {})[0][0],
-  );
   return {
     contact_id: contact.id.toString(),
     case_id: caseObj.id,


### PR DESCRIPTION
## Description
This PR fixes the bug described in the ticket, where Beacon API sporadically returns error responses from our dispatches when they should be valid. The reason for this bug is how the categories are saved in the contact payload: 
- If you select one category, then unselect it, the categories object will keep the empty array of the corresponding parent category.
- If a new category is then selected, the expression `Object.values(categories || {})[0][0]` will try to get the first element of the empty array described above, not from the new category.
- This leads to `category` property of the Beacon payload being `undefined`, resulting in the error we see.

The fix is to look for the first non-blank category in the categories object.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3320)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P