### PR TITLE
CHI-3279: Remove contact based filters in all but legacy search queries

### DIFF
--- a/hrm-domain/hrm-core/case/caseDataAccess.ts
+++ b/hrm-domain/hrm-core/case/caseDataAccess.ts
@@ -81,16 +81,10 @@ export type CaseSearchCriteria = {
   lastName?: string;
 };
 
-export type CategoryFilter = {
-  category: string;
-  subcategory: string;
-};
-
 export type CaseListFilters = {
   statuses?: string[];
   excludedStatuses?: string[];
   counsellors?: string[];
-  categories?: CategoryFilter[];
   customFilter?: { [key: string]: string[] };
   createdAt?: DateFilter;
   updatedAt?: DateFilter;

--- a/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
+++ b/hrm-domain/hrm-core/case/sql/caseSearchSql.ts
@@ -232,7 +232,7 @@ const selectCasesUnorderedSql = ({
   LEFT JOIN LATERAL (
       ${selectContactsOwnedCount('twilioWorkerSid')}
   ) "contactsOwnedCount" ON true
-  ${whereClause} GROUP BY
+  ${whereClause ?? ''} GROUP BY
     "cases"."accountSid",
     "cases"."id",
     "contactsOwnedCount"."contactsOwnedByUserCount"
@@ -281,23 +281,29 @@ const selectSearchCaseBaseQuery = (whereClause: string): SearchQueryBuilder => {
     ].filter(sql => sql).join(`
     AND `);
     const orderBySql = generateOrderByClause(orderByClauses.concat(DEFAULT_SORT));
-    return selectCasesPaginatedSql({ whereClause: whereSql, orderByClause: orderBySql });
+    return selectCasesPaginatedSql({
+      whereClause: whereSql ? `WHERE ${whereSql}` : null,
+      orderByClause: orderBySql,
+    });
   };
 };
 
 export const selectCaseSearch = selectSearchCaseBaseQuery(
-  `WHERE
-      $<accountSid> IS NOT NULL AND cases."accountSid" = $<accountSid>
+  `$<accountSid> IS NOT NULL AND cases."accountSid" = $<accountSid>
     AND ${SEARCH_WHERE_CLAUSE}
   `,
 );
 
+export const selectCaseFilterOnly = selectSearchCaseBaseQuery(
+  'cases."accountSid" = $<accountSid>',
+);
+
 export const selectCaseSearchByProfileId = selectSearchCaseBaseQuery(
-  `WHERE cases."accountSid" = $<accountSid> AND cases."id" IN (
+  `cases."accountSid" = $<accountSid> AND cases."id" IN (
     SELECT "caseId" FROM "Contacts" "c" WHERE "c"."profileId" = $<profileId> AND "c"."accountSid" = $<accountSid>
   )`,
 );
 
 export const selectCasesByIds = selectSearchCaseBaseQuery(
-  `WHERE cases."accountSid" = $<accountSid> AND cases."id" = ANY($<caseIds>::INTEGER[])`,
+  `cases."accountSid" = $<accountSid> AND cases."id" = ANY($<caseIds>::INTEGER[])`,
 );

--- a/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseSearch.test.ts
@@ -871,8 +871,10 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  followUpDate: {
-                    to: add(baselineDate, { days: 4, hours: 12 }).toISOString(),
+                  caseInfoFilters: {
+                    followUpDate: {
+                      to: add(baselineDate, { days: 4, hours: 12 }).toISOString(),
+                    },
                   },
                 },
               },
@@ -896,9 +898,11 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  followUpDate: {
-                    from: add(baselineDate, { days: 2, hours: 12 }).toISOString(),
-                    to: add(baselineDate, { days: 6, hours: 12 }).toISOString(),
+                  caseInfoFilters: {
+                    followUpDate: {
+                      from: add(baselineDate, { days: 2, hours: 12 }).toISOString(),
+                      to: add(baselineDate, { days: 6, hours: 12 }).toISOString(),
+                    },
                   },
                 },
               },
@@ -924,9 +928,11 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  followUpDate: {
-                    from: add(baselineDate, { days: 2, hours: 12 }).toISOString(),
-                    to: add(baselineDate, { days: 6, hours: 12 }).toISOString(),
+                  caseInfoFilters: {
+                    followUpDate: {
+                      from: add(baselineDate, { days: 2, hours: 12 }).toISOString(),
+                      to: add(baselineDate, { days: 6, hours: 12 }).toISOString(),
+                    },
                   },
                 },
               },
@@ -954,8 +960,10 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  followUpDate: {
-                    exists: DateExistsCondition.MUST_NOT_EXIST,
+                  caseInfoFilters: {
+                    followUpDate: {
+                      exists: DateExistsCondition.MUST_NOT_EXIST,
+                    },
                   },
                 },
               },
@@ -976,8 +984,10 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  followUpDate: {
-                    exists: DateExistsCondition.MUST_NOT_EXIST,
+                  caseInfoFilters: {
+                    followUpDate: {
+                      exists: DateExistsCondition.MUST_NOT_EXIST,
+                    },
                   },
                 },
               },
@@ -1087,7 +1097,7 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  customFilter: {
+                  caseInfoFilters: {
                     operatingArea: ['East'],
                   },
                 },
@@ -1126,7 +1136,7 @@ describe('/cases route', () => {
               searchRoute: `/v0/accounts/${accounts[0]}/cases/search`,
               body: {
                 filters: {
-                  customFilter: {
+                  caseInfoFilters: {
                     operatingArea: ['East', 'North'],
                   },
                 },
@@ -1164,7 +1174,7 @@ describe('/cases route', () => {
               body: {
                 helpline: helplines[0],
                 filters: {
-                  customFilter: {
+                  caseInfoFilters: {
                     operatingArea: ['East'],
                   },
                 },


### PR DESCRIPTION
# Review after #878 is merged

## Description

- Ensure clauses to search cases by name & phone number are only included in legacy search queries, not those originating from the case list (that never specify them anyway)
- Remove support for filtering cases by connected content categories

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

Case list & search regression

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P