### PR TITLE
CHI-3719: Add contact and case creation to the admin API

### DIFF
--- a/hrm-domain/hrm-core/case/adminCaseRoutesV0.ts
+++ b/hrm-domain/hrm-core/case/adminCaseRoutesV0.ts
@@ -22,9 +22,16 @@ import {
 import type { Request, Response, NextFunction } from 'express';
 import { publicEndpoint, SafeRouter } from '../permissions';
 import { renotifyCasesStream } from './caseNotifyService';
+import * as caseApi from './caseService';
 import createError from 'http-errors';
 
 const adminCasesRouter = SafeRouter();
+
+adminCasesRouter.post('/', publicEndpoint, async (req, res) => {
+  const { hrmAccountId, user } = req;
+  const createdCase = await caseApi.createCase(req.body, hrmAccountId, user.workerSid);
+  res.json(createdCase);
+});
 
 // admin POST endpoint to renotify cases. req body has accountSid, dateFrom, dateTo
 adminCasesRouter.post(

--- a/hrm-domain/hrm-core/contact/adminContactRoutesV0.ts
+++ b/hrm-domain/hrm-core/contact/adminContactRoutesV0.ts
@@ -21,9 +21,46 @@ import {
 } from '@tech-matters/hrm-types';
 import { publicEndpoint, SafeRouter } from '../permissions';
 import { processContactsStream } from './contactsNotifyService';
+import { connectContactToCase, createContact } from './contactService';
 import createError from 'http-errors';
 
 const adminContactsRouter = SafeRouter();
+
+// example: curl -XPOST -H'Content-Type: application/json' localhost:3000/admin/v0/accounts/ACxxx/contacts -d'{"createdBy": "system", ...}'
+adminContactsRouter.post('/', publicEndpoint, async (req: Request, res: Response) => {
+  const { hrmAccountId, user, body, permissionRules } = req;
+  const contact = await createContact(hrmAccountId, body.createdBy, body, {
+    permissionRules,
+    can: req.can,
+    user,
+  });
+  res.json(contact);
+});
+
+adminContactsRouter.put(
+  '/:contactId/connectToCase',
+  publicEndpoint,
+  async (req: Request, res: Response) => {
+    const { hrmAccountId, user, permissionRules } = req;
+    const { contactId } = req.params;
+    const { caseId } = req.body;
+    try {
+      const updatedContact = await connectContactToCase(hrmAccountId, contactId, caseId, {
+        can: req.can,
+        user,
+        permissionRules,
+      });
+      res.json(updatedContact);
+    } catch (err) {
+      if (
+        err.message.toLowerCase().includes('violates foreign key constraint') ||
+        err.message.toLowerCase().includes('contact not found')
+      ) {
+        throw createError(404);
+      } else throw err;
+    }
+  },
+);
 
 // admin POST endpoint to reindex contacts. req body has accountSid, dateFrom, dateTo
 adminContactsRouter.post(

--- a/hrm-domain/hrm-service/service-tests/case/caseCrd.test.ts
+++ b/hrm-domain/hrm-service/service-tests/case/caseCrd.test.ts
@@ -21,7 +21,7 @@ import { CaseService } from '@tech-matters/hrm-core/case/caseService';
 import * as caseDb from '@tech-matters/hrm-core/case/caseDataAccess';
 
 import * as mocks from '../mocks';
-import { headers } from '../server';
+import { adminHeaders, headers } from '../server';
 import { newTwilioUser } from '@tech-matters/twilio-worker-auth';
 import { ALWAYS_CAN } from '../mocks';
 import { casePopulated } from '../mocks';
@@ -29,7 +29,7 @@ import { setupServiceTests } from '../setupServiceTest';
 
 const { case1, case2, accountSid, workerSid } = mocks;
 
-const { request } = setupServiceTests(workerSid);
+const { request, internalRequest } = setupServiceTests(workerSid);
 
 describe('/cases route', () => {
   const route = `/v0/accounts/${accountSid}/cases`;
@@ -70,6 +70,20 @@ describe('/cases route', () => {
       // Check the DB is actually updated
       const fromDb = await caseApi.getCase(response.body.id, accountSid, ALWAYS_CAN);
       expect(fromDb).toStrictEqual(expected);
+    });
+
+    test('admin route should return 200, attributed to the system user', async () => {
+      const adminRoute = `/admin/v0/accounts/${accountSid}/cases`;
+      const response = await internalRequest
+        .post(adminRoute)
+        .set(adminHeaders)
+        .send({ ...case1, label: 'Created case' });
+
+      expect(response.status).toBe(200);
+      // createCase ignores body.createdBy; always uses the authenticated user's workerSid
+      expect(response.body).toStrictEqual({ ...expected, createdBy: 'system' });
+      const fromDb = await caseApi.getCase(response.body.id, accountSid, ALWAYS_CAN);
+      expect(fromDb).toStrictEqual({ ...expected, createdBy: 'system' });
     });
   });
 

--- a/hrm-domain/hrm-service/service-tests/contact/connectToCase.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/connectToCase.test.ts
@@ -29,14 +29,14 @@ import * as caseApi from '@tech-matters/hrm-core/case/caseService';
 import * as caseDb from '@tech-matters/hrm-core/case/caseDataAccess';
 import * as contactApi from '@tech-matters/hrm-core/contact/contactService';
 import * as contactDb from '@tech-matters/hrm-core/contact/contactDataAccess';
-import { headers, setRules } from '../server';
+import { adminHeaders, headers, setRules } from '../server';
 import { deleteContactById } from './dbCleanup';
 import { actionsMaps } from '@tech-matters/hrm-core/permissions/index';
 import { TKConditionsSets } from '@tech-matters/hrm-core/permissions/rulesMap';
 import each from 'jest-each';
 import { setupServiceTests } from '../setupServiceTest';
 
-const { request } = setupServiceTests();
+const { request, internalRequest } = setupServiceTests();
 
 const route = `/v0/accounts/${accountSid}/contacts`;
 
@@ -125,6 +125,8 @@ describe('/contacts/:contactId/connectToCase route', () => {
 
   describe('PUT', () => {
     const subRoute = contactId => `${route}/${contactId}/connectToCase`;
+    const adminSubRoute = contactId =>
+      `/admin/v0/accounts/${accountSid}/contacts/${contactId}/connectToCase`;
 
     test('should return 401', async () => {
       const response = await request.put(subRoute(existingContactId)).send({});
@@ -143,6 +145,17 @@ describe('/contacts/:contactId/connectToCase route', () => {
       expect(response.body.caseId).toBe(existingCaseId);
 
       // Test the association
+      expect(response.body.csamReports).toHaveLength(0);
+    });
+
+    test('admin route should return 200', async () => {
+      const response = await internalRequest
+        .put(adminSubRoute(existingContactId))
+        .set(adminHeaders)
+        .send({ caseId: existingCaseId });
+
+      expect(response.status).toBe(200);
+      expect(response.body.caseId).toBe(existingCaseId);
       expect(response.body.csamReports).toHaveLength(0);
     });
 

--- a/hrm-domain/hrm-service/service-tests/contact/createContact.test.ts
+++ b/hrm-domain/hrm-service/service-tests/contact/createContact.test.ts
@@ -33,7 +33,7 @@ import {
 import '../case/caseValidation';
 import * as contactDb from '@tech-matters/hrm-core/contact/contactDataAccess';
 import { selectSingleContactByTaskId } from '@tech-matters/hrm-core/contact/sql/contact-get-sql';
-import { basicHeaders, headers } from '../server';
+import { adminHeaders, basicHeaders, headers } from '../server';
 import { newTwilioUser } from '@tech-matters/twilio-worker-auth';
 import * as profilesDB from '@tech-matters/hrm-core/profile/profileDataAccess';
 import * as profilesService from '@tech-matters/hrm-core/profile/profileService';
@@ -60,6 +60,12 @@ each([
     route: `/internal/v0/accounts/${accountSid}/contacts`,
     testHeaders: basicHeaders,
     description: 'internal route',
+  },
+  {
+    testRequest: internalRequest,
+    route: `/admin/v0/accounts/${accountSid}/contacts`,
+    testHeaders: adminHeaders,
+    description: 'admin route',
   },
 ]).describe('POST /contacts $description', ({ testRequest, route, testHeaders }) => {
   test('should return 401', async () => {

--- a/hrm-domain/hrm-service/service-tests/server.ts
+++ b/hrm-domain/hrm-service/service-tests/server.ts
@@ -90,6 +90,11 @@ export const basicHeaders = {
   Authorization: `Basic BBC`,
 };
 
+export const adminHeaders = {
+  'Content-Type': 'application/json',
+  Authorization: `Basic VCS`,
+};
+
 export type ApiTestSuiteParameters = {
   request: SuperAgentTest;
   requestDescription: 'PUBLIC' | 'INTERNAL';

--- a/hrm-domain/hrm-service/setTestEnvVars.js
+++ b/hrm-domain/hrm-service/setTestEnvVars.js
@@ -53,6 +53,7 @@ process.env.PERMISSIONS_CONFIG_LOCAL_OVERRIDE = JSON.stringify({
 });
 
 process.env.STATIC_KEY_ACCOUNT_SID = 'BBC';
+process.env.STATIC_KEY_ADMIN_HRM = 'VCS';
 
 process.env.INCLUDE_ERROR_IN_RESPONSE = 'true';
 


### PR DESCRIPTION
## Description

Adds `POST /` (create) to both `adminContactRoutesV0.ts` and `adminCaseRoutesV0.ts`, plus `PUT /:contactId/connectToCase` to `adminContactRoutesV0.ts`. The admin API currently only supports notify operations (reindex/republish/reexport) for contacts and cases, and there is no way to create either. Needed for an upcoming admin-cli import script.

Each route mirrors the equivalent internal/public logic exactly (same `createContact`/`createCase`/`connectContactToCase` calls, same createdBy handling). Not a new pattern - `adminProfileRoutesV0.ts` already has real creation/mutation routes alongside its own notify-operation catch-all; this applies that pattern to contacts and cases.

Note: case creation always attributes `createdBy` to the authenticated system user's fixed workerSid, ignoring any `createdBy` in the request body. This is unlike contact creation, which does honor it. It's pre-existing behavior on the internal path, not introduced here, just flagging since it's a direct consequence of adding this.

### Checklist
- [ ] Corresponding issue has been opened
- [x] New tests added
- [ ] Feature flags / configuration added

### Other Related Issues
Related to CHI-3719 (PRN/iCarol contact import); this unblocks that
migration script's use of the admin API for contact/case creation.

### Verification steps

Confirm a contact/case can be created via
`/admin/v0/accounts/:accountSid/contacts` and
`/admin/v0/accounts/:accountSid/cases`, and that
`PUT /admin/v0/accounts/:accountSid/contacts/:contactId/connectToCase`
correctly links them.

### AFTER YOU MERGE

1. Cut a release tag using the GitHub workflow. Wait for it to complete and notify in the #aselo-deploys Slack channel.
2. Comment on the ticket with the release tag version AND any additional instructions required to configure an environment to test the changes.
3. Only then move the ticket into the QA column in JIRA

You are responsible for ensuring the above steps are completed. If you move a ticket into QA without advising what version to test, the QA team will assume the latest tag has the changes. If it does not, the following confusion is on you! :-P

AI-assisted: claude-sonnet-5