### PR TITLE
CHI-3296: Add incident number to beacon poller

### DIFF
--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
@@ -25,6 +25,7 @@ import { Responder, responderToCaseSection } from './responder';
 
 export type IncidentReport = {
   id: number;
+  number: number;
   class: string;
   priority: string;
   case_id: string | null;
@@ -57,6 +58,7 @@ export type IncidentReport = {
 
 export const incidentReportToCaseSection = ({
   id,
+  number,
   case_id,
   updated_at,
   created_at,
@@ -83,6 +85,7 @@ export const incidentReportToCaseSection = ({
       sectionId: id.toString(),
       sectionTypeSpecificData: {
         beaconIncidentId: id.toString(),
+        incidentNumber: number?.toString(),
         incidentCreationTimestamp: created_at,
         incidentType: category,
         latitude,

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/mockGenerators.ts
@@ -21,6 +21,7 @@ import {
 } from '../src/caseReport/apiPayload';
 
 const EMPTY_INCIDENT_REPORT: IncidentReport = {
+  number: 0,
   priority: '',
   address: '',
   caller_name: '',

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/service/beaconPoller.test.ts
@@ -119,6 +119,7 @@ const generateIncidentReports = (
           ? { case_id: caseIds[indexInCurrentIteration] }
           : {}),
         id: iteration,
+        number: numberToGenerate - iteration,
         contact_id: `contact-for-case-${caseIds[indexInCurrentIteration]}`,
         description: `Incident report #${iteration}, for case ${caseIds[indexInCurrentIteration]}`,
         address: `Address for incident report #${iteration}`,

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/tests/unit/incidentReport.test.ts
@@ -68,6 +68,7 @@ describe('incidentReportToCaseSection', () => {
         created_at: '1969',
         case_id: '1234',
         id: 5678,
+        number: 8765,
         category_id: 22,
         category: 'Planetary Evacuation',
         latitude: -4.2,
@@ -108,6 +109,7 @@ describe('incidentReportToCaseSection', () => {
       sectionId: '5678',
       sectionTypeSpecificData: {
         beaconIncidentId: '5678',
+        incidentNumber: '8765',
         incidentCreationTimestamp: '1969',
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,
@@ -181,6 +183,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         created_at: '1969',
         case_id: '1234',
         id: 5678,
+        number: 8765,
         category_id: 22,
         category: 'Planetary Evacuation',
         latitude: -4.2,
@@ -233,6 +236,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
       sectionId: '5678',
       sectionTypeSpecificData: {
         beaconIncidentId: '5678',
+        incidentNumber: '8765',
         incidentCreationTimestamp: '1969',
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,
@@ -297,6 +301,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
         created_at: '1969',
         case_id: '1234',
         id: 5678,
+        number: 8765,
         priority: 'Existential Threat',
         class: 'Earth',
         category_id: 22,
@@ -323,6 +328,7 @@ describe('addIncidentReportSectionsToAseloCase', () => {
       sectionId: '5678',
       sectionTypeSpecificData: {
         beaconIncidentId: '5678',
+        incidentNumber: '8765',
         incidentCreationTimestamp: '1969',
         incidentType: 'Planetary Evacuation',
         latitude: -4.2,


### PR DESCRIPTION
## Description

Now pulls 'number' from incident reports provided by Beacon and maps it to incidentNumber in an incident report case section

### Checklist
- [x] Corresponding issue has been opened
- [x] New tests added
- [n/a] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps

- Deploy this version of the beacon poller lambda
- Dispatch an incident to beacon
- Create an incident report in beacon with an incident number set for this incident in beacon
- Wait for the poller to run
- Check that the case associated with the incident has an incident report section with the Incident Number set to what you specified in beacon

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P