### PR TITLE
chore: handle spammy errors from beacon poller [CHI-3834]

### DIFF
--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/caseReport/index.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/caseReport/index.ts
@@ -266,11 +266,12 @@ export const addCaseReportSectionsToAseloCase: ItemProcessor<
     }
     const errors = (await Promise.all(results)).filter(isErr);
     if (errors.length) {
+      const errorLevel = errors.some(e => e.error.level === 'error') ? 'error' : 'warn';
       return newErr({
         message: 'Failed to add additional sections from case report to Aselo case',
         error: {
           type: 'AggregateError',
-          level: 'error',
+          level: errorLevel,
           lastUpdated: caseReportResult.unwrap(),
           errors,
         },

--- a/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
+++ b/hrm-domain/lambdas/custom-integrations/uscr-beacon-poller/src/incidentReport.ts
@@ -145,11 +145,12 @@ export const addIncidentReportSectionsToAseloCase: ItemProcessor<IncidentReport>
       isErr(result),
     );
     if (errors.length) {
+      const errorLevel = errors.some(e => e.error.level === 'error') ? 'error' : 'warn';
       return newErr({
         message: 'Failed to add responders from incident report to Aselo case',
         error: {
           type: 'AggregateError',
-          level: 'error',
+          level: errorLevel,
           lastUpdated: incidentReportResult.unwrap(),
           errors,
         },


### PR DESCRIPTION
## Description
This PR changes the spammy errors seen in Datadog logs.
`AggregateError` from `itemProcessor`s seemed to be the reason of this logs. The logs are preserved as error if there is at least one error in the processed batch, but changed to warn if all the errors have a severity of warn (which seems to be most of the times).

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3834)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P