### PR TITLE
feat: add search on contact number field

### DIFF
--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -288,13 +288,19 @@ const generateContactNumberQueries = ({
 }): QueryDslQueryContainer[] => {
   const terms = searchParameters.searchTerm.split(' ');
 
-  const numericTerms = terms
-    .map(t => t.match(/\d+/g)?.join(''))
-    .filter(t => t && t.length > 8);
+  const numericTerms = searchParameters.searchTerm
+    .match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
+    .map(t => t.trim());
 
   // filter duplicates
   const numberTerms = Array.from(
-    new Set([...terms, ...numericTerms.flatMap(t => [t, `+${t}`])]),
+    new Set([
+      ...terms,
+      ...numericTerms.flatMap(t => {
+        const sanitized = t.replaceAll(/[\s\-]/g, ''); // remove spaces or dashes if any
+        return [t, `+${t}`, sanitized, `+${sanitized}`]; // use original format and sanitized
+      }),
+    ]),
   );
 
   return [

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -312,6 +312,10 @@ const generateContactsQueriesFromFilters = ({
           boost: BOOST_FACTORS.contact,
         },
         {
+          field: 'number',
+          boost: BOOST_FACTORS.contact,
+        },
+        {
           field: 'id',
           boost: BOOST_FACTORS.id * BOOST_FACTORS.contact,
         },

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -289,9 +289,10 @@ const generateContactNumberQueries = ({
   const terms = searchParameters.searchTerm.split(' ');
 
   const numericTerms = searchParameters.searchTerm
-    .match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
-    .map(t => t && t.trim())
-    .filter(t => Boolean(t));
+    ? searchParameters.searchTerm
+        .match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
+        .map(t => t && t.trim())
+    : [];
 
   // filter duplicates
   const numberTerms = Array.from(

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -288,11 +288,8 @@ const generateContactNumberQueries = ({
 }): QueryDslQueryContainer[] => {
   const terms = searchParameters.searchTerm.split(' ');
 
-  const numericTerms = searchParameters.searchTerm
-    ? searchParameters
-        .searchTerm!.match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
-        .map(t => t && t.trim())
-    : [];
+  const numericTerms = (searchParameters.searchTerm.match(/[\d\s\-]{8,}/g) || []) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
+    .map(t => t && t.trim());
 
   // filter duplicates
   const numberTerms = Array.from(

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -290,7 +290,8 @@ const generateContactNumberQueries = ({
 
   const numericTerms = searchParameters.searchTerm
     .match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
-    .map(t => t.trim());
+    .map(t => t && t.trim())
+    .filter(t => Boolean(t));
 
   // filter duplicates
   const numberTerms = Array.from(

--- a/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
+++ b/hrm-domain/packages/hrm-search-config/generateElasticsearchQuery.ts
@@ -289,8 +289,8 @@ const generateContactNumberQueries = ({
   const terms = searchParameters.searchTerm.split(' ');
 
   const numericTerms = searchParameters.searchTerm
-    ? searchParameters.searchTerm
-        .match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
+    ? searchParameters
+        .searchTerm!.match(/[\d\s\-]{8,}/g) // find sequences of 8 consecutive numbers, maybe separed by spaces or dashes
         .map(t => t && t.trim())
     : [];
 


### PR DESCRIPTION
## Description
This PR adds a query on `number` field of `contact` documents when searching on ElasticSearch indices.
The terms sent by the user are used in it's "raw" format and also sanitized as if they were phone numbers - if the term is a sequence of numbers. This is to avoid miss-matches on non-sanitized identifiers.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3290)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P