### PR TITLE
chore: rewrite isActive filter to exclude only resources explicitly inactive

### DIFF
--- a/resources-domain/packages/resources-search-config/generateElasticsearchQuery.ts
+++ b/resources-domain/packages/resources-search-config/generateElasticsearchQuery.ts
@@ -16,11 +16,10 @@
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { SearchQuery } from '@tech-matters/elasticsearch-client';
 import {
+  FilterValue,
   ResourcesSearchConfiguration,
   getQuerySearchFields,
 } from './searchConfiguration';
-
-type FilterValue = boolean | number | string | Date | string[];
 
 export type SearchParameters = {
   filters?: Record<string, boolean | number | string | string[]>;
@@ -82,7 +81,7 @@ const generateFilters = (
     const targetField = mapping?.targetField ?? key;
     if (mapping) {
       switch (mapping.type) {
-        case 'range':
+        case 'range': {
           if (!Array.isArray(value)) {
             filterClauses.push({
               range: {
@@ -97,9 +96,15 @@ const generateFilters = (
             );
           }
           break;
-        case 'term':
+        }
+        case 'term': {
           filterClauses.push(generateTermFilter(targetField, value));
           break;
+        }
+        case 'custom': {
+          filterClauses.push(mapping.filterGenerator(value));
+          break;
+        }
       }
     } else if (!Array.isArray(value) && typeof value !== 'string') {
       // If there is no explicit mapping, but it isn't a string or a string array, still treat it as a term filter

--- a/resources-domain/packages/resources-search-config/index.ts
+++ b/resources-domain/packages/resources-search-config/index.ts
@@ -50,6 +50,16 @@ const resourceSearchConfiguration: ResourcesSearchConfiguration = {
     interpretationTranslationServicesAvailable: {
       type: 'term',
     },
+    isActive: {
+      type: 'custom',
+      filterGenerator: value => ({
+        bool: {
+          must_not: {
+            term: { isActive: value },
+          },
+        },
+      }),
+    },
   },
   generateSuggestQuery,
 };

--- a/resources-domain/packages/resources-search-config/searchConfiguration.ts
+++ b/resources-domain/packages/resources-search-config/searchConfiguration.ts
@@ -14,8 +14,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { SearchSuggester } from '@elastic/elasticsearch/lib/api/types';
+import {
+  QueryDslQueryContainer,
+  SearchSuggester,
+} from '@elastic/elasticsearch/lib/api/types';
 import { SuggestParameters } from '@tech-matters/elasticsearch-client';
+
+export type FilterValue = boolean | number | string | Date | string[];
 
 /**
  * Used if you need to alias a text filter in the API to a different field in the index.
@@ -38,7 +43,13 @@ type RangeFilterMapping = {
   operator: RangeFilterOperator;
 };
 
-type FilterMapping = TermFilterMapping | RangeFilterMapping;
+type CustomFilterMapping = {
+  type: 'custom';
+  targetField?: string;
+  filterGenerator: (value: FilterValue) => QueryDslQueryContainer;
+};
+
+type FilterMapping = TermFilterMapping | RangeFilterMapping | CustomFilterMapping;
 
 export type ResourcesSearchConfiguration = {
   searchFieldBoosts: Record<string, number>;

--- a/resources-domain/resources-service/src/resource/resourceService.ts
+++ b/resources-domain/resources-service/src/resource/resourceService.ts
@@ -147,8 +147,8 @@ export const resourceService = () => {
         ...searchParameters,
         filters: {
           ...searchParameters.filters,
-          // exclude resources that are explicitly flagged as inactive
-          isActive: true,
+          // exclude resources that are explicitly flagged as inactive. See resources-domain/packages/resources-search-config/index.ts filter mapping for more details on how this filter is generated.
+          isActive: false,
         },
         pagination: { ...searchParameters.pagination!, limit },
       };

--- a/resources-domain/resources-service/tests/unit/resource/resourceService.test.ts
+++ b/resources-domain/resources-service/tests/unit/resource/resourceService.test.ts
@@ -262,7 +262,7 @@ describe('searchResources', () => {
             limit: expectedSearchLimit ?? esInput.pagination.limit,
           },
           filters: {
-            isActive: true,
+            isActive: false,
           },
         },
       });


### PR DESCRIPTION
## Description
This PR refactors how the filter on `isActive` property is generated (introduced in https://github.com/techmatters/hrm/pull/914). Now, a resources search with no other filters will include a filter clause like
```
{
  "query": {
    "bool": {
      "must": [ ...... ],
      "filter": [
        {
          "bool": {
            "must_not": {
              "term": {
                "isActive": false
              }
            }
          }
        }
      ]
    }
  },
}
```
which results in returning the resources that either have `isActive` set to `true`, or those that do not have the `isActive` property yet.
This change allows for a smooth migration, until the resources have been re-imported with the new `isActive` flag.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P