### PR TITLE
fix: generalized search - prevent 500 errors when index is not initialized [CHI-3871]

### DIFF
--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -44,6 +44,7 @@ import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import {
   DocumentType,
   HRM_CASES_INDEX_TYPE,
+  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 import { publishCaseChangeNotification } from '../notifications/entityChangeNotify';
@@ -380,16 +381,38 @@ export const generalisedCasesSearch = async (
       })
     ).searchClient(hrmSearchConfiguration);
 
-    const { total, items } = await client.search({
-      searchParameters: {
-        type: DocumentType.Case,
-        searchTerm,
-        searchFilters,
-        permissionFilters,
-        pagination,
-      },
-    });
+    let searchResult: Awaited<ReturnType<typeof client.search>> = { items: [], total: 0 };
+    try {
+      searchResult = await client.search({
+        searchParameters: {
+          type: DocumentType.Case,
+          searchTerm,
+          searchFilters,
+          permissionFilters,
+          pagination,
+        },
+      });
+    } catch (err) {
+      // If the error is caused because the index does not exists, create it.
+      if (
+        err.meta?.statusCode === 404 &&
+        (err.message as string)?.includes('index_not_found_exception')
+      ) {
+        (
+          await getClient({
+            accountSid,
+            indexType: HRM_CASES_INDEX_TYPE,
+            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
+          })
+        )
+          .indexClient(hrmIndexConfiguration)
+          .createIndex({});
+      } else {
+        throw err;
+      }
+    }
 
+    const { items, total } = searchResult;
     const caseIds = items.map(item => parseInt(item.id, 10));
 
     const { cases } = await searchCasesByIds(

--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -44,6 +44,7 @@ import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import {
   DocumentType,
   HRM_CASES_INDEX_TYPE,
+  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 import { publishCaseChangeNotification } from '../notifications/entityChangeNotify';
@@ -392,14 +393,20 @@ export const generalisedCasesSearch = async (
         },
       });
     } catch (err) {
+      // If the error is caused because the index does not exists, create it.
       if (
         err.meta?.statusCode === 404 &&
         (err.message as string)?.includes('index_not_found_exception')
       ) {
-        console.info(
-          `[generalised-search-cases] AccountSid: ${accountSid} - Index missing, returning empty list.`,
-        );
-        return newOk({ data: { count: 0, cases: [] } });
+        (
+          await getClient({
+            accountSid,
+            indexType: HRM_CASES_INDEX_TYPE,
+            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
+          })
+        )
+          .indexClient(hrmIndexConfiguration)
+          .createIndex({});
       } else {
         throw err;
       }

--- a/hrm-domain/hrm-core/case/caseService.ts
+++ b/hrm-domain/hrm-core/case/caseService.ts
@@ -44,7 +44,6 @@ import { RulesFile, TKConditionsSets } from '../permissions/rulesMap';
 import {
   DocumentType,
   HRM_CASES_INDEX_TYPE,
-  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 import { publishCaseChangeNotification } from '../notifications/entityChangeNotify';
@@ -393,20 +392,14 @@ export const generalisedCasesSearch = async (
         },
       });
     } catch (err) {
-      // If the error is caused because the index does not exists, create it.
       if (
         err.meta?.statusCode === 404 &&
         (err.message as string)?.includes('index_not_found_exception')
       ) {
-        (
-          await getClient({
-            accountSid,
-            indexType: HRM_CASES_INDEX_TYPE,
-            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
-          })
-        )
-          .indexClient(hrmIndexConfiguration)
-          .createIndex({});
+        console.info(
+          `[generalised-search-cases] AccountSid: ${accountSid} - Index missing, returning empty list.`,
+        );
+        return newOk({ data: { count: 0, cases: [] } });
       } else {
         throw err;
       }

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -35,6 +35,7 @@ import { getClient } from '@tech-matters/elasticsearch-client';
 import {
   DocumentType,
   HRM_CONTACTS_INDEX_TYPE,
+  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 
@@ -687,14 +688,20 @@ export const generalisedContactSearch = async (
         },
       });
     } catch (err) {
+      // If the error is caused because the index does not exists, create it.
       if (
         err.meta?.statusCode === 404 &&
         (err.message as string)?.includes('index_not_found_exception')
       ) {
-        console.info(
-          `[generalised-search-contacts] AccountSid: ${accountSid} - Index missing, returning empty list.`,
-        );
-        return newOk({ data: { count: 0, contacts: [] } });
+        (
+          await getClient({
+            accountSid,
+            indexType: HRM_CONTACTS_INDEX_TYPE,
+            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
+          })
+        )
+          .indexClient(hrmIndexConfiguration)
+          .createIndex({});
       } else {
         throw err;
       }

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -35,6 +35,7 @@ import { getClient } from '@tech-matters/elasticsearch-client';
 import {
   DocumentType,
   HRM_CONTACTS_INDEX_TYPE,
+  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 
@@ -675,16 +676,38 @@ export const generalisedContactSearch = async (
       })
     ).searchClient(hrmSearchConfiguration);
 
-    const { total, items } = await client.search({
-      searchParameters: {
-        type: DocumentType.Contact,
-        searchTerm,
-        searchFilters,
-        permissionFilters,
-        pagination,
-      },
-    });
+    let searchResult: Awaited<ReturnType<typeof client.search>> = { items: [], total: 0 };
+    try {
+      searchResult = await client.search({
+        searchParameters: {
+          type: DocumentType.Contact,
+          searchTerm,
+          searchFilters,
+          permissionFilters,
+          pagination,
+        },
+      });
+    } catch (err) {
+      // If the error is caused because the index does not exists, create it.
+      if (
+        err.meta?.statusCode === 404 &&
+        (err.message as string)?.includes('index_not_found_exception')
+      ) {
+        (
+          await getClient({
+            accountSid,
+            indexType: HRM_CONTACTS_INDEX_TYPE,
+            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
+          })
+        )
+          .indexClient(hrmIndexConfiguration)
+          .createIndex({});
+      } else {
+        throw err;
+      }
+    }
 
+    const { items, total } = searchResult;
     const contactIds = items.map(item => parseInt(item.id, 10));
 
     const { contacts } = await searchContactsByIds(

--- a/hrm-domain/hrm-core/contact/contactService.ts
+++ b/hrm-domain/hrm-core/contact/contactService.ts
@@ -35,7 +35,6 @@ import { getClient } from '@tech-matters/elasticsearch-client';
 import {
   DocumentType,
   HRM_CONTACTS_INDEX_TYPE,
-  hrmIndexConfiguration,
   hrmSearchConfiguration,
 } from '@tech-matters/hrm-search-config';
 
@@ -688,20 +687,14 @@ export const generalisedContactSearch = async (
         },
       });
     } catch (err) {
-      // If the error is caused because the index does not exists, create it.
       if (
         err.meta?.statusCode === 404 &&
         (err.message as string)?.includes('index_not_found_exception')
       ) {
-        (
-          await getClient({
-            accountSid,
-            indexType: HRM_CONTACTS_INDEX_TYPE,
-            ssmConfigParameter: process.env.SSM_PARAM_ELASTICSEARCH_CONFIG,
-          })
-        )
-          .indexClient(hrmIndexConfiguration)
-          .createIndex({});
+        console.info(
+          `[generalised-search-contacts] AccountSid: ${accountSid} - Index missing, returning empty list.`,
+        );
+        return newOk({ data: { count: 0, contacts: [] } });
       } else {
         throw err;
       }

--- a/hrm-domain/hrm-service/service-tests/profiles.test.ts
+++ b/hrm-domain/hrm-service/service-tests/profiles.test.ts
@@ -201,7 +201,7 @@ describe('/profiles', () => {
           .set(customHeaders || headers);
         expect(response.statusCode).toBe(expectStatus);
         if (expectFunction) {
-          expectFunction(response);
+          await expectFunction(response);
         }
       },
     );
@@ -607,7 +607,7 @@ describe('/profiles', () => {
                 .set(customHeaders || headers);
               expect(response.statusCode).toBe(expectStatus);
               if (expectFunction) {
-                expectFunction(response, profileId, profileFlagId, startTime);
+                await expectFunction(response, profileId, profileFlagId, startTime);
               }
             },
           );
@@ -758,7 +758,7 @@ describe('/profiles', () => {
                 .send(payload);
               expect(response.statusCode).toBe(expectStatus);
               if (expectFunction) {
-                expectFunction(response, profileId, payload, startTime);
+                await expectFunction(response, profileId, payload, startTime);
               }
             },
           );
@@ -804,7 +804,7 @@ describe('/profiles', () => {
                 .set(customHeaders || headers);
               expect(response.statusCode).toBe(expectStatus);
               if (expectFunction) {
-                expectFunction(response, profileId, payload);
+                await expectFunction(response, profileId, payload);
               }
             },
           );


### PR DESCRIPTION
## Description
This PR fixes the 500 spikes we've seen when generalized search endpoints are called and the account does not has contacts/cases.
- When a contact or case is created, and it is indexed, the index is created.
- If no contact/case exists yet, the index does not exists either.
  - Because of this, calling search endpoints returns a 500 internal server error.

This PR has two possible fixes for this issue:
- [fix: create ES index if does not exists](https://github.com/techmatters/hrm/commit/134a0ced60501966e5f9ec4e6ec1a886373d8be1) creates the index.
- [chore: return empty search if index is missing](https://github.com/techmatters/hrm/commit/3f0aa2860874333008d537d06f90c5a1e5f74cfc) returns a hardcoded response as if the search resulted in zero matches, avoiding going to the DB.

I'm leaning towards the second solution as it's simpler, but I'm open to reverting this commit if we prefer the other option.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3871)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P