### PR TITLE
chore: Migrate & sanitize existing phone numbers [CHI-3341]

### DIFF
--- a/hrm-domain/hrm-service/migrations/20250523200734-sanitize_all_identifiers.js
+++ b/hrm-domain/hrm-service/migrations/20250523200734-sanitize_all_identifiers.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async queryInterface => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize voice contacts
+      -- for sip, convert 'sip:+123456789@twilio.dcthosted.net' into '+123456789'
+      UPDATE "Contacts" SET "number" = regexp_replace(number, '^sip:([^@]+)@.*$', '\\1') WHERE "channel" = 'voice' AND "number" LIKE 'sip:%';
+      -- remove hyphens and spaces
+      UPDATE "Contacts" SET "number" = regexp_replace(number, '[-\s]', '', 'g') WHERE "channel" = 'voice';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized voice contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize sms contacts
+      -- remove hyphens and spaces
+      UPDATE "Contacts" SET "number" = regexp_replace(number, '[-\s]', '', 'g') WHERE "channel" = 'sms';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized sms contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize whatsapp contacts
+      -- remove 'whatsapp:' prefix
+      UPDATE "Contacts" SET "number" = replace("number", 'whatsapp:', '') WHERE "channel" = 'whatsapp' AND "number" LIKE 'whatsapp:%';
+      -- remove hyphens and spaces
+      UPDATE "Contacts" SET "number" = regexp_replace(number, '[-\s]', '', 'g') WHERE "channel" = 'whatsapp';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized whatsapp contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize modica contacts
+      -- remove 'modica:' prefix
+      UPDATE "Contacts" SET "number" = replace("number", 'modica:', '') WHERE "channel" = 'modica' AND "number" LIKE 'modica:%';
+      -- remove hyphens and spaces
+      UPDATE "Contacts" SET "number" = regexp_replace(number, '[-\s]', '', 'g') WHERE "channel" = 'modica';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized modica contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize messenger contacts
+      -- remove 'messenger:' prefix
+      UPDATE "Contacts" SET "number" = replace("number", 'messenger:', '') WHERE "channel" = 'messenger' AND "number" LIKE 'messenger:%';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized messenger contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize instagram contacts
+      -- remove 'instagram:' prefix
+      UPDATE "Contacts" SET "number" = replace("number", 'instagram:', '') WHERE "channel" = 'instagram' AND "number" LIKE 'instagram:%';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized instagram contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Sanitize telegram contacts
+      -- remove 'telegram:' prefix
+      UPDATE "Contacts" SET "number" = replace("number", 'telegram:', '') WHERE "channel" = 'telegram' AND "number" LIKE 'telegram:%';
+    `,
+        { transaction },
+      );
+      console.log('Sanitized telegram contacts');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Merge contacts with the same "number" into using the samae identifierId and profileId
+      -- The chosen identifiers are the sanitized version or the minimal id if no sanitized version exists
+      WITH duplicates AS (
+        SELECT
+          "accountSid",
+          "number"
+        FROM "Contacts"
+        GROUP BY "accountSid", "number"
+        HAVING COUNT(DISTINCT "identifierId") > 1
+      ),
+      candidate_identifiers AS (
+        SELECT
+          c."accountSid",
+          c."number",
+          c."identifierId",
+          i."identifier" AS "rawIdentifier",
+          CASE
+            WHEN i."identifier" = c."number" THEN TRUE
+            ELSE FALSE
+          END AS "isSanitized"
+        FROM "Contacts" c
+        JOIN "Identifiers" i ON c."identifierId" = i."id"
+        JOIN duplicates d ON d."accountSid" = c."accountSid" AND d."number" = c."number"
+      ),
+      resolved_identifiers AS (
+        SELECT
+          "accountSid",
+          "number",
+          -- Prefer sanitized one, fallback to min(identifierId)
+          COALESCE(
+            MIN("identifierId") FILTER (WHERE "isSanitized"),
+            MIN("identifierId")
+          ) AS "targetIdentifierId"
+        FROM candidate_identifiers
+        GROUP BY "accountSid", "number"
+      ),
+      with_target_ids AS (
+        SELECT
+          c."id",
+          c."accountSid",
+          c."number",
+          c."identifierId",
+          r."targetIdentifierId"
+        FROM "Contacts" c
+        JOIN resolved_identifiers r ON r."accountSid" = c."accountSid" AND r."number" = c."number"
+        WHERE c."identifierId" <> r."targetIdentifierId"
+      ),
+      target_contacts AS (
+        SELECT
+          w."id",
+          w."targetIdentifierId",
+          p2i."profileId" AS "targetProfileId"
+        FROM with_target_ids w
+        JOIN "ProfilesToIdentifiers" p2i
+          ON p2i."accountSid" = w."accountSid"
+        AND p2i."identifierId" = w."targetIdentifierId"
+      )
+      UPDATE "Contacts" c
+      SET
+        "identifierId" = t."targetIdentifierId",
+        "profileId" = t."targetProfileId"
+      FROM target_contacts t
+      WHERE c."id" = t."id";
+    `,
+        { transaction },
+      );
+      console.log('Unified matching-number contact identifierId');
+
+      await queryInterface.sequelize.query(
+        `
+      -- Correct mismatched identifiers (if they were not sanitized, this will fix it)
+      WITH mismatched_identifiers AS (
+        SELECT
+          i."id" AS "identifierId",
+          MIN(c."number") AS "newNumber"
+        FROM "Identifiers" i
+        JOIN "Contacts" c
+          ON c."accountSid" = i."accountSid"
+        AND c."identifierId" = i."id"
+        WHERE i."identifier" IS DISTINCT FROM c."number"
+          AND c."channel" <> 'web'
+        GROUP BY i."id"
+      )
+      UPDATE "Identifiers" i
+      SET "identifier" = m."newNumber"
+      FROM mismatched_identifiers m
+      WHERE i."id" = m."identifierId";
+    `,
+        { transaction },
+      );
+      console.log('Fixed non-sanitized identifiers');
+
+      await transaction.commit();
+      console.log('Transaction commited');
+    } catch (err) {
+      await transaction.rollback();
+      console.log('Transaction rollbacked');
+      console.error(err);
+      throw err;
+    }
+  },
+  down: async () => {},
+};


### PR DESCRIPTION
Should be deployed after https://github.com/techmatters/flex-plugins/pull/2993 is out.

## Description
This PR sanitizes all the existing identifiers, as a follow up from the bug fixed in the above linked PR.
This involves running a migration that:
- Sanitizes all existing contacts `number`s, applying the same "sanitize rules" as Flex applies (see above PR for reference).
- Unifies contacts under unified identifiers - that is, if there are contacts with matching `number` but different `identifierId`, merges all of them under a common one. The unifiedd identifier is chosen as follows:
  - If there is an already sanitized version of the identifier - that is `"Identifiers"."identifier"` = `"Contacts"."number"` - use it.
  - If not, pick the one with the smallest identifier id.
- Sanitizes all existing `identifier`s in the `Identifiers` table by using the above sanitized numbers. This will only apply for those identifier ids that fall under the second bullet point from above.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3341)
- [ ] New tests added
- [ ] Feature flags / configuration added


### Important note
If you see the migration that updates the `Identifiers` to mach the now sanitized version that `Contacts` table holds, I'm adding `WHERE i."identifier" IS DISTINCT FROM c."number" AND c."channel" <> 'web'` clause to exclude web contacts in case they share the same `identifier` as other type of contacts. This avoids overriding `Identifiers` table with non-sanitized data coming from `web` channel contacts - as they do not have any sanitization rules, but I've seen some records sharing the same identifier in development DB as voice contacts.
```
"channel"    "identifierId"      "number"
"web"          248               "+1 828-242-2126"
"voice"        248               "+18282422126"
"voice"        1288               "+19056711577"
"web"          1288               "+1 905-671-1577"
"web"          1664               "+1 205-308-9376"
"voice"        1664               "+12053089376"
```
I assume this are broken or old records that were manually changed, but I'm adding the check just in case.

After the migration is run, we should confirm that there are no instances of this weird records in production databases by running
```
SELECT DISTINCT channel, "identifierId", number FROM "Contacts" WHERE "identifierId" IN (
  SELECT
    i."id" AS "identifierId"
  FROM "Identifiers" i
  JOIN "Contacts" c
    ON c."accountSid" = i."accountSid"
   AND c."identifierId" = i."id"
  WHERE i."identifier" IS DISTINCT FROM c."number"
) ORDER BY "identifierId"
```

If there are, we should either:
- Manually patch those `web` contacts to contain the sanitized `number` if we want them to be merged with the other channels ones, or
- Manually create records in `Identifiers`, `Profiles` and `ProfilesToIdentifiers` tables to match the non-sanitized version (just to use in `web` contacts) and update the `web` contacts referencing the Identifier to use the newly created ones.

### Verification steps
Using PGAdmin, you can under "Execute options", disable the "Auto commit" item then run this queries from.
You run all of the queries at once, then after you confirmed that the query runs and fixes inconsistencies, just execute `ROLLBACK;END;`, so that the migration can be properly executed on deploy.
![image](https://github.com/user-attachments/assets/c7b76240-9476-4853-86d2-b15558c5c9be)

To detect inconsistencies: 
- After running the "sanitize contacts queries", run this to see the contacts that require "merging with the unified identifier"
  ```
  WITH duplicates AS (
    SELECT
      "accountSid",
      "number"
    FROM "Contacts"
    GROUP BY "accountSid", "number"
    HAVING COUNT(DISTINCT "identifierId") > 1
  ),
  candidate_identifiers AS (
    SELECT
      c."accountSid",
      c."number",
      c."identifierId",
      i."identifier" AS "rawIdentifier",
      CASE
        WHEN i."identifier" = c."number" THEN TRUE
        ELSE FALSE
      END AS "isSanitized"
    FROM "Contacts" c
    JOIN "Identifiers" i ON c."identifierId" = i."id"
    JOIN duplicates d ON d."accountSid" = c."accountSid" AND d."number" = c."number"
  ),
  resolved_identifiers AS (
    SELECT
      "accountSid",
      "number",
      -- Prefer sanitized one, fallback to min(identifierId)
      COALESCE(
        MIN("identifierId") FILTER (WHERE "isSanitized"),
        MIN("identifierId")
      ) AS "targetIdentifierId"
    FROM candidate_identifiers
    GROUP BY "accountSid", "number"
  ),
  with_target_ids AS (
    SELECT
      c."id",
      c."accountSid",
      c."number",
      c."identifierId",
      r."targetIdentifierId"
    FROM "Contacts" c
    JOIN resolved_identifiers r ON r."accountSid" = c."accountSid" AND r."number" = c."number"
    WHERE c."identifierId" <> r."targetIdentifierId"
  ),
  target_contacts AS (
    SELECT
      w."id",
      w."identifierId",
      w."targetIdentifierId",
      p2i."profileId" AS "targetProfileId"
    FROM with_target_ids w
    JOIN "ProfilesToIdentifiers" p2i
      ON p2i."accountSid" = w."accountSid"
     AND p2i."identifierId" = w."targetIdentifierId"
  )
  SELECT * FROM target_contacts
  ```
- After running the "sanitize contacts queries" and the "merging with the unified identifier" query, run this to see the `Identifiers` that need to be sanitized
  ```
  WITH mismatched_identifiers AS (
    SELECT
      i."id" AS "identifierId",
      MIN(c."number") AS "newNumber"
    FROM "Identifiers" i
    JOIN "Contacts" c
      ON c."accountSid" = i."accountSid"
     AND c."identifierId" = i."id"
    WHERE i."identifier" IS DISTINCT FROM c."number"
      AND c."channel" <> 'web'
    GROUP BY i."id"
  )
  SELECT * FROM mismatched_identifiers;
  ```

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P