### PR TITLE
chore: usch - filter mappings to apply on location fields [CHI-3501]

### DIFF
--- a/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings/uschMappings.ts
+++ b/resources-domain/packages/resources-search-config/resourceIndexDocumentMappings/uschMappings.ts
@@ -90,6 +90,15 @@ const resourceIndexDocumentMappings: ResourceIndexDocumentMappings = {
 };
 
 const filterMappings: ResourcesSearchConfiguration['filterMappings'] = {
+  country: {
+    type: 'term',
+  },
+  province: {
+    type: 'term',
+  },
+  city: {
+    type: 'term',
+  },
   isActive: {
     type: 'custom',
     filterGenerator: value => ({


### PR DESCRIPTION
## Description
This PR adds filters mappings for USCH so they are applied as part of the `filters` cluase in the ES query.

An example generated query with this update, applying all three filters, looks like
```
{
  ...
  "query": {
    "bool": {
      "must": [
        {
          "match_all": {}
        }
      ],
      "filter": [
        {
          "term": {
            "city": "Alameda"
          }
        },
        {
          "term": {
            "country": "Albania"
          }
        },
        {
          "term": {
            "province": "AK"
          }
        },
        {
          "bool": {
            "must_not": {
              "term": {
                "isActive": false
              }
            }
          }
        }
      ]
    }
  },
  "size": 5
}
```

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3501)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P