### PR TITLE
(temp fix) chore: use case id for contact notifications to avoid ES race conditions [CHI-3975]

### DIFF
--- a/hrm-domain/hrm-core/notifications/entityChangeNotify.ts
+++ b/hrm-domain/hrm-core/notifications/entityChangeNotify.ts
@@ -137,15 +137,49 @@ type CaseWithLegacySections = CaseService & {
   connectedContacts: Contact[];
 };
 
-export const publishEntityChangeNotification = async (
-  accountSid: HrmAccountId,
-  entityType: 'contact' | 'case' | 'profile',
-  entity: Contact | CaseWithLegacySections | ProfileWithRelationships,
-  operation: NotificationOperation,
-) => {
+type EntityPayload =
+  | {
+      entityType: 'contact';
+      entity: Contact;
+    }
+  | {
+      entityType: 'case';
+      entity: CaseWithLegacySections;
+    }
+  | {
+      entityType: 'profile';
+      entity: ProfileWithRelationships;
+    };
+
+export const publishEntityChangeNotification = async ({
+  entityType,
+  accountSid,
+  entity,
+  operation,
+}: {
+  accountSid: HrmAccountId;
+  entityType: 'contact' | 'case' | 'profile';
+  entity: Contact | CaseWithLegacySections | ProfileWithRelationships;
+  operation: NotificationOperation;
+} & EntityPayload) => {
   // eslint-disable-next-line @typescript-eslint/dot-notation
   delete entity['totalCount'];
-  const messageGroupId = `${accountSid}-${entityType}-${entity.id}`;
+
+  // TODO: This is a temporary fix to prevent race conditions on case updates trigger due to contact updates. I.e. two contacts with same caseId can cause a version conflict race condition and updates are missed.
+  //       When the time comes to introduce profiles search, this won't work anymore.
+  //       A better long term fix would be to
+  //       - Introduce intermediate Lambda "splitter".
+  //       - Introduce 3 queues, -contacts -cases and -profiles.
+  //       - Splitter lambda creates multiple messages from a single contact event, for the corresponding queues.
+  //       - Consumer receives messages from the 3 queues, race conditions are prevented by messageGroupId on target document.
+  //       This will preserve the current "notify on event" system in HRM
+  //       while reflecting more accurately how a single event updates multiple indices in ES.
+  // const messageGroupId = `${accountSid}-${entityType}-${entity.id}`;
+  const messageGroupId =
+    entityType === 'contact' && entity.caseId
+      ? `${accountSid}-'case'-${entity.caseId}`
+      : `${accountSid}-${entityType}-${entity.id}`;
+
   let publishResponse: { MessageId?: string };
   if (operation === 'delete') {
     publishResponse = await publishToSns({
@@ -185,7 +219,12 @@ export const publishContactChangeNotification = async ({
       contact.updatedAt ?? contact.createdAt
     }/${operation})`,
   );
-  return publishEntityChangeNotification(accountSid, 'contact', contact, operation);
+  return publishEntityChangeNotification({
+    accountSid,
+    entityType: 'contact',
+    entity: contact,
+    operation,
+  });
 };
 
 export const publishCaseChangeNotification = async ({
@@ -208,16 +247,16 @@ export const publishCaseChangeNotification = async ({
       caseObj.updatedAt ?? caseObj.createdAt
     }/${operation})`,
   );
-  return publishEntityChangeNotification(
+  return publishEntityChangeNotification({
     accountSid,
-    'case',
-    {
+    entityType: 'case',
+    entity: {
       ...caseObj,
       sections: timelineToLegacySections(timeline),
       connectedContacts: timelineToLegacyConnectedContacts(timeline),
     },
     operation,
-  );
+  });
 };
 
 export const publishProfileChangeNotification = async ({
@@ -238,5 +277,10 @@ export const publishProfileChangeNotification = async ({
       profile.updatedAt ?? profile.createdAt
     }/${operation})`,
   );
-  return publishEntityChangeNotification(accountSid, 'profile', profile, operation);
+  return publishEntityChangeNotification({
+    accountSid,
+    entityType: 'profile',
+    entity: profile,
+    operation,
+  });
 };

--- a/hrm-domain/hrm-core/notifications/entityChangeNotify.ts
+++ b/hrm-domain/hrm-core/notifications/entityChangeNotify.ts
@@ -167,13 +167,8 @@ export const publishEntityChangeNotification = async ({
 
   // TODO: This is a temporary fix to prevent race conditions on case updates trigger due to contact updates. I.e. two contacts with same caseId can cause a version conflict race condition and updates are missed.
   //       When the time comes to introduce profiles search, this won't work anymore.
-  //       A better long term fix would be to
-  //       - Introduce intermediate Lambda "splitter".
-  //       - Introduce 3 queues, -contacts -cases and -profiles.
-  //       - Splitter lambda creates multiple messages from a single contact event, for the corresponding queues.
-  //       - Consumer receives messages from the 3 queues, race conditions are prevented by messageGroupId on target document.
-  //       This will preserve the current "notify on event" system in HRM
-  //       while reflecting more accurately how a single event updates multiple indices in ES.
+  //       A better long term fix is suggested in https://github.com/techmatters/hrm/pull/1116
+  //
   // const messageGroupId = `${accountSid}-${entityType}-${entity.id}`;
   const messageGroupId =
     entityType === 'contact' && entity.caseId

--- a/hrm-domain/hrm-core/profile/profileEntityBroadcast.ts
+++ b/hrm-domain/hrm-core/profile/profileEntityBroadcast.ts
@@ -36,7 +36,12 @@ const doProfileChangeNotification =
           : await getProfileById()(accountSid, profileOrId, true);
       if (profile) {
         console.debug('Broadcasting profile', JSON.stringify(profile, null, 2));
-        await publishEntityChangeNotification(accountSid, 'profile', profile, operation);
+        await publishEntityChangeNotification({
+          accountSid,
+          entityType: 'profile',
+          entity: profile,
+          operation,
+        });
       } else {
         console.error(
           `Profile ${profileOrId} (${accountSid}) not found to broadcast despite successfully updating data on it.`,

--- a/packages/elasticsearch-client/src/updateDocument.ts
+++ b/packages/elasticsearch-client/src/updateDocument.ts
@@ -99,6 +99,7 @@ export const updateScript = async <T>({
       script: scriptUpdate,
       upsert: documentUpdate,
       scripted_upsert: scriptedUpsert,
+      retry_on_conflict: 5,
     });
 
     return newOk({ data: response });

--- a/packages/elasticsearch-client/src/updateDocument.ts
+++ b/packages/elasticsearch-client/src/updateDocument.ts
@@ -99,7 +99,6 @@ export const updateScript = async <T>({
       script: scriptUpdate,
       upsert: documentUpdate,
       scripted_upsert: scriptedUpsert,
-      retry_on_conflict: 5,
     });
 
     return newOk({ data: response });


### PR DESCRIPTION
## Description
This PR addresses a bug I spotted while working with cases that are related to many contacts.
Basically:
- If a lot of contacts are related to the same case, they are processed in parallel.
- Each contact results in an update on the `-hrm-contacts` and other in `-hrm-cases` indices.
- The later results in race conditions, because of concurrent updates on the same case document. The consequence are lost updates.

This is a temporary fix:
- If the contact is linked to a case, then we use the case id as the "message group id" for SQS, which guarantees that the messages are processed sequentially (FIFO queues).
- If the contact is not linked to a case, things continue to work as usual.
- A consequence of this is that we'll have slower indexing on big `reindex` operations.

A proper long term fix:
- Update `-hrm-search-index-consumer` so that given a single update payload, creates individual messages for each, using the target document id. This messages are sent to the below described queue.
- Create a new queue, `-hrm-search-index-updater-pending.fifo` which will receive above messages.
- Create a new Lambda, `-hrm-search-index-updater`, which will receive payloads representing a single update on a single document.
This alternative implementation reflects more explicitly the behavior of how a single event can affect multiple resources in ES. Benefiting from SQS FIFO queues and message group ids, we prevent race conditions.
E.g.:
- A new contact update event reaches `-hrm-search-index-consumer-pending.fifo` queue.
- `-hrm-search-index-consumer` Lambda is triggered. This event results in 3 different things to update:
  - New message (group contact id) containing the target contact in `-hrm-contacts` index update.
  - New message (group case id) containing the target case in `-hrm-case` index update.
  - New message (group profile id) containing the target profile in `-hrm-profiles` index update - This does not exists yet but the idea is to introduce profiles search.
  The 3 messages are sent to `-hrm-search-index-updater-pending.fifo`.
- `-hrm-search-index-updater` Lambda processes each message.


### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/browse/CHI-3975)
- [ ] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
<!--
- The primary issue this PR addresses should be part of the PR title.
- If there are other tickets related to this PR, reference them here with context of how they are relevant.
-->
None

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P